### PR TITLE
feat: support non-default class for midway-schedule

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -319,13 +319,15 @@ import { schedule } from 'midway';
   interval: 2333, // 2.333s 间隔
   type: 'worker', // 指定某一个 worker 执行
 })
-export default class HelloCron {
+export class HelloCron {
   // 定时执行的具体任务
   async exec(ctx) {
     ctx.logger.info(process.pid, 'hello');
   }
 }
 ```
+
+PS: 定时任务类需 `export` 导出才会被加载，并且一个 `.ts` 文件可以 `export` 多个定时任务类，但是如果 `export default` 了，则只会读取 `default` 的类。
 
 ### 注入日志对象
 

--- a/packages/midway-schedule/package.json
+++ b/packages/midway-schedule/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "npm run lint && midway-bin build -c",
     "lint": "../../node_modules/.bin/tslint --format prose -c ../../tslint.json src/**/*.ts test/**/*.ts",
-    "test": "npm run lint && midway-bin clean && NODE_ENV=test midway-bin test --ts"
+    "test": "npm run lint && midway-bin clean && NODE_ENV=unittest midway-bin test --ts"
   },
   "keywords": [],
   "author": "",

--- a/packages/midway-schedule/test/fixtures/worker-non-default-class/package.json
+++ b/packages/midway-schedule/test/fixtures/worker-non-default-class/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "worker-non-default-class",
+	"scripts": {
+		"build": "midway-bin build -c"
+	}
+}

--- a/packages/midway-schedule/test/fixtures/worker-non-default-class/src/lib/schedule/interval.ts
+++ b/packages/midway-schedule/test/fixtures/worker-non-default-class/src/lib/schedule/interval.ts
@@ -1,0 +1,23 @@
+'use strict';
+
+import { schedule } from '../../../../../../../midway';
+
+@schedule({
+  type: 'worker',
+  interval: 1000,
+})
+export class IntervalCron {
+  async exec(ctx) {
+    ctx.logger.info(process.pid, 'hello decorator');
+  }
+}
+
+@schedule({
+  type: 'worker',
+  interval: 1000,
+})
+export class NonDefCron {
+  async exec(ctx) {
+    ctx.logger.info(process.pid, 'hello other functions');
+  }
+}

--- a/packages/midway-schedule/test/schedule.test.ts
+++ b/packages/midway-schedule/test/schedule.test.ts
@@ -61,6 +61,19 @@ describe('test/schedule.test.ts', () => {
       const log = getLogContent(name);
       assert(contains(log, 'hello decorator') === 4, '未正确执行 4 次');
     });
+
+    it('should support non-default class with @schedule decorator', async () => {
+      const name = 'worker-non-default-class';
+      application = cluster(name, {
+        typescript: true,
+        worker: 2,
+      });
+      await application.ready();
+      await sleep(5000);
+      const log = getLogContent(name);
+      assert(contains(log, 'hello decorator') === 4, '未正确执行 4 次');
+      assert(contains(log, 'hello other functions') === 4, '未正确执行 4 次');
+    });
   });
 });
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->

Fixes #60 

##### Description of change
<!-- Provide a description of the change below this comment. -->

Before
```typescript
// src/lib/schedule/task1.ts
import { schedule } from 'midway';

@schedule({ ... })
export default class Task1 {
  async exec(ctx) {
    // ...
  }
}

// src/lib/schedule/task2.ts
import { schedule } from 'midway';

@schedule({ ... })
export default class Task2 {
  async exec(ctx) {
    // ...
  }
}
```

After
```typescript
// src/lib/schedule/task.ts
import { schedule } from 'midway';

@schedule({ ... })
export  /* no default */  class Task1 {
  async exec(ctx) {
    // ...
  }
}

@schedule({ ... })
export /* no default */ class Task2 {
  async exec(ctx) {
    // ...
  }
}
```

If use `export default` midway-schedule will only load the default task.
