### PR TITLE
feat: add egg definition

### DIFF
--- a/packages/midway-definition/index.d.ts
+++ b/packages/midway-definition/index.d.ts
@@ -1,0 +1,1 @@
+export * from './typings/egg';

--- a/packages/midway-definition/package.json
+++ b/packages/midway-definition/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@midwayjs/definition",
+  "version": "1.3.2",
+  "description": "declare all midway dependencies by typescript definition",
+  "scripts": {
+    "lint": "../../node_modules/.bin/tslint --format prose -c ../../tslint.json *.ts",
+    "test-local": "midway-bin test",
+    "test": "npm run lint && midway-bin test",
+    "ci": "npm run lint && midway-bin cov"
+  },
+  "dependencies": {
+    "egg": "^2.14.2",
+    "egg-logger": "^2.3.1"
+  },
+  "keywords": [
+    "midway",
+    "typings",
+    "definition"
+  ],
+  "engines": {
+    "node": ">= 8.0.0"
+  },
+  "author": "Harry Chen <czy88840616@gmail.com>",
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/midwayjs/midway.git"
+  }
+}

--- a/packages/midway-definition/typings/egg/index.d.ts
+++ b/packages/midway-definition/typings/egg/index.d.ts
@@ -1,0 +1,23 @@
+import * as egg from 'egg';
+import * as eggLogger from 'egg-logger';
+
+export declare namespace Egg {
+  export interface Context extends egg.Context {}
+  export interface IContextLocals extends egg.IContextLocals {}
+  export type EggEnvType = egg.EggEnvType;
+  export interface EggPlugin extends egg.EggPlugin {}
+  export interface EggAppConfig extends egg.EggAppConfig {}
+  export interface IApplicationLocals extends egg.IApplicationLocals {}
+  export interface EggApplication extends egg.EggApplication {}
+  export interface EggAppInfo extends egg.EggAppInfo {}
+  export interface EggHttpClient extends egg.EggHttpClient {}
+  export interface EggContextHttpClient extends egg.EggContextHttpClient {}
+  export interface Request extends egg.Request {}
+  export interface Response extends egg.Response {}
+  export interface Router extends egg.Router {}
+  export interface EggLoggerOptions extends eggLogger.EggLoggerOptions {}
+  export type EggLoggerLevel = eggLogger.LoggerLevel;
+  export interface EggLogger extends eggLogger.EggLogger {}
+  export interface EggLoggers extends eggLogger.EggLoggers {}
+  export interface EggContextLogger extends eggLogger.EggContextLogger {}
+}

--- a/packages/midway/package.json
+++ b/packages/midway/package.json
@@ -22,9 +22,7 @@
     "midway-bin": "^1.3.0"
   },
   "dependencies": {
-    "egg": "^2.14.2",
     "egg-cluster": "^1.22.2",
-    "egg-core": "^4.13.1",
     "injection": "^1.1.0",
     "midway-core": "^1.3.2",
     "midway-web": "^1.3.2",

--- a/packages/midway/src/index.ts
+++ b/packages/midway/src/index.ts
@@ -1,30 +1,6 @@
 export * from 'injection';
 export * from 'midway-core';
 export * from 'midway-web';
-export {
-  Context,
-  IContextLocals,
-  EggEnvType,
-  IEggPluginItem,
-  EggPlugin,
-  PowerPartial,
-  EggAppConfig,
-  FileStream,
-  IApplicationLocals,
-  EggApplication,
-  EggAppInfo,
-  EggHttpClient,
-  EggContextHttpClient,
-  Request,
-  Response,
-  Router,
-} from 'egg';
-export {
-  LoggerLevel as EggLoggerLevel,
-  EggLogger,
-  EggLoggers,
-  EggContextLogger,
-} from 'egg-logger';
 const Master = require('../cluster/master');
 
 /**


### PR DESCRIPTION
- 增加新包 @midwayjs/definition，用于存放外部的定义，包括egg，插件等非 midway 内置的定义。
- midway 原来导出的定义考虑可以移除了，但是这个属于 breaking change，之前的包是6天前发布的。。。