### PR TITLE
refactor: different router and get same result

### DIFF
--- a/packages/midway-web/package.json
+++ b/packages/midway-web/package.json
@@ -30,7 +30,8 @@
     "@types/mocha": "^2.2.41",
     "@types/node": "^10.5.5",
     "egg-mock": "^3.17.3",
-    "midway-bin": "^0.3.2"
+    "midway-bin": "^0.3.2",
+    "pedding": "^1.1.0"
   },
   "dependencies": {
     "camelcase": "^5.0.0",

--- a/packages/midway-web/src/decorators/requestMapping.ts
+++ b/packages/midway-web/src/decorators/requestMapping.ts
@@ -2,9 +2,9 @@
  * 'HEAD', 'OPTIONS', 'GET', 'PUT', 'PATCH', 'POST', 'DELETE' 封装
  */
 import 'reflect-metadata';
-import {RequestMethod} from '../constants';
-import {WEB_ROUTER_CLS, WEB_ROUTER_PROP} from './metaKeys';
-import {attachMetaDataOnClass} from '../utils';
+import { RequestMethod } from '../constants';
+import { WEB_ROUTER_CLS, WEB_ROUTER_PROP } from './metaKeys';
+import { attachMetaDataOnClass } from '../utils';
 
 const PATH_METADATA = 'PATH_METADATA';
 const METHOD_METADATA = 'METHOD_METADATA';
@@ -32,9 +32,13 @@ export const RequestMapping = (
   return (target, key, descriptor: PropertyDescriptor) => {
     // save method name on class
     attachMetaDataOnClass(target.constructor, WEB_ROUTER_CLS, key);
-
+    let props = Reflect.getMetadata(WEB_ROUTER_PROP, target.constructor, key);
+    if (!props) {
+      props = [];
+    }
+    props.push({path, requestMethod, routerName});
     // save metadata on method
-    Reflect.defineMetadata(WEB_ROUTER_PROP, {path, requestMethod, routerName}, target.constructor, key);
+    Reflect.defineMetadata(WEB_ROUTER_PROP, props, target.constructor, key);
     return descriptor;
   };
 };

--- a/packages/midway-web/src/loader/webLoader.ts
+++ b/packages/midway-web/src/loader/webLoader.ts
@@ -86,14 +86,18 @@ export class MidwayWebLoader extends MidwayLoader {
       newRouter.prefix(controllerPrefix);
       const methodNames = Reflect.getMetadata(WEB_ROUTER_CLS, target);
       for (let methodName of methodNames) {
-        const mappingInfo = Reflect.getMetadata(WEB_ROUTER_PROP, target, methodName);
-        const routerArgs = [
-          mappingInfo.routerName,
-          mappingInfo.path,
-          this.generateController(`${controllerId}.${methodName}`)
-        ];
-        // apply controller from request context
-        newRouter[mappingInfo.requestMethod].apply(newRouter, routerArgs);
+        const mappingInfos: Array<{ path: string; requestMethod: string; routerName: string; }> = Reflect.getMetadata(WEB_ROUTER_PROP, target, methodName);
+        if(mappingInfos && mappingInfos.length) {
+          for (let mappingInfo of mappingInfos) {
+            const routerArgs = [
+              mappingInfo.routerName,
+              mappingInfo.path,
+              this.generateController(`${controllerId}.${methodName}`)
+            ];
+            // apply controller from request context
+            newRouter[mappingInfo.requestMethod].apply(newRouter, routerArgs);
+          }
+        }
       }
       app.use(newRouter.middleware());
     }

--- a/packages/midway-web/test/enhance.test.ts
+++ b/packages/midway-web/test/enhance.test.ts
@@ -3,6 +3,7 @@ const request = require('supertest');
 const path = require('path');
 const utils = require('./utils');
 const mm = require('mm');
+const pedding = require('pedding');
 
 describe('/test/enhance.test.ts', () => {
 
@@ -67,7 +68,7 @@ describe('/test/enhance.test.ts', () => {
           typescript: true
         });
         await app.ready();
-      } catch(e) {
+      } catch (e) {
         suc = true;
       }
       assert.ok(suc);
@@ -220,6 +221,36 @@ describe('/test/enhance.test.ts', () => {
         .get('/api')
         .expect(200)
         .expect('64t', done);
+    });
+  });
+
+  describe('should support multi router in one function', () => {
+    let app;
+    before(() => {
+      app = utils.app('enhance/base-app-router', {
+        typescript: true
+      });
+      return app.ready();
+    });
+
+    after(() => app.close());
+
+    it('should invoke different router and get same result', (done) => {
+      done = pedding(3, done);
+      request(app.callback())
+        .get('/')
+        .expect(200)
+        .expect('hello', done);
+
+      request(app.callback())
+        .get('/home')
+        .expect(200)
+        .expect('hello', done);
+
+      request(app.callback())
+        .get('/poster')
+        .expect(200)
+        .expect('hello', done);
     });
   });
 

--- a/packages/midway-web/test/fixtures/enhance/base-app-router/package.json
+++ b/packages/midway-web/test/fixtures/enhance/base-app-router/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "ali-demo"
+}

--- a/packages/midway-web/test/fixtures/enhance/base-app-router/src/app/controller/home.ts
+++ b/packages/midway-web/test/fixtures/enhance/base-app-router/src/app/controller/home.ts
@@ -1,0 +1,15 @@
+import { provide } from 'injection';
+import { controller, get } from '../../../../../../../src/';
+
+@provide()
+@controller('/')
+export class HomeController {
+
+  @get('/')
+  @get('/home')
+  @get('/poster')
+  async index(ctx) {
+    ctx.body = 'hello';
+  }
+
+}

--- a/packages/midway-web/test/fixtures/enhance/base-app-router/src/config/config.default.ts
+++ b/packages/midway-web/test/fixtures/enhance/base-app-router/src/config/config.default.ts
@@ -1,0 +1,12 @@
+
+export const keys = 'key';
+
+export const hello = {
+  a: 1,
+  b: 2,
+  d: [1, 2, 3],
+};
+
+export const plugins = {
+  bucLogin: false,
+};

--- a/packages/midway-web/test/fixtures/enhance/base-app-router/src/config/config.unittest.ts
+++ b/packages/midway-web/test/fixtures/enhance/base-app-router/src/config/config.unittest.ts
@@ -1,0 +1,5 @@
+
+exports.hello = {
+  b: 4,
+  c: 3,
+};


### PR DESCRIPTION
支持多路由绑定到同一个方法上

```
  @get('/')
  @get('/home')
  @get('/poster')
  async index(ctx) {
    ctx.body = 'hello';
  }
```