### PR TITLE
add class name when inject preperty error

### DIFF
--- a/packages/context/src/factory/applicationContext.ts
+++ b/packages/context/src/factory/applicationContext.ts
@@ -164,6 +164,9 @@ export class BaseApplicationContext extends EventEmitter implements IApplication
   }
 
   get<T>(identifier: ObjectIdentifier, args?: any): T {
+    // 以 ${identifier} 开头的 Error 信息将被增加详细的类名，在 ManagedResolverFactory.ts create 方法中
+    // 因为在这里拿不到类名
+
     if (this.registry.hasObject(identifier)) {
       return this.registry.getObject(identifier);
     }
@@ -187,6 +190,9 @@ export class BaseApplicationContext extends EventEmitter implements IApplication
   }
 
   async getAsync<T>(identifier: ObjectIdentifier, args?: any): Promise<T> {
+    // 以 ${identifier} 开头的 Error 信息将被增加详细的类名，在 ManagedResolverFactory.ts createAsync 方法中
+    // 因为在这里拿不到类名
+
     if (this.registry.hasObject(identifier)) {
       return this.registry.getObject(identifier);
     }

--- a/packages/context/src/factory/applicationContext.ts
+++ b/packages/context/src/factory/applicationContext.ts
@@ -14,6 +14,7 @@ import {
 } from '../interfaces';
 import { ObjectConfiguration } from '../base/Configuration';
 import { ManagedResolverFactory } from './common/ManagedResolverFactory';
+import { NotFoundError } from '../utils/errorFactory';
 
 const graphviz = require('graphviz');
 
@@ -164,8 +165,7 @@ export class BaseApplicationContext extends EventEmitter implements IApplication
   }
 
   get<T>(identifier: ObjectIdentifier, args?: any): T {
-    // 以 ${identifier} 开头的 Error 信息将被增加详细的类名，在 ManagedResolverFactory.ts create 方法中
-    // 因为在这里拿不到类名
+    // 因为在这里拿不到类名, NotFoundError 类的错误信息在 ManagedResolverFactory.ts createAsync 方法中增加错误类名
 
     if (this.registry.hasObject(identifier)) {
       return this.registry.getObject(identifier);
@@ -184,14 +184,13 @@ export class BaseApplicationContext extends EventEmitter implements IApplication
       return this.parent.get<T>(identifier, args);
     }
     if (!definition) {
-      throw new Error(`${identifier} is not valid in current context`);
+      throw new NotFoundError(identifier);
     }
     return this.resolverFactory.create(definition, args);
   }
 
   async getAsync<T>(identifier: ObjectIdentifier, args?: any): Promise<T> {
-    // 以 ${identifier} 开头的 Error 信息将被增加详细的类名，在 ManagedResolverFactory.ts createAsync 方法中
-    // 因为在这里拿不到类名
+    // 因为在这里拿不到类名, NotFoundError 类的错误信息在 ManagedResolverFactory.ts createAsync 方法中增加错误类名
 
     if (this.registry.hasObject(identifier)) {
       return this.registry.getObject(identifier);
@@ -203,7 +202,7 @@ export class BaseApplicationContext extends EventEmitter implements IApplication
     }
 
     if (!definition) {
-      throw new Error(`${identifier} is not valid in current context`);
+      throw new NotFoundError(identifier);
     }
     return await this.resolverFactory.createAsync(definition, args);
   }

--- a/packages/context/src/factory/common/ManagedResolverFactory.ts
+++ b/packages/context/src/factory/common/ManagedResolverFactory.ts
@@ -24,8 +24,8 @@ import {
 } from '../../interfaces';
 import { ObjectConfiguration } from '../../base/Configuration';
 import { Autowire } from './Autowire';
+import { NotFoundError } from '../../utils/errorFactory';
 
-const is = require('is-type-of');
 
 // 基础模版，用于 {{xxx.xx}} 这种形式的属性注入
 function tpl(s: string, props: any): string {
@@ -386,17 +386,13 @@ export class ManagedResolverFactory {
       const keys = definition.properties.keys();
       for (let i = 0; i < keys.length; i++) {
         const key = keys[i];
-        if (!is.nullOrUndefined(inst) && is.function(inst.hasOwnProperty) && inst.hasOwnProperty(key)) {
-          console.warn(`${inst}\'s own property ${key} will be overwritten by the same name property on the prototype chain`);
-        }
         const identifier = definition.properties.getProperty(key);
         try {
           inst[key] = this.resolveManaged(identifier);
         } catch (error) {
-          const errorWithGetRegExp = new RegExp(`^${identifier.name}`);
-          if(error.message.match(errorWithGetRegExp)) {
+          if(NotFoundError.isClosePrototypeOf(error)) {
             const className = definition.path.name;
-            error.message = `${identifier.name} in class ${className} is not valid in context`;
+            error.updateErrorMsg(className);
           }
           throw error;
         }
@@ -466,17 +462,13 @@ export class ManagedResolverFactory {
       const keys = definition.properties.keys();
       for (let i = 0; i < keys.length; i++) {
         const key = keys[i];
-        if (!is.nullOrUndefined(inst) && is.function(inst.hasOwnProperty) && inst.hasOwnProperty(key)) {
-          console.warn(`${inst}\'s own property ${key} will be overwritten by the same name property on the prototype chain`);
-        }
         const identifier = definition.properties.getProperty(key);
         try {
           inst[key] = await this.resolveManagedAsync(identifier);
         } catch (error) {
-          const errorWithGetRegExp = new RegExp(`^${identifier.name}`);
-          if(error.message.match(errorWithGetRegExp)) {
+          if(NotFoundError.isClosePrototypeOf(error)) {
             const className = definition.path.name;
-            error.message = `${identifier.name} in class ${className} is not valid in context`;
+            error.updateErrorMsg(className);
           }
           throw error;
         }

--- a/packages/context/src/utils/errorFactory.ts
+++ b/packages/context/src/utils/errorFactory.ts
@@ -1,0 +1,17 @@
+import { ObjectIdentifier } from '../interfaces';
+
+export class NotFoundError extends Error {
+  static readonly type = Symbol.for('#NotFoundError');
+  static isClosePrototypeOf(ins: NotFoundError): boolean {
+    return ins ? ins[NotFoundError.type] === NotFoundError.type : false;
+  }
+  constructor(identifier: ObjectIdentifier) {
+    super(`${identifier} is not valid in current context`);
+    this[NotFoundError.type] = NotFoundError.type;
+  }
+  updateErrorMsg(className: string): void {
+    const identifier = this.message.split(' is not valid in current context')[0];
+    const msg = `${identifier} in class ${className} is not valid in context`;
+    this.message = msg;
+  }
+}

--- a/packages/context/test/unit/container.test.ts
+++ b/packages/context/test/unit/container.test.ts
@@ -150,13 +150,19 @@ describe('/test/unit/container.test.ts', () => {
     expect(ins1).to.equal(ins2);
   });
 
-  it('should resolve instance', () => {
+  it('should resolve instance', async() => {
     const container = new Container();
     const ins1 = container.resolve(Katana);
     expect(ins1 instanceof Katana).to.be.true;
     expect(() => {
       container.get(Katana);
     }).to.throw(/is not valid in current context/);
+
+    try {
+      await container.getAsync(Katana);
+    } catch (error) {
+      expect(function () { throw error; }).to.throw(/is not valid in current context/);
+    }
   });
 
   it('should use get async method replace get', async () => {

--- a/packages/context/test/unit/container.test.ts
+++ b/packages/context/test/unit/container.test.ts
@@ -114,6 +114,26 @@ describe('/test/unit/container.test.ts', () => {
     ]);
   });
 
+  it('should throw error with class name when injected property error', async () => {
+    const container = new Container();
+    container.bind<Grandson>('grandson', <any>Grandson);
+
+    expect(function () { container.get('grandson'); }).to.throw(Error, /Grandson/);
+    expect(function () { container.get('nograndson'); }).to.throw(Error, /nograndson/);
+
+    try {
+      await container.getAsync('grandson');
+    } catch (error) {
+      expect(function () { throw error; }).to.throw(Error, /Grandson/);
+    }
+    try {
+      await container.getAsync('nograndson');
+    } catch (error) {
+      expect(function () { throw error; }).to.throw(Error, /nograndson/);
+    }
+  });
+
+
   it('should load js dir and inject with $', () => {
     const container = new Container();
     container.bind('app', require(path.join(__dirname, '../fixtures/js-app-inject', 'app.js')));

--- a/packages/context/test/unit/factory/utils/errorFactory.test.ts
+++ b/packages/context/test/unit/factory/utils/errorFactory.test.ts
@@ -1,0 +1,41 @@
+import { NotFoundError } from '../../../../src/utils/errorFactory';
+import { expect } from 'chai';
+
+describe('/test/unit/utils/errorFactory.test.ts', () => {
+  const creatNormalError = function(msg) {
+    throw new Error(msg);
+  };
+  const creatNotFoundError = function(msg) {
+    throw new NotFoundError(msg);
+  };
+
+  try {
+    creatNormalError('');
+  } catch (error) {
+    expect(error).to.instanceOf(Error);
+    expect(NotFoundError.isClosePrototypeOf(error)).to.false;
+  }
+
+  try {
+    creatNotFoundError('');
+  } catch (error) {
+    expect(error).to.instanceOf(Error);
+    expect(error).to.instanceOf(NotFoundError);
+    expect(NotFoundError.isClosePrototypeOf(error)).to.true;
+    expect(() => {
+      throw error;
+    }).to.throw(/is not valid in current context/);
+  }
+
+  try {
+    creatNotFoundError('testKey');
+  } catch (error) {
+    expect(error).to.instanceOf(Error);
+    expect(error).to.instanceOf(NotFoundError);
+    expect(NotFoundError.isClosePrototypeOf(error)).to.true;
+    error.updateErrorMsg('TestClass');
+    expect(() => {
+      throw error;
+    }).to.throw('testKey in class TestClass is not valid in context');
+  }
+});


### PR DESCRIPTION
Fixes #66 

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->

###### 依赖注入时增加出错的类名信息

https://github.com/midwayjs/midway/blob/c0d58b72e044397f83f1b1e3a5f05843948b0044/packages/context/src/factory/common/ManagedResolverFactory.ts#L383-L389
https://github.com/midwayjs/midway/blob/c0d58b72e044397f83f1b1e3a5f05843948b0044/packages/context/src/factory/common/ManagedResolverFactory.ts#L450-L456
改写了注入不存在属性名时的错误提示信息

###### 增加依赖注入重名属性时在控制台打印警告

当依赖注入的属性与类的构造函数中给实例增加的属性重名时，在控制台打印警告信息，但最终注入的属性依然会覆盖在构造函数增加的属性。
```TypeScript
@provide()
class UserController {
  @inject('userService')
  service;
  constructor() {
    this.service = 'test';
  }
}
const userController = new UserController();
```
`userController.service`是通过注入得到的`userService`实例，并非'test'字符串。
##### Description of change
<!-- Provide a description of the change below this comment. -->
将以上两处向实例增加属性的语句放入`try...catch`，在`catch`中判断出错的信息，发现是注入不存在的属性名时，增加当前出错的类名。
错误信息提示始终是出错类的类名，当在类上用了`@provider('my')`装饰器时，出错信息依然提供的是类名