### PR TITLE
fix: not only inject properties that declared on the property

### DIFF
--- a/docs/ioc.md
+++ b/docs/ioc.md
@@ -193,6 +193,44 @@ export class UserService {
 注入的时机为构造器（new）之后，所以在构造方法(constructor)中是无法获取注入的属性的，如果要获取注入的内容，可以使用 [构造器注入](#构造器注入)。
 :::
 
+父类的属性使用 `@inject()` 装饰器装饰，子类实例会得到装饰后的属性。
+
+```typescript
+class Parent {
+  @inject()
+  katana1;
+}
+
+class Child extends Parent {
+  @inject()
+  katana2;
+}
+
+class Grandson extends Child {
+  @inject()
+  katana3;
+}
+```
+
+`Grandson` 的实例 `gradson` 拥有 `@inject()` 装饰器注入的
+`grandson.katana3`, `grandson.katana2`, `grandson.katana1` 属性。
+
+实现时，会查找 `Gradson` 的原型链，遍历原型链上所有用 `@inject()` 装饰的属性，运行装饰器，注入相应的属性。
+
+查找类的原型使用 [reflect-metadata](https://github.com/rbuckton/reflect-metadata) 仓库的 [OrdinaryGetPrototypeOf](https://github.com/rbuckton/reflect-metadata/blob/c2dbe1d02ceb9987f9002eedf0cdb21d74de0019/Reflect.ts#L1553-L1583) 方法，使用 `recursiveGetPrototypeOf` 方法以数组形式返回该类的所有原型。
+
+``` typescript
+function recursiveGetPrototypeOf(target: any): any[] {
+  const properties = [];
+  let parent = ordinaryGetPrototypeOf(target);
+  while (parent !== null) {
+    properties.push(parent);
+    parent = ordinaryGetPrototypeOf(parent);
+  }
+  return properties;
+}
+```
+
 ## 对象 id
 
 在默认情况下，injection 会将类名变为 `驼峰` 形式作为对象 id，这样你可以通过容器获取实例。

--- a/packages/context/src/base/ObjectCreator.ts
+++ b/packages/context/src/base/ObjectCreator.ts
@@ -73,7 +73,7 @@ export class ObjectCreator implements IObjectCreator {
     if (this.definition.constructMethod) {
       const fn = Clzz[this.definition.constructMethod];
       if (is.generatorFunction(fn)) {
-        inst = await co.wrap(fn).apply(null, args);
+        inst = await co.wrap(fn).apply(Clzz, args);
       } else if (is.asyncFunction(fn)) {
         inst = await fn.apply(Clzz, args);
       } else {
@@ -148,16 +148,16 @@ export class ObjectCreator implements IObjectCreator {
     if (this.definition.destroyMethod && obj[this.definition.destroyMethod]) {
       const fn = obj[this.definition.destroyMethod];
       if (is.generatorFunction(fn)) {
-        await co.wrap(fn)();
+        await co.wrap(fn).call(obj);
       } else if (is.asyncFunction(fn)) {
-        await fn();
+        await fn.call(obj);
       } else {
         if (fn.length === 1) {
           await new Promise(resolve => {
-            fn(resolve);
+            fn.call(obj, resolve);
           });
         } else {
-          fn();
+          fn.call(obj);
         }
       }
     }

--- a/packages/context/src/factory/container.ts
+++ b/packages/context/src/factory/container.ts
@@ -65,7 +65,6 @@ export class Container extends XmlApplicationContext implements IContainer {
 
     // inject properties
     let metaDatas = recursiveGetMetadata(TAGGED_PROP, target);
-    // console.log(TAGGED_PROP, target, metaDatas);
     for (const metaData of metaDatas) {
       debug(`   register inject properties = [${Object.keys(metaData)}]`);
       for (let metaKey in metaData) {
@@ -82,7 +81,7 @@ export class Container extends XmlApplicationContext implements IContainer {
     this.registerCustomBinding(definition, target);
 
     this.registerDefinition(identifier, definition);
-    debug(`   bind and build definition complete, id = [${definition.id}] ${definition}`);
+    debug(`   bind and build definition complete, id = [${definition.id}]`);
   }
 
   registerCustomBinding(objectDefinition: ObjectDefinition, target: any) {

--- a/packages/context/src/factory/container.ts
+++ b/packages/context/src/factory/container.ts
@@ -4,6 +4,7 @@ import { OBJ_DEF_CLS, ObjectDefinition, TAGGED, TAGGED_CLS, TAGGED_PROP } from '
 import { ManagedReference, ManagedValue } from './common/managed';
 import { FunctionDefinition } from '../base/FunctionDefinition';
 import { XmlApplicationContext } from './xml/XmlApplicationContext';
+import { recursiveGetMetadata } from '../utils/reflectTool';
 import { Autowire } from './common/Autowire';
 
 const uuidv1 = require('uuid/v1');
@@ -63,8 +64,9 @@ export class Container extends XmlApplicationContext implements IContainer {
     }
 
     // inject properties
-    let metaData = Reflect.getMetadata(TAGGED_PROP, target);
-    if (metaData) {
+    let metaDatas = recursiveGetMetadata(TAGGED_PROP, target);
+    // console.log(TAGGED_PROP, target, metaDatas);
+    for (const metaData of metaDatas) {
       debug(`   register inject properties = [${Object.keys(metaData)}]`);
       for (let metaKey in metaData) {
         for (let propertyMeta of metaData[metaKey]) {
@@ -80,7 +82,7 @@ export class Container extends XmlApplicationContext implements IContainer {
     this.registerCustomBinding(definition, target);
 
     this.registerDefinition(identifier, definition);
-    debug(`   bind and build definition complete, id = [${definition.id}]`);
+    debug(`   bind and build definition complete, id = [${definition.id}] ${definition}`);
   }
 
   registerCustomBinding(objectDefinition: ObjectDefinition, target: any) {

--- a/packages/context/src/utils/reflectTool.ts
+++ b/packages/context/src/utils/reflectTool.ts
@@ -1,0 +1,72 @@
+import {ReflectResult} from '../interfaces';
+import 'reflect-metadata';
+
+const functionPrototype = Object.getPrototypeOf(Function);
+
+// get property of an object
+// https://tc39.github.io/ecma262/#sec-ordinarygetprototypeof
+function ordinaryGetPrototypeOf(O: any): any {
+  const proto = Object.getPrototypeOf(O);
+  if (typeof O !== 'function' || O === functionPrototype) return proto;
+
+  // TypeScript doesn't set __proto__ in ES5, as it's non-standard.
+  // Try to determine the superclass constructor. Compatible implementations
+  // must either set __proto__ on a subclass constructor to the superclass constructor,
+  // or ensure each class has a valid `constructor` property on its prototype that
+  // points back to the constructor.
+
+  // If this is not the same as Function.[[Prototype]], then this is definately inherited.
+  // This is the case when in ES6 or when using __proto__ in a compatible browser.
+  if (proto !== functionPrototype) return proto;
+
+  // If the super prototype is Object.prototype, null, or undefined, then we cannot determine the heritage.
+  const prototype = O.prototype;
+  const prototypeProto = prototype && Object.getPrototypeOf(prototype);
+  if (prototypeProto == null || prototypeProto === Object.prototype) return proto;
+
+  // If the constructor was not a function, then we cannot determine the heritage.
+  const constructor = prototypeProto.constructor;
+  if (typeof constructor !== 'function') return proto;
+
+  // If we have some kind of self-reference, then we cannot determine the heritage.
+  if (constructor === O) return proto;
+
+  // we have a pretty good guess at the heritage.
+  return constructor;
+}
+
+/**
+ * 以数组形式返回对象所有 property, 数组第一个元素是距离 o 最近的原型
+ * @param target 对象，class 或者 function
+ */
+export function recursiveGetPrototypeOf(target: any): any[] {
+  const properties = [];
+  let parent = ordinaryGetPrototypeOf(target);
+  while (parent !== null) {
+    properties.push(parent);
+    parent = ordinaryGetPrototypeOf(parent);
+  }
+  return properties;
+}
+
+/**
+ * get metadata value of a metadata key on the prototype chain of an object and property
+ * @param metadataKey metadata's key
+ * @param target the target of metadataKey
+ */
+export function recursiveGetMetadata(metadataKey: any, target: any, propertyKey?: string | symbol): ReflectResult[] {
+  const metadatas: ReflectResult[] = [];
+
+  // get metadata value of a metadata key on the prototype
+  let metadata =  Reflect.getOwnMetadata(metadataKey, target, propertyKey);
+  metadata !== undefined && metadatas.push(metadata);
+
+  // get metadata value of a metadata key on the prototype chain
+  let parent = ordinaryGetPrototypeOf(target);
+  while (parent !== null) {
+    metadata = Reflect.getOwnMetadata(metadataKey, parent, propertyKey);
+    metadata !== undefined && metadatas.push(metadata);
+    parent = ordinaryGetPrototypeOf(parent);
+  }
+  return metadatas;
+}

--- a/packages/context/test/fixtures/class_sample.ts
+++ b/packages/context/test/fixtures/class_sample.ts
@@ -61,3 +61,19 @@ export class BaseServiceGenerator {
   }
 }
 
+
+export class Parent {
+  @inject('katana1')
+  katana1: Katana;
+}
+
+export class Child extends Parent {
+  @inject('katana2')
+  katana2: Katana;
+}
+
+export class Grandson extends Child {
+  @inject('katana3')
+  katana3: Katana;
+}
+

--- a/packages/context/test/unit/factory/utils/reflectTool.test.ts
+++ b/packages/context/test/unit/factory/utils/reflectTool.test.ts
@@ -1,0 +1,17 @@
+import { recursiveGetPrototypeOf } from '../../../../src/utils/reflectTool';
+import { expect } from 'chai';
+import { Grandson, Child, Parent } from '../../../fixtures/class_sample';
+
+describe('/test/unit/utils/reflectTools.test.ts', () => {
+  const grandsonPrototyp = recursiveGetPrototypeOf(Grandson);
+  const childPrototyp = recursiveGetPrototypeOf(Child);
+  const parentPrototyp = recursiveGetPrototypeOf(Parent);
+  expect(grandsonPrototyp).deep.eq([
+    Child,
+    Parent,
+    Object.getPrototypeOf(Function),
+    Object.prototype
+  ]);
+  expect(parentPrototyp).deep.eq([Function.prototype, Object.prototype]);
+  expect(grandsonPrototyp.slice(1)).deep.eq(childPrototyp);
+});


### PR DESCRIPTION
Fixes #53

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->
###### 修复 properties 注入
https://github.com/midwayjs/midway/blob/cd9e5fc1d8b2a7c3eded1426c8a034d575700f8d/packages/context/src/factory/container.ts#L65-L76
此处应该是获取原型及其原型链上所有的 metaData，所以使用 `recursiveGetMetadata(TAGGED_PROP, target)`替换

###### 修复 `doConstructAsync` 和 `doDestroyAsync` 中函数执行上下文信息
https://github.com/midwayjs/midway/blob/cd9e5fc1d8b2a7c3eded1426c8a034d575700f8d/packages/context/src/base/ObjectCreator.ts#L73-L84
https://github.com/midwayjs/midway/blob/cd9e5fc1d8b2a7c3eded1426c8a034d575700f8d/packages/context/src/base/ObjectCreator.ts#L147-L164


##### Description of change
<!-- Provide a description of the change below this comment. -->
新增 reflectTool.ts 文件，对外提供两个方法
  - `recursiveGetPrototypeOf(target) ` 获取 target 的所有原型，返回 target 原型组成的数组
  - `recursiveGetMetadata(metadataKey, target, propertyKey)`  获取 target 原型和其原型链上的metaData 值，返回 metaData 组成的数组

新增 `should inject attributes that on the prototype chain and property` 测试用例
修复 `doConstructAsync` 和 `doDestroyAsync` 中函数执行上下文信息，使用 `call` 调用