### PR TITLE
feat(midway-bin): do not populate exec argv to child processes

### DIFF
--- a/packages/midway-bin/lib/cmd/build.js
+++ b/packages/midway-bin/lib/cmd/build.js
@@ -84,7 +84,7 @@ class BuildCommand extends Command {
       args.push('-p');
       args.push(argv.project);
     }
-    await this.helper.forkNode(tscCli, args, { cwd });
+    await this.helper.forkNode(tscCli, args, { cwd, execArgv: [] });
   }
 
   async bundle(entry, outDir, { sourceMap = false, mode } = {}) {

--- a/packages/midway-bin/lib/cmd/doc.js
+++ b/packages/midway-bin/lib/cmd/doc.js
@@ -68,7 +68,7 @@ class DocCommand extends Command {
     }
 
     const docBin = require.resolve('typedoc/bin/typedoc');
-    await this.helper.forkNode(docBin, args, { cwd });
+    await this.helper.forkNode(docBin, args, { cwd, execArgv: [] });
   }
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
`midway-bin`


##### Description of change
Prevent conflicts while inspecting the midway-bin process and the forked build process also been populated with the same exec argv.
