### PR TITLE
chore: set default typescript options true

### DIFF
--- a/packages/midway/cluster/utils.js
+++ b/packages/midway/cluster/utils.js
@@ -17,7 +17,7 @@ exports.formatOptions = (options) => {
     options.baseDir = process.cwd();
   }
 
-  if(options.typescript === undefined) {
+  if(typeof options.typescript === 'undefined') {
     options.typescript = true;
   }
 

--- a/packages/midway/cluster/utils.js
+++ b/packages/midway/cluster/utils.js
@@ -18,18 +18,7 @@ exports.formatOptions = (options) => {
   }
 
   if(options.typescript === undefined) {
-    /* istanbul ignore else*/
-    if(exports.isTypeScriptEnvironment()) {
-      options.typescript = true;
-    } else {
-      const pkg = require(path.join(options.baseDir, 'package.json'));
-      if(pkg['dependencies'] && pkg['dependencies']['typescript']) {
-        options.typescript = true;
-      }
-      if(pkg['devDependencies'] && pkg['devDependencies']['typescript']) {
-        options.typescript = true;
-      }
-    }
+    options.typescript = true;
   }
 
   return options;


### PR DESCRIPTION
社区 midway 都为 typescript 版本，默认就设置 true，否则在没有 ts 依赖的情况下无法判断。
#341 