### PR TITLE
chore: update comma lint

### DIFF
--- a/packages/tslint-midway-contrib/tslint.json
+++ b/packages/tslint-midway-contrib/tslint.json
@@ -59,6 +59,14 @@
       }
     ],
     "no-object-literal-type-assertion": null,
+    "trailing-comma": [
+      true,
+      {
+        "multiline": {
+          "imports": "ignore"
+        }
+      }
+    ],
     "interface-name": false,
     "variable-name": false,
     "switch-final-break": false,


### PR DESCRIPTION
```
import {a,b,c ,} from ''  // c 后面的逗号太奇怪了
```