### PR TITLE
fix: fix ts mode value is empty for non-ts items

### DIFF
--- a/packages/midway-bin/package.json
+++ b/packages/midway-bin/package.json
@@ -24,6 +24,7 @@
   "license": "MIT",
   "dependencies": {
     "@zeit/ncc": "^0.20.5",
+    "co": "^4.6.0",
     "egg-bin": "^4.11.1",
     "fs-extra": "^8.1.0",
     "globby": "^10.0.1",

--- a/packages/midway-web/src/loader/webLoader.ts
+++ b/packages/midway-web/src/loader/webLoader.ts
@@ -42,7 +42,7 @@ export class MidwayWebLoader extends EggLoader {
    * 判断是否是 ts 模式，在构造器内就会被执行
    */
   get isTsMode(): boolean {
-    return this.app.options.typescript;
+    return !!this.app.options.typescript;
   }
 
   get applicationContext(): MidwayContainer {


### PR DESCRIPTION
如果仓库里有前端项目，由于默认值为 true，会自动扫描到前端仓库。修复方法为强制传入 false，不影响社区版本。

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
