### PR TITLE
fix: lock egg-schedule version to avoid breaking change in midway-schedule

### DIFF
--- a/packages/midway-schedule/package.json
+++ b/packages/midway-schedule/package.json
@@ -23,7 +23,7 @@
     "midway-bin": "^0.7.0"
   },
   "dependencies": {
-    "egg-schedule": "^3.4.0",
+    "egg-schedule": "3.4.0",
     "reflect-metadata": "^0.1.12"
   }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

Due to https://github.com/eggjs/egg-schedule/pull/44, timer was removed. There is a breaking change. First thing to do, we would lock the egg-schedule version, then waiting plan to upgrade.