### PR TITLE
fix: fix invoke loadController repeatedly

### DIFF
--- a/packages/midway-web/src/loader/webLoader.ts
+++ b/packages/midway-web/src/loader/webLoader.ts
@@ -24,11 +24,11 @@ export class MidwayWebLoader extends MidwayLoader {
     router: Router
   }> = [];
 
-  async loadController(opt?): Promise<void> {
+  async loadController(opt: { directory? } = {}): Promise<void> {
     // load midway controller to binding router
     const appDir = path.join(this.options.baseDir, 'app');
     const results = loading(this.getFileExtension(['controllers/**/*', 'controller/**/*']), {
-      loadDirs: appDir,
+      loadDirs: opt.directory || appDir,
       call: false,
     });
 

--- a/packages/midway-web/test/enhance.test.ts
+++ b/packages/midway-web/test/enhance.test.ts
@@ -351,4 +351,23 @@ describe('/test/enhance.test.ts', () => {
       assert(cfg.env, 'unittest');
     });
   });
+
+  describe('plugin can load controller directory directly', () => {
+    let app;
+    before(() => {
+      app = utils.app('enhance/loader-duplicate', {
+        typescript: true
+      });
+      return app.ready();
+    });
+
+    after(() => app.close());
+
+    it('should fix egg-socket.io load controller directory', (done) => {
+      request(app.callback())
+        .get('/')
+        .expect(200)
+        .expect('root_test', done);
+    });
+  });
 });

--- a/packages/midway-web/test/fixtures/enhance/loader-duplicate/package.json
+++ b/packages/midway-web/test/fixtures/enhance/loader-duplicate/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "ali-demo"
+}

--- a/packages/midway-web/test/fixtures/enhance/loader-duplicate/src/app.ts
+++ b/packages/midway-web/test/fixtures/enhance/loader-duplicate/src/app.ts
@@ -1,0 +1,10 @@
+import * as path from 'path';
+
+export = (app) => {
+  app.beforeStart(() => {
+    app.loader.loadController({
+      directory: [path.join(app.baseDir, 'io', 'controller')],
+      target: {},
+    });
+  });
+};

--- a/packages/midway-web/test/fixtures/enhance/loader-duplicate/src/app/controller/my.ts
+++ b/packages/midway-web/test/fixtures/enhance/loader-duplicate/src/app/controller/my.ts
@@ -1,0 +1,11 @@
+import { provide } from 'injection';
+import { controller, get } from '../../../../../../../src/';
+
+@provide()
+@controller('/')
+export class My {
+  @get('/')
+  async index(ctx) {
+    ctx.body = 'root_test';
+  }
+}

--- a/packages/midway-web/test/fixtures/enhance/loader-duplicate/src/config/config.default.ts
+++ b/packages/midway-web/test/fixtures/enhance/loader-duplicate/src/config/config.default.ts
@@ -1,0 +1,12 @@
+
+export const keys = 'key';
+
+export const hello = {
+  a: 1,
+  b: 2,
+  d: [1, 2, 3],
+};
+
+export const plugins = {
+  bucLogin: false,
+};

--- a/packages/midway-web/test/fixtures/enhance/loader-duplicate/src/config/config.unittest.ts
+++ b/packages/midway-web/test/fixtures/enhance/loader-duplicate/src/config/config.unittest.ts
@@ -1,0 +1,5 @@
+
+exports.hello = {
+  b: 4,
+  c: 3,
+};

--- a/packages/midway-web/test/fixtures/enhance/loader-duplicate/src/io/controller/chat.ts
+++ b/packages/midway-web/test/fixtures/enhance/loader-duplicate/src/io/controller/chat.ts
@@ -1,0 +1,9 @@
+module.exports = (app) => {
+  class Controller extends app.Controller {
+    async ping() {
+      const message = this.ctx.args[0];
+      await this.ctx.socket.emit('res', `Hi! I've got your message: ${message}`);
+    }
+  }
+  return Controller;
+};


### PR DESCRIPTION
由于 egg-socket.io 重复调用了 loadControlelr 导致控制器重复注册了定义。