### PR TITLE
fix: change default search directory

### DIFF
--- a/packages/midway-web/package.json
+++ b/packages/midway-web/package.json
@@ -38,7 +38,7 @@
     "camelcase": "^5.0.0",
     "debug": "^3.1.0",
     "egg": "^2.9.1",
-    "extend2": "^3.0.0",
+    "extend2": "^1.0.0",
     "globby": "^8.0.1",
     "inflection": "^1.12.0",
     "injection": "^0.6.3",

--- a/packages/midway-web/package.json
+++ b/packages/midway-web/package.json
@@ -38,7 +38,7 @@
     "camelcase": "^5.0.0",
     "debug": "^3.1.0",
     "egg": "^2.9.1",
-    "extend": "^3.0.0",
+    "extend2": "^3.0.0",
     "globby": "^8.0.1",
     "inflection": "^1.12.0",
     "injection": "^0.6.3",

--- a/packages/midway-web/src/loader/webLoader.ts
+++ b/packages/midway-web/src/loader/webLoader.ts
@@ -151,14 +151,14 @@ export class MidwayWebLoader extends MidwayLoader {
 
   protected getFileExtension(names: string | string[]): string[] {
     if (typeof names === 'string') {
-      return [names + '.ts', names + '.js', '!**/**.d.ts'];
-    } else {
-      let arr = [];
-      names.forEach((name) => {
-        arr = arr.concat([name + '.ts', name + '.js']);
-      });
-      return arr.concat(['!**/**.d.ts']);
+      names = [names];
     }
+
+    let arr = [];
+    names.forEach((name) => {
+      arr = arr.concat([name + '.ts', name + '.js']);
+    });
+    return arr.concat(['!**/**.d.ts']);
   }
 
   async refreshContext(): Promise<void> {

--- a/packages/midway-web/src/loader/webLoader.ts
+++ b/packages/midway-web/src/loader/webLoader.ts
@@ -26,8 +26,8 @@ export class MidwayWebLoader extends MidwayLoader {
 
   async loadController(opt: { directory? } = {}): Promise<void> {
     // load midway controller to binding router
-    const appDir = path.join(this.options.baseDir, 'app');
-    const results = loading(this.getFileExtension(['controllers/**/*', 'controller/**/*']), {
+    const appDir = path.join(this.options.baseDir, 'app/controller');
+    const results = loading(this.getFileExtension('**/*'), {
       loadDirs: opt.directory || appDir,
       call: false,
     });

--- a/packages/midway-web/src/loading.ts
+++ b/packages/midway-web/src/loading.ts
@@ -4,7 +4,7 @@
 const debug = require('debug')('midway:loading');
 const is = require('is-type-of');
 const globby = require('globby');
-const extend = require('extend');
+const extend = require('extend2');
 const assert = require('assert');
 const path = require('path');
 

--- a/packages/midway-web/test/enhance.test.ts
+++ b/packages/midway-web/test/enhance.test.ts
@@ -63,6 +63,26 @@ describe('/test/enhance.test.ts', () => {
     });
   });
 
+  describe('load ts class when controller has default export', () => {
+    let app;
+    before(() => {
+      app = utils.app('enhance/base-app-controller-default-export', {
+        typescript: true
+      });
+      return app.ready();
+    });
+
+    after(() => app.close());
+
+    it('should load controller', (done) => {
+      request(app.callback())
+        .get('/')
+        .expect(200)
+        .expect('root_test', done);
+    });
+
+  });
+
   describe('load ts class controller use decorator conflicts', () => {
     let app;
     it('should load controller conflicts', async () => {

--- a/packages/midway-web/test/fixtures/enhance/base-app-controller-default-export/package.json
+++ b/packages/midway-web/test/fixtures/enhance/base-app-controller-default-export/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "ali-demo"
+}

--- a/packages/midway-web/test/fixtures/enhance/base-app-controller-default-export/src/app/controller/api.ts
+++ b/packages/midway-web/test/fixtures/enhance/base-app-controller-default-export/src/app/controller/api.ts
@@ -1,0 +1,29 @@
+'use strict';
+
+
+import { inject, provide, scope, ScopeEnum } from 'injection';
+import { controller, get } from '../../../../../../../src/';
+
+const assert = require('assert');
+
+@provide()
+@scope(ScopeEnum.Request)
+export class BaseApi {
+  async index(ctx) {
+    ctx.body = 'index';
+  }
+}
+
+@provide()
+@controller('/components/')
+export class Api {
+
+  @inject()
+  logger;
+
+  @get('/')
+  async index(ctx) {
+    assert(this.logger.constructor.name === 'ContextLogger');
+    ctx.body = 'hello';
+  }
+}

--- a/packages/midway-web/test/fixtures/enhance/base-app-controller-default-export/src/app/controller/my.ts
+++ b/packages/midway-web/test/fixtures/enhance/base-app-controller-default-export/src/app/controller/my.ts
@@ -1,0 +1,12 @@
+import { provide } from 'injection';
+import { controller, get } from '../../../../../../../src/';
+
+@provide()
+@controller('/')
+class My {
+  @get('/')
+  async index(ctx) {
+    ctx.body = 'root_test';
+  }
+}
+export = My;

--- a/packages/midway-web/test/fixtures/enhance/base-app-controller-default-export/src/app/router.ts
+++ b/packages/midway-web/test/fixtures/enhance/base-app-controller-default-export/src/app/router.ts
@@ -1,0 +1,3 @@
+module.exports = function(app) {
+  app.get('/api/index', app.generateController('baseApi.index'));
+};

--- a/packages/midway-web/test/fixtures/enhance/base-app-controller-default-export/src/config/config.default.ts
+++ b/packages/midway-web/test/fixtures/enhance/base-app-controller-default-export/src/config/config.default.ts
@@ -1,0 +1,12 @@
+
+export const keys = 'key';
+
+export const hello = {
+  a: 1,
+  b: 2,
+  d: [1, 2, 3],
+};
+
+export const plugins = {
+  bucLogin: false,
+};

--- a/packages/midway-web/test/fixtures/enhance/base-app-controller-default-export/src/config/config.unittest.ts
+++ b/packages/midway-web/test/fixtures/enhance/base-app-controller-default-export/src/config/config.unittest.ts
@@ -1,0 +1,5 @@
+
+exports.hello = {
+  b: 4,
+  c: 3,
+};

--- a/packages/midway-web/test/fixtures/enhance/base-app-default-scope/src/app/controller/api.ts
+++ b/packages/midway-web/test/fixtures/enhance/base-app-default-scope/src/app/controller/api.ts
@@ -2,11 +2,13 @@
 
 import { provide } from 'injection';
 import { controller, get } from '../../../../../../../src/';
-
+import * as assert from 'assert';
 
 @provide()
 export class BaseApi {
   async index(ctx) {
+    const baseApi = await ctx.requestContext.getAsync('baseApi');
+    assert(baseApi);
     ctx.body = 'index';
   }
 }


### PR DESCRIPTION
外部传入的 directory 带了 controller 后缀导致查询的时候可能触发找不到 controller 的问题。