### PR TITLE
fix: fix midway-init ci error

### DIFF
--- a/packages/midway-init/.autod.conf.js
+++ b/packages/midway-init/.autod.conf.js
@@ -15,6 +15,7 @@ module.exports = {
   devdep: [
   ],
   keep: [
-    "midway"
+    "midway",
+    "yargs",
   ]
 };

--- a/packages/midway-init/package.json
+++ b/packages/midway-init/package.json
@@ -3,9 +3,9 @@
   "version": "1.4.8",
   "dependencies": {
     "co": "^4.6.0",
-    "egg-init": "^1.15.1",
+    "egg-init": "^1.16.1",
     "enquirer": "^2.3.0",
-    "yargs": "^13.2.2"
+    "yargs": "^11.1.0"
   },
   "main": "lib/command.js",
   "devDependencies": {


### PR DESCRIPTION
新版本 yargs 在默认值上和旧版本不同，ci 报错，做降级处理。