### PR TITLE
fix(midway-init): Internal employees can not use the external network…

### DIFF
--- a/packages/midway-init/bin/midway-init.js
+++ b/packages/midway-init/bin/midway-init.js
@@ -40,7 +40,10 @@ co(function* () {
 // 判断是否处于内网环境
 function isInternal() {
   try {
-    const { stdout } = childProcess.spawnSync('tnpm', [ 'view', '@ali/midway-init', '--json' ]);
+    const { stdout } = childProcess.spawnSync('tnpm', [ 'view', '@ali/midway-init', '--json'], {
+      timeout: 3000
+    });
+
     const npmData = JSON.parse(stdout.toString(), null, 2);
 
     if (npmData.name === '@ali/midway-init') {


### PR DESCRIPTION

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->

midway-init

##### Description of change
<!-- Provide a description of the change below this comment. -->
Add a timeout (3000ms) in function `isInternal` at midway-init