### PR TITLE
refactor: add preload exports modules in container load

### DIFF
--- a/packages/midway-core/src/container.ts
+++ b/packages/midway-core/src/container.ts
@@ -197,8 +197,8 @@ export class MidwayContainer extends Container implements IContainer {
    */
   load(opts: {
     loadDir: string | string[];
-    pattern?: string[];
-    ignore?: string[];
+    pattern?: string | string[];
+    ignore?: string | string[];
   }) {
     const loadDirs = [].concat(opts.loadDir || []);
 
@@ -219,22 +219,25 @@ export class MidwayContainer extends Container implements IContainer {
         const file = path.join(dir, name);
         debug(`binding file => ${file}`);
         const exports = require(file);
+        this.bindClass(exports);
+      }
+    }
+  }
 
-        if (is.class(exports) || is.function(exports)) {
-          this.bindClass(exports);
-        } else {
-          for (const m in exports) {
-            const module = exports[m];
-            if (is.class(module) || is.function(module)) {
-              this.bindClass(module);
-            }
-          }
+  bindClass(exports) {
+    if (is.class(exports) || is.function(exports)) {
+      this.bindModule(exports);
+    } else {
+      for (const m in exports) {
+        const module = exports[m];
+        if (is.class(module) || is.function(module)) {
+          this.bindModule(module);
         }
       }
     }
   }
 
-  protected bindClass(module) {
+  protected bindModule(module) {
     if (is.class(module)) {
       const providerId = getProviderId(module);
       if (providerId) {

--- a/packages/midway-core/src/loader.ts
+++ b/packages/midway-core/src/loader.ts
@@ -13,13 +13,15 @@ export class ContainerLoader {
 
   baseDir;
   pluginContext;
-  applicationContext;
+  applicationContext: MidwayContainer;
   requestContext;
   isTsMode;
+  preloadModules;
 
-  constructor({baseDir, isTsMode = true}) {
+  constructor({baseDir, isTsMode = true, preloadModules = []}) {
     this.baseDir = baseDir;
     this.isTsMode = isTsMode;
+    this.preloadModules = preloadModules;
   }
 
   initialize() {
@@ -82,6 +84,12 @@ export class ContainerLoader {
         pattern: loadOpts.pattern,
         ignore: loadOpts.ignore
       });
+    }
+
+    if (this.preloadModules && this.preloadModules.length) {
+      for (const preloadModule of this.preloadModules) {
+        this.applicationContext.bindClass(preloadModule);
+      }
     }
   }
 

--- a/packages/midway-core/test/loader.test.ts
+++ b/packages/midway-core/test/loader.test.ts
@@ -43,7 +43,7 @@ describe('/test/loader.test.ts', () => {
     });
 
     const appCtx = loader.getApplicationContext();
-    const baseService = await appCtx.getAsync('baseService');
+    const baseService: any = await appCtx.getAsync('baseService');
     assert(baseService.config === 'hello');
     assert(baseService.logger === console);
     assert(baseService.plugin2.b === 2);
@@ -144,6 +144,26 @@ describe('/test/loader.test.ts', () => {
     } catch (err) {
       assert(err);
     }
+  });
+
+  it('should load preload module', async () => {
+    const loader = new ContainerLoader({
+      baseDir: path.join(__dirname, './fixtures/base-app/src'),
+      preloadModules: [
+        class TestModule {
+          test() {
+            return 'hello';
+          }
+        }
+      ]
+    });
+    loader.initialize();
+    loader.loadDirectory();
+    await loader.refresh();
+
+    const appCtx = loader.getApplicationContext();
+    const module: any = await appCtx.getAsync('testModule');
+    assert(module.test() === 'hello');
   });
 
 });


### PR DESCRIPTION
在 container 扫描目录前额外增加模块参数，用于不在目录中的模块，但是却又要放入 ioc 的场景。