### PR TITLE
fix: midway-bin include jest config

### DIFF
--- a/packages/midway-bin/package.json
+++ b/packages/midway-bin/package.json
@@ -43,6 +43,7 @@
   "files": [
     "bin",
     "lib",
+    "jest",
     "index.js"
   ],
   "author": "Harry Chen <czy88840616@gmail.com>",


### PR DESCRIPTION
midway-bin 发布时包含 Jest 测试文件