### PR TITLE
refactor: support set koa middleware directly

### DIFF
--- a/docs/tool_set.md
+++ b/docs/tool_set.md
@@ -133,3 +133,23 @@ midway-bin doc
 npm install -g midway-init
 midway-init
 ```
+
+## tslint-midway-contrib
+
+midway 对 Typescript 应用提供了简单的 tslint 规则包，只需要在 tslint.json 中做简单的继承，如果有其他的需求
+
+```json
+// package.json
+  "devDependencies": {
+    "tslint-midway-contrib": "1",
+  }
+```
+
+```json
+// tslint.json
+{
+  "extends": [
+    "tslint-midway-contrib"
+  ]
+}
+```

--- a/packages/midway-decorator/src/interface.ts
+++ b/packages/midway-decorator/src/interface.ts
@@ -1,3 +1,1 @@
-export interface WebMiddleware {
-  resolve(): (ctx, next?) => void;
-}
+export type KoaMiddleware = (context: any, next: () => Promise<any>) => any;

--- a/packages/midway-decorator/src/web/controller.ts
+++ b/packages/midway-decorator/src/web/controller.ts
@@ -1,13 +1,13 @@
 import { saveClassMetadata, saveModule, scope, ScopeEnum } from 'injection';
 import { CONTROLLER_KEY } from '../constant';
-import { WebMiddleware } from '../interface';
+import { KoaMiddleware } from '../interface';
 
 export interface ControllerOption {
   prefix: string;
-  routerOptions: { middleware?: Array<string | WebMiddleware> };
+  routerOptions: { middleware?: Array<string | KoaMiddleware> };
 }
 
-export function controller(prefix: string, routerOptions: { middleware: Array<string | WebMiddleware> } = {middleware: []}): ClassDecorator {
+export function controller(prefix: string, routerOptions: { middleware: Array<string | KoaMiddleware> } = {middleware: []}): ClassDecorator {
   return (target: any) => {
     saveModule(CONTROLLER_KEY, target);
     saveClassMetadata(CONTROLLER_KEY, {

--- a/packages/midway-decorator/src/web/requestMapping.ts
+++ b/packages/midway-decorator/src/web/requestMapping.ts
@@ -3,14 +3,14 @@
  */
 import { attachClassMetadata } from 'injection';
 import { WEB_ROUTER_KEY } from '../constant';
-import { WebMiddleware } from '../interface';
+import { KoaMiddleware } from '../interface';
 
 export interface RouterOption {
   path?: string;
   requestMethod: string;
   routerName?: string;
   method: string;
-  middleware?: Array<string | WebMiddleware>;
+  middleware?: Array<string | KoaMiddleware>;
 }
 
 export const RequestMethod = {
@@ -40,7 +40,7 @@ export interface RequestMappingMetadata {
   [PATH_METADATA]?: string;
   [METHOD_METADATA]: string;
   [ROUTER_NAME_METADATA]?: string;
-  [ROUTER_MIDDLEWARE]?: Array<string | WebMiddleware>;
+  [ROUTER_MIDDLEWARE]?: Array<string | KoaMiddleware>;
 }
 
 export const RequestMapping = (
@@ -68,7 +68,7 @@ const createMappingDecorator = (method: string) => (
   path?: string,
   routerOptions: {
     routerName?: string;
-    middleware?: Array<string | WebMiddleware>;
+    middleware?: Array<string | KoaMiddleware>;
   } = {middleware: []}
 ): MethodDecorator => {
   return RequestMapping({

--- a/packages/midway-init/package.json
+++ b/packages/midway-init/package.json
@@ -14,7 +14,7 @@
     "eslint-config-egg": "^7.0.0",
     "intelli-espower-loader": "^1.0.1",
     "midway-bin": "^1.4.7",
-    "mm": "^2.4.1",
+    "mm": "^2.5.0",
     "mz-modules": "^2.1.0",
     "power-assert": "^1.6.1",
     "proxy": "^0.2.4",

--- a/packages/midway-web/src/interface.ts
+++ b/packages/midway-web/src/interface.ts
@@ -1,6 +1,10 @@
 import {EggLoaderOptions} from 'egg-core';
 import {IApplicationContext} from 'injection';
 
+export interface WebMiddleware {
+  resolve(): (context: any, next: () => Promise<any>) => any;
+}
+
 export interface MidwayLoaderOptions extends EggLoaderOptions {
   logger: any;
   plugins?: any;

--- a/packages/midway-web/test/enhance.test.ts
+++ b/packages/midway-web/test/enhance.test.ts
@@ -366,14 +366,14 @@ describe('/test/enhance.test.ts', () => {
       request(app.callback())
         .get('/')
         .expect(200)
-        .expect('11112224', done);
+        .expect('1111444455552224', done);
     });
 
     it('should support multi-router in one method', (done) => {
       request(app.callback())
         .post('/api/data')
         .expect(200)
-        .expect('1111', done);
+        .expect('11114444', done);
     });
 
   });

--- a/packages/midway-web/test/fixtures/enhance/base-app-middleware/src/web/controller/my.ts
+++ b/packages/midway-web/test/fixtures/enhance/base-app-middleware/src/web/controller/my.ts
@@ -1,14 +1,26 @@
 import { inject, provide } from 'injection';
 import { controller, get, post } from '../../../../../../../src/';
 
+const mw = async (ctx, next) => {
+  ctx.home = ctx.home + '4444';
+  await next();
+};
+
+const newMiddleware = (data) => {
+  return async (ctx, next) => {
+    ctx.home = ctx.home + data;
+    await next();
+  };
+};
+
 @provide()
-@controller('/', {middleware: ['homeMiddleware']})
+@controller('/', {middleware: ['homeMiddleware', mw]})
 export class My {
 
   @inject()
   ctx;
 
-  @get('/', {middleware: ['apiMiddleware']})
+  @get('/', {middleware: ['apiMiddleware', newMiddleware('5555')]})
   @post('/api/data')
   async index() {
     this.ctx.body = this.ctx.home + (this.ctx.api || '');

--- a/packages/midway-web/test/fixtures/enhance/base-app-middleware/src/web/middleware/api.ts
+++ b/packages/midway-web/test/fixtures/enhance/base-app-middleware/src/web/middleware/api.ts
@@ -1,5 +1,6 @@
-import { WebMiddleware, config } from '@midwayjs/decorator';
+import { config } from '@midwayjs/decorator';
 import { provide } from 'injection';
+import { WebMiddleware } from '../../../../../../../src/interface';
 
 @provide()
 export class ApiMiddleware implements WebMiddleware {

--- a/packages/midway-web/test/fixtures/enhance/base-app-middleware/src/web/middleware/home.ts
+++ b/packages/midway-web/test/fixtures/enhance/base-app-middleware/src/web/middleware/home.ts
@@ -1,5 +1,5 @@
 import { provide } from 'injection';
-import { WebMiddleware } from '@midwayjs/decorator';
+import { WebMiddleware } from '../../../../../../../src/interface';
 
 @provide()
 export class HomeMiddleware implements WebMiddleware {


### PR DESCRIPTION
#167

```ts
const mw = async (ctx, next) => {
  await next();
};

const newMiddleware = (data) => {
  return async (ctx, next) => {
    await next();
  };
};

@provide()
@controller('/', {middleware: ['homeMiddleware', mw]})
export class My {

  @inject()
  ctx;

  @get('/', {middleware: ['apiMiddleware', newMiddleware('5555')]})
  async index() {
  }
}

```

支持在 `@controller/@get/@post` 等装饰器的 middleware 属性中直接添加 koa middleware