### PR TITLE
fix: executing midway-bin build at arbitrary directory

### DIFF
--- a/packages/midway-bin/package.json
+++ b/packages/midway-bin/package.json
@@ -23,7 +23,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@zeit/ncc": "^0.20.5",
+    "@midwayjs/ncc": "^0.22.0",
     "co": "^4.6.0",
     "egg-bin": "^4.11.1",
     "fs-extra": "^8.1.0",


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
`midway-bin`

##### Description of change
Allow usage of the multi-package project to share node_modules and generate source-maps with correct modules source file reference.