### PR TITLE
ManagedResolverFactory创建单例对象缓存时增加判断逻辑

### DIFF
--- a/packages/context/src/factory/common/ManagedResolverFactory.ts
+++ b/packages/context/src/factory/common/ManagedResolverFactory.ts
@@ -411,7 +411,7 @@ export class ManagedResolverFactory {
     // after properties set then do init
     definition.creator.doInit(inst);
 
-    if (definition.isSingletonScope()) {
+    if (definition.isSingletonScope() && definition.id) {
       this.singletonCache.set(definition.id, inst);
     }
 
@@ -487,7 +487,7 @@ export class ManagedResolverFactory {
     // after properties set then do init
     await definition.creator.doInitAsync(inst);
 
-    if (definition.isSingletonScope()) {
+    if (definition.isSingletonScope() && definition.id) {
       this.singletonCache.set(definition.id, inst);
     }
 

--- a/packages/context/test/fixtures/app/lib/ctor/obj7.js
+++ b/packages/context/test/fixtures/app/lib/ctor/obj7.js
@@ -1,0 +1,13 @@
+const assert = require('assert');
+
+module.exports = class Obj7 {
+  constructor(options) {
+    assert(options.hello, 'hello is null')
+    console.log(options);
+    this.options = options;
+  }
+
+  getHello() {
+    return this.options.hello;
+  }
+}

--- a/packages/context/test/fixtures/app/resources/construction.xml
+++ b/packages/context/test/fixtures/app/resources/construction.xml
@@ -25,6 +25,28 @@
   <object id="ctor:obj3" path="obj3" direct="true">
   </object>
 
+  <object id="ctor:obj7" path="obj7">
+    <constructor-arg>
+      <object>
+        <property name="hello" value="hello" />
+        <property name="reff">
+          <ref object="ctor:obj2"></ref>
+        </property>
+      </object>
+    </constructor-arg>
+  </object>
+
+  <object id="ctor:obj8" path="obj7">
+    <constructor-arg>
+      <object>
+        <property name="hello" value="hello8" />
+        <property name="reff">
+          <ref object="ctor:obj2"></ref>
+        </property>
+      </object>
+    </constructor-arg>
+  </object>
+
   <object id="ctor:async" path="async" async="true" construct-method="getInstance">
   </object>
 

--- a/packages/context/test/unit/factory/xml/XmlApplicationContext.test.ts
+++ b/packages/context/test/unit/factory/xml/XmlApplicationContext.test.ts
@@ -98,4 +98,11 @@ describe('/test/unit/factory/xml/XmlApplicationContext', () => {
     expect(obj62).deep.eq(obj63);
     expect(obj6).deep.eq(obj63);
   });
+  it('context constructor-arg object should be ok', () => {
+    const aa: any = context.get('ctor:obj7');
+    expect(aa.getHello()).eq('hello');
+
+    const aa1: any = context.get('ctor:obj8');
+    expect(aa1.getHello()).eq('hello8');
+  });
 });


### PR DESCRIPTION
* 不缓存definition.id为空时的对象，表示该对象需要取用时创建
