### PR TITLE
feat(midway-bin): add bundle support

### DIFF
--- a/packages/midway-bin/README.md
+++ b/packages/midway-bin/README.md
@@ -42,7 +42,7 @@ Add `midway-bin` to `package.json` scripts like [egg-bin], but just replace comm
 - build
 - clean
 - doc
- 
+
 ### build
 
 build typescript source file to dist directory like `tsc`  and copy js/css/html file to same place.
@@ -54,6 +54,7 @@ $ midway-bin build
 #### options
 
 - `--clean -c` clean dist directory before build
+- `--entrypoint <entrypoint-file>` bundle the output with the specified file as entrypoint
 
 #### copy static file
 

--- a/packages/midway-bin/package.json
+++ b/packages/midway-bin/package.json
@@ -23,6 +23,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "@zeit/ncc": "^0.20.5",
     "egg-bin": "^4.11.1",
     "fs-extra": "^8.1.0",
     "globby": "^10.0.1",

--- a/packages/midway-bin/test/lib/cmd/build.test.js
+++ b/packages/midway-bin/test/lib/cmd/build.test.js
@@ -138,3 +138,64 @@ describe('test/lib/cmd/build.test.js - with another tsconfig', () => {
     await rimraf(path.join(cwd, 'dist'));
   });
 });
+
+describe('test/lib/cmd/build.test.js - bundling', () => {
+  const midwayBin = require.resolve('../../../bin/midway-bin.js');
+
+  afterEach(mm.restore);
+
+  it('should warn message', async () => {
+    const cwd = path.join(__dirname, '../../fixtures/ts-dir-without-config');
+    const child = coffee
+      .fork(midwayBin, [ 'build', '--entrypoint', 'a.js' ], { cwd })
+      .expect('stdout', /tsconfig/);
+
+    await child.expect('code', 0).end();
+  });
+
+  it('should build success', async () => {
+    const cwd = path.join(__dirname, '../../fixtures/ts-dir');
+    await rimraf(path.join(cwd, 'dist'));
+    const child = coffee.fork(midwayBin, [ 'build', '--entrypoint', 'a.js' ], { cwd });
+    await child.expect('code', 0).end();
+    assert(fs.existsSync(path.join(cwd, 'dist/a.js')));
+    await rimraf(path.join(cwd, 'dist'));
+  });
+
+  it('should auto clean dir before build', async () => {
+    const cwd = path.join(__dirname, '../../fixtures/ts-dir');
+    const child = coffee.fork(midwayBin, [ 'build', '--entrypoint', 'a.js' ], { cwd });
+    await child.expect('code', 0).end();
+    assert(fs.existsSync(path.join(cwd, 'dist/a.js')));
+    await rimraf(path.join(cwd, 'dist'));
+  });
+
+  it('should copy assets file to dist dir', async () => {
+    const cwd = path.join(__dirname, '../../fixtures/ts-dir-with-assets');
+    const child = coffee.fork(midwayBin, [ 'build', '-c', '--entrypoint', 'a.js' ], { cwd });
+    await child.expect('code', 0).end();
+    assert(fs.existsSync(path.join(cwd, 'dist/a.js')));
+    assert(fs.existsSync(path.join(cwd, 'dist/view/index.html')));
+    assert(fs.existsSync(path.join(cwd, 'dist/public/test.css')));
+    assert(fs.existsSync(path.join(cwd, 'dist/public/test.js')));
+    assert(fs.existsSync(path.join(cwd, 'dist/resource.json')));
+    assert(fs.existsSync(path.join(cwd, 'dist/lib/b.json')));
+    assert(fs.existsSync(path.join(cwd, 'dist/lib/a.text')));
+    assert(fs.existsSync(path.join(cwd, 'dist/pattern/ignore.css')));
+    assert(fs.existsSync(path.join(cwd, 'dist/pattern/sub/sub_ignore.css')));
+    await rimraf(path.join(cwd, 'dist'));
+  });
+
+  it('should copy assets file and ignore not exists directory', async () => {
+    const cwd = path.join(
+      __dirname,
+      '../../fixtures/ts-dir-with-not-exists-file'
+    );
+    const child = coffee.fork(midwayBin, [ 'build', '-c', '--entrypoint', 'a.js' ], { cwd }).debug();
+    await child.expect('code', 0).end();
+    assert(!fs.existsSync(path.join(cwd, 'dist/view/index.html')));
+    assert(fs.existsSync(path.join(cwd, 'dist/public/test.css')));
+    assert(fs.existsSync(path.join(cwd, 'dist/public/test.js')));
+    await rimraf(path.join(cwd, 'dist'));
+  });
+});


### PR DESCRIPTION

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
`midway-bin`


##### Description of change
Add bundle support with command line option `midway-bin build --entrypoint <entry-file>`. Out dir and source map support were automatically inferred from `tsconfig.json`.

While ncc is used currently, it doesn't mean rollup could not be an option.