### PR TITLE
perf(web): use set to avoid duplicate lookup

### DIFF
--- a/packages/midway-web/src/loader/webLoader.ts
+++ b/packages/midway-web/src/loader/webLoader.ts
@@ -66,25 +66,25 @@ export class MidwayWebLoader extends EggLoader {
     }
 
     const name: string = plugin.package || plugin.name;
-    const lookupDirs: string[] = [];
+    const lookupDirs: Set<string> = new Set();
 
     // 尝试在以下目录找到匹配的插件
     //  -> {APP_PATH}/node_modules
     //    -> {EGG_PATH}/node_modules
     //      -> $CWD/node_modules
-    lookupDirs.push(path.join(this.appDir, 'node_modules'));
+    lookupDirs.add(path.join(this.appDir, 'node_modules'));
 
     // 到 egg 中查找，优先从外往里查找
     for (let i = this.eggPaths.length - 1; i >= 0; i--) {
       const eggPath: string = this.eggPaths[i];
-      lookupDirs.push(path.join(eggPath, 'node_modules'));
+      lookupDirs.add(path.join(eggPath, 'node_modules'));
     }
 
     // should find the $cwd/node_modules when test the plugins under npm3
-    lookupDirs.push(path.join(process.cwd(), 'node_modules'));
+    lookupDirs.add(path.join(process.cwd(), 'node_modules'));
 
     if (process.env.PLUGIN_PATH) {
-      lookupDirs.push(path.join(process.env.PLUGIN_PATH, 'node_modules'));
+      lookupDirs.add(path.join(process.env.PLUGIN_PATH, 'node_modules'));
     }
 
     for (let dir of lookupDirs) {
@@ -94,7 +94,7 @@ export class MidwayWebLoader extends EggLoader {
       }
     }
 
-    throw new Error(`Can not find plugin ${name} in "${lookupDirs.join(', ')}"`);
+    throw new Error(`Can not find plugin ${name} in "${Array.from(lookupDirs).join(', ')}"`);
   }
 
   protected registerTypescriptDirectory(): void {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes (`npm test` fails even before this change)
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->

- midway-web

##### Description of change
<!-- Provide a description of the change below this comment. -->

Use `Set` to avoid duplicate `lookupDirs`
