### PR TITLE
Eslint normalize

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,0 +1,12 @@
+extends: './packages/eslint-midway-contrib/recommended.js'
+parserOptions:
+  project: 'tsconfig.eslint.json'
+
+# https://eslint.org/docs/rules/
+# https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/eslint-plugin
+# https://github.com/benmosher/eslint-plugin-import
+# https://github.com/sindresorhus/eslint-plugin-unicorn
+rules:
+  # Use tsconfig.json noUnusedLocals:true instead
+  "@typescript-eslint/no-unused-vars": 0
+

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [10.x, 12.x, 13.x]
 
     steps:
       - uses: actions/checkout@v2
@@ -21,6 +21,7 @@ jobs:
           openssl version
           npm i -g lerna codecov
           npm run bootstrap
+          npm run lint:nofix
           npm run build --if-present
           npm run cov
         env:

--- a/.mocharc.yml
+++ b/.mocharc.yml
@@ -1,0 +1,11 @@
+
+bail: true
+full-trace: true
+require:
+  - intelli-espower-loader
+  - espower-typescript/guess
+spec: 
+  - test/**/*.test.ts
+timeout: 60000 
+ui: bdd
+

--- a/lerna.json
+++ b/lerna.json
@@ -6,6 +6,9 @@
     "bootstrap": {
       "hoist": true,
       "noCi": true,
+      "nohoist": [
+        "cross-env"
+      ],
       "npmClientArgs": [
         "--no-package-lock"
       ]

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "1.0.0",
   "devDependencies": {
     "@types/chai": "^4.1.7",
+    "@types/debug": "4",
     "@types/lodash": "^4.14.119",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.12.18",
@@ -30,6 +31,8 @@
     "test": "lerna run test",
     "cov": "lerna run cov --concurrency=1",
     "ci": "npm run build && npm run cov",
+    "lint": "lerna run lint --parallel",
+    "lint:nofix": "lerna run lint:nofix --parallel",
     "purge": "npm run clean && rm -rf node_modules",
     "reset": "npm run purge && npm i && npm run ci",
     "canary": "sh scripts/publish.sh --canary",

--- a/packages/midway-bin/.eslintrc
+++ b/packages/midway-bin/.eslintrc
@@ -1,3 +1,0 @@
-{
-  "extends": "eslint-config-egg"
-}

--- a/packages/midway-bin/bin/midway-bin.js
+++ b/packages/midway-bin/bin/midway-bin.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
-'use strict';
 
 const Command = require('../').MidwayBin;
+
+
 new Command().start();

--- a/packages/midway-bin/bin/midway-bin.js
+++ b/packages/midway-bin/bin/midway-bin.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-
+'use strict';
 
 const Command = require('../').MidwayBin;
 

--- a/packages/midway-bin/bin/mocha.js
+++ b/packages/midway-bin/bin/mocha.js
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
 
-'use strict';
 
 require('egg-bin/bin/mocha');

--- a/packages/midway-bin/lib/cmd/autod.js
+++ b/packages/midway-bin/lib/cmd/autod.js
@@ -1,10 +1,9 @@
-'use strict';
-
 class AutodCommand extends require('egg-bin/lib/cmd/autod') {
   constructor(rawArgv) {
     super(rawArgv);
     this.usage = 'Usage: midway-bin autod';
   }
 }
+
 
 module.exports = AutodCommand;

--- a/packages/midway-bin/lib/cmd/build.js
+++ b/packages/midway-bin/lib/cmd/build.js
@@ -1,13 +1,20 @@
-'use strict';
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable brace-style */
+/* eslint-disable @typescript-eslint/brace-style */
+/* eslint-disable indent */
+/* eslint-disable @typescript-eslint/indent */
 
-const Command = require('egg-bin').Command;
 const path = require('path');
 const fs = require('fs');
+
+const Command = require('egg-bin').Command;
 const rimraf = require('mz-modules/rimraf');
 const fse = require('fs-extra');
 const globby = require('globby');
 const ncc = require('@midwayjs/ncc');
 const terser = require('terser');
+
+
 let typescript;
 
 const shebangRegEx = /^#![^\n\r]*[\r\n]/;
@@ -60,7 +67,7 @@ class BuildCommand extends Command {
 
     const tscCli = require.resolve('typescript/bin/tsc');
     const projectFile = path.join(cwd, argv.project);
-    if (!fs.existsSync(projectFile)) {
+    if (! fs.existsSync(projectFile)) {
       console.log(`[midway-bin] tsconfig.json not found in ${cwd}\n`);
       return;
     }
@@ -85,11 +92,14 @@ class BuildCommand extends Command {
     }
     if (argv.entrypoint) {
       outDir = outDirAbsolute || path.resolve(projectDir, 'dist');
-      await this.bundle(path.resolve(cwd, argv.entrypoint), outDir,
+      await this.bundle(
+        path.resolve(cwd, argv.entrypoint),
+        outDir,
         {
           sourceMap: this.inferCompilerOptions(tsConfig, 'sourceMap', { projectDir }),
           mode: argv.mode,
-        });
+        },
+      );
       return;
     }
 
@@ -130,7 +140,9 @@ class BuildCommand extends Command {
     if (mode === 'release') {
       options.minify = true;
     }
-    const { error, code, map, assets, symlinks } = await ncc(entry, options);
+    const {
+      error, code, map, assets, symlinks,
+    } = await ncc(entry, options);
 
     if (error) {
       console.error(error);
@@ -140,11 +152,11 @@ class BuildCommand extends Command {
     fse.mkdirpSync(outDir);
 
     let basename = path.basename(entry, '.ts');
-    if (!basename.endsWith('.js')) {
+    if (! basename.endsWith('.js')) {
       basename += '.js';
     }
     fs.writeFileSync(outDir + '/' + basename, code, { mode: code.match(shebangRegEx) ? 0o777 : 0o666 });
-    if (map) fs.writeFileSync(outDir + '/index.js.map', map);
+    if (map) { fs.writeFileSync(outDir + '/index.js.map', map); }
 
     for (const asset of Object.keys(assets)) {
       const assetPath = outDir + '/' + asset;
@@ -169,12 +181,14 @@ class BuildCommand extends Command {
       const pkg = require(path.join(from, 'package.json'));
       if (pkg['midway-bin-build'] && pkg['midway-bin-build'].include) {
         for (const file of pkg['midway-bin-build'].include) {
-          if (typeof file === 'string' && !/\*/.test(file)) {
+          if (typeof file === 'string' && ! /\*/.test(file)) {
             const srcDir = path.join(argv.srcDir, file);
             const targetDir = path.join(outDir, file);
             // 目录，或者不含通配符的普通文件
+
             this.copyFile(srcDir, targetDir, from);
-          } else {
+          }
+          else {
             // 通配符的情况
             const paths = await globby([].concat(file), {
               cwd: path.join(from, argv.srcDir),
@@ -183,7 +197,7 @@ class BuildCommand extends Command {
               this.copyFile(
                 path.join(argv.srcDir, p),
                 path.join(outDir, p),
-                from
+                from,
               );
             }
           }
@@ -193,7 +207,7 @@ class BuildCommand extends Command {
   }
 
   copyFile(srcFile, targetFile, from) {
-    if (!fs.existsSync(srcFile)) {
+    if (! fs.existsSync(srcFile)) {
       console.warn(`[midway-bin] can't find ${srcFile} and skip it`);
     } else {
       fse.copySync(path.join(from, srcFile), path.join(from, targetFile));
@@ -206,8 +220,8 @@ class BuildCommand extends Command {
     // get setting from its parent
     if (tsConfig && tsConfig.extends) {
       if (
-        !tsConfig.compilerOptions ||
-        (tsConfig.compilerOptions && !tsConfig.compilerOptions[optionKeyPath])
+        ! tsConfig.compilerOptions ||
+        tsConfig.compilerOptions && ! tsConfig.compilerOptions[optionKeyPath]
       ) {
         return this.inferCompilerOptions(require(path.join(projectDir, tsConfig.extends)), optionKeyPath, { projectDir });
       }
@@ -219,37 +233,41 @@ class BuildCommand extends Command {
   }
 
   async minify(tsConfig, outDir) {
-    if (typescript == null) {
+    if (typescript === null) {
       typescript = require('typescript');
     }
 
-    const inlineSourceMap = !!tsConfig.compilerOptions.inlineSourceMap;
+    const inlineSourceMap = !! tsConfig.compilerOptions.inlineSourceMap;
     const sourceMap = inlineSourceMap || tsConfig.compilerOptions.sourceMap;
-    if (!sourceMap) {
+    if (! sourceMap) {
       return;
     }
 
     let files;
     if (outDir) {
-      files = globby.sync([ '**/*.js' ], {
+      files = globby.sync(['**/*.js'], {
         cwd: outDir,
-        ignore: [ '**/node_modules' ],
+        ignore: ['**/node_modules'],
       });
+
       files = files.map(it => path.join(outDir, it));
-    } else {
+    }
+    else {
       const host = typescript.createCompilerHost(tsConfig.compilerOptions);
-      files = host.readDirectory(__dirname, [ '.ts' ], tsConfig.exclude, tsConfig.include);
-      files = files.map(it => {
+      files = host.readDirectory(__dirname, ['.ts'], tsConfig.exclude, tsConfig.include);
+      files = files.map((it) => {
         return path.join(path.dirname(it), path.basename(it, '.js'));
       });
     }
 
     for (const file of files) {
-      let code = await fse.readFile(file, 'utf8');
+      const code = await fse.readFile(file, 'utf8');
       let map;
       if (inlineSourceMap) {
-        map = this.parseInlineSourceMap(code);
-      } else {
+        map = this.parseInlineSource;
+        Map(code);
+      }
+      else {
         map = await fse.readFile(file + '.map', 'utf8');
       }
       map = JSON.parse(map);
@@ -265,20 +283,20 @@ class BuildCommand extends Command {
           url: inlineSourceMap ? 'inline' : `${path.basename(file)}.map`,
         },
       });
-      ({ code, map } = result);
-      if (code == null) {
+      const { code: codeNew, map: mapNew } = result;
+      if (codeNew === null) {
         break;
       }
-      if (!inlineSourceMap) {
-        await fse.writeFile(file + '.map', map, 'utf8');
+      if (! inlineSourceMap) {
+        await fse.writeFile(file + '.map', mapNew, 'utf8');
       }
-      await fse.writeFile(file, code, 'utf8');
+      await fse.writeFile(file, codeNew, 'utf8');
     }
   }
 
   parseInlineSourceMap(code) {
     const match = inlineSourceMapRegEx.exec(code);
-    if (match == null) {
+    if (match === null) {
       return;
     }
     const map = Buffer.from(match[1], 'base64').toString('utf8');

--- a/packages/midway-bin/lib/cmd/clean.js
+++ b/packages/midway-bin/lib/cmd/clean.js
@@ -1,10 +1,11 @@
-'use strict';
-
-const Command = require('egg-bin').Command;
-const rimraf = require('mz-modules/rimraf');
+/* eslint-disable @typescript-eslint/no-var-requires */
 const cp = require('child_process');
 const path = require('path');
 const fs = require('fs');
+
+const Command = require('egg-bin').Command;
+const rimraf = require('mz-modules/rimraf');
+
 
 class CleanCommand extends Command {
   constructor(rawArgv) {
@@ -18,7 +19,7 @@ class CleanCommand extends Command {
 
   async run(context) {
     const { cwd } = context;
-    if (!fs.existsSync(path.join(cwd, 'package.json'))) {
+    if (! fs.existsSync(path.join(cwd, 'package.json'))) {
       console.log(`[midway-bin] package.json not found in ${cwd}\n`);
       return;
     }
@@ -27,17 +28,21 @@ class CleanCommand extends Command {
 
   async cleanDir(cwd) {
     await new Promise((resolve, reject) => {
-      cp.exec('find . -type d -name \'logs\' -or -name \'run\' -or -name \'.nodejs-cache\' | xargs rm -rf', {
-        cwd,
-      }, error => {
-        if (error) {
-          console.error(`[midway-bin] exec error: ${error}`);
-          reject(error);
-          return;
-        }
-        console.log('[midway-bin] clean midway temporary files complete!');
-        resolve();
-      });
+      cp.exec(
+        'find . -type d -name \'logs\' -or -name \'run\' -or -name \'.nodejs-cache\' | xargs rm -rf',
+        {
+          cwd,
+        },
+        (error) => {
+          if (error) {
+            console.error(`[midway-bin] exec error: ${error}`);
+            reject(error);
+            return;
+          }
+          console.log('[midway-bin] clean midway temporary files complete!');
+          resolve();
+        },
+      );
     });
 
     const pkg = require(path.join(cwd, 'package.json'));

--- a/packages/midway-bin/lib/cmd/cov.js
+++ b/packages/midway-bin/lib/cmd/cov.js
@@ -1,5 +1,5 @@
 /* istanbul ignore next */
-'use strict';
+
 
 /* istanbul ignore next */
 class CovCommand extends require('egg-bin').CovCommand {
@@ -8,5 +8,6 @@ class CovCommand extends require('egg-bin').CovCommand {
     this.usage = 'Usage: midway-bin cov';
   }
 }
+
 
 module.exports = CovCommand;

--- a/packages/midway-bin/lib/cmd/debug.js
+++ b/packages/midway-bin/lib/cmd/debug.js
@@ -1,6 +1,8 @@
-'use strict';
-const resolver = require('../util').resolveModule;
+/* eslint-disable @typescript-eslint/no-var-requires */
 const co = require('co');
+
+const resolver = require('../util').resolveModule;
+
 
 class DebugCommand extends require('egg-bin').DebugCommand {
   constructor(rawArgv) {
@@ -9,7 +11,7 @@ class DebugCommand extends require('egg-bin').DebugCommand {
   }
 
   async run(context) {
-    if (!context.argv.framework) {
+    if (! context.argv.framework) {
       context.argv.framework = this.findFramework('midway') || this.findFramework('midway-mirror');
     }
     await co(super.run(context));
@@ -19,5 +21,6 @@ class DebugCommand extends require('egg-bin').DebugCommand {
     return resolver(module);
   }
 }
+
 
 module.exports = DebugCommand;

--- a/packages/midway-bin/lib/cmd/dev.js
+++ b/packages/midway-bin/lib/cmd/dev.js
@@ -1,6 +1,8 @@
-'use strict';
-const resolver = require('../util').resolveModule;
+/* eslint-disable @typescript-eslint/no-var-requires */
 const co = require('co');
+
+const resolver = require('../util').resolveModule;
+
 
 class DevCommand extends require('egg-bin/lib/cmd/dev') {
   constructor(rawArgv) {
@@ -10,7 +12,7 @@ class DevCommand extends require('egg-bin/lib/cmd/dev') {
   }
 
   async run(context) {
-    if (!context.argv.framework) {
+    if (! context.argv.framework) {
       context.argv.framework = this.findFramework('midway') || this.findFramework('midway-mirror');
     }
     await co(super.run(context));
@@ -20,5 +22,6 @@ class DevCommand extends require('egg-bin/lib/cmd/dev') {
     return resolver(module);
   }
 }
+
 
 module.exports = DevCommand;

--- a/packages/midway-bin/lib/cmd/doc.js
+++ b/packages/midway-bin/lib/cmd/doc.js
@@ -1,6 +1,5 @@
-'use strict';
-
 const Command = require('egg-bin').Command;
+
 
 class DocCommand extends Command {
   constructor(rawArgv) {
@@ -59,11 +58,13 @@ class DocCommand extends Command {
     let args;
     if (argv.options) {
       // if has options args just ignore others
-      args = [ '--options', argv.options ];
-    } else {
+      args = ['--options', argv.options];
+    // eslint-disable-next-line @typescript-eslint/indent, brace-style
+    }
+    else {
       args = this.helper.unparseArgv(argv, { allowCamelCase: true, useEquals: false });
-      args = args.filter(item => {
-        return !/--\w+-\w+/.test(item);
+      args = args.filter((item) => {
+        return ! /--\w+-\w+/.test(item);
       });
     }
 

--- a/packages/midway-bin/lib/cmd/pkgfiles.js
+++ b/packages/midway-bin/lib/cmd/pkgfiles.js
@@ -1,10 +1,9 @@
-'use strict';
-
 class PkgfilesCommand extends require('egg-bin').PkgfilesCommand {
   constructor(rawArgv) {
     super(rawArgv);
     this.usage = 'Usage: midway-bin pkgfiles';
   }
 }
+
 
 module.exports = PkgfilesCommand;

--- a/packages/midway-bin/lib/cmd/test.js
+++ b/packages/midway-bin/lib/cmd/test.js
@@ -1,4 +1,4 @@
-'use strict';
+/* eslint-disable @typescript-eslint/no-var-requires */
 const co = require('co');
 
 class TestCommand extends require('egg-bin').TestCommand {
@@ -8,11 +8,12 @@ class TestCommand extends require('egg-bin').TestCommand {
   }
 
   async run(context) {
-    if (!context.env.NODE_ENV) {
+    if (! context.env.NODE_ENV) {
       context.env.NODE_ENV = 'unittest';
     }
     await co(super.run(context));
   }
 }
+
 
 module.exports = TestCommand;

--- a/packages/midway-bin/lib/util.js
+++ b/packages/midway-bin/lib/util.js
@@ -1,4 +1,5 @@
-'use strict';
+/* eslint-disable @typescript-eslint/no-var-requires */
+
 const fs = require('fs');
 const path = require('path');
 
@@ -8,7 +9,7 @@ const path = require('path');
  * @return {string} full path or blank
  */
 function resolveModule(moduleName) {
-  if (!moduleName) {
+  if (! moduleName) {
     console.log('[midway-bin] value of framework/module to be loaded is blank and skipped.');
     return '';
   }
@@ -29,13 +30,15 @@ function resolveModule(moduleName) {
 function retrieveModulePath(moduleName) {
   const paths = require.resolve.paths(moduleName);
 
-  const moduleDir = paths.find(dir => {
+  const moduleDir = paths.find((dir) => {
     const mpath = path.join(dir, moduleName);
     try {
       fs.accessSync(mpath, fs.constants.R_OK);
       const stats = fs.statSync(mpath);
       return stats && stats.isDirectory();
-    } catch (ex) {
+    // eslint-disable-next-line @typescript-eslint/indent, brace-style
+    }
+    catch (ex) {
       return false;
     }
   });

--- a/packages/midway-bin/package.json
+++ b/packages/midway-bin/package.json
@@ -8,13 +8,14 @@
     "mocha": "bin/mocha.js"
   },
   "scripts": {
-    "lint": "eslint .",
+    "lint": "eslint --fix --cache {bin,lib,test}/**/*.js",
+    "lint:nofix": "eslint --cache {bin,lib,test}/**/*.js",
     "pkgfiles": "node bin/midway-bin.js pkgfiles",
-    "test": "npm run lint -- --fix && npm run test-local",
+    "test": "npm run lint:nofix && npm run test-local",
     "test-local": "node bin/midway-bin.js test -t 3600000",
     "cov": "nyc -r lcov -r text-summary npm run test-local",
     "ci-test-only": "TESTS=test/lib/cmd/cov.test.js npm run test-local",
-    "ci": "npm run lint && npm run pkgfiles -- --check && npm run ci-test-only && npm run cov",
+    "ci": "npm run lint:nofix && npm run pkgfiles -- --check && npm run ci-test-only && npm run cov",
     "autod": "node bin/midway-bin.js autod"
   },
   "keywords": [
@@ -36,8 +37,6 @@
   "devDependencies": {
     "co-mocha": "^1.2.2",
     "coffee": "^5.2.1",
-    "eslint": "^6.1.0",
-    "eslint-config-egg": "^7.0.0",
     "mm": "^2.5.0"
   },
   "engines": {

--- a/packages/midway-bin/test/lib/cmd/build.test.js
+++ b/packages/midway-bin/test/lib/cmd/build.test.js
@@ -7,6 +7,8 @@ const coffee = require('coffee');
 const mm = require('mm');
 const rimraf = require('mz-modules/rimraf');
 
+process.setMaxListeners(0);
+
 describe('test/lib/cmd/build.test.js', () => {
   const midwayBin = require.resolve('../../../bin/midway-bin.js');
 

--- a/packages/midway-bin/tsconfig.eslint.json
+++ b/packages/midway-bin/tsconfig.eslint.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts",
+    "test_browser/**/*.ts",
+    "bin/**/*.js",
+    "lib/**/*.js"
+  ],
+  "exclude": [
+    "asset",
+    "app/public",
+    "app/views",
+    "dist",
+    "node_modules*",
+    "**/*.d.ts",
+    "**/*.spec.ts"
+  ]
+}

--- a/packages/midway-bin/tsconfig.json
+++ b/packages/midway-bin/tsconfig.json
@@ -1,0 +1,34 @@
+{
+  "compilerOptions": {
+    "declaration": false,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "incremental": true,
+    "module": "commonjs",
+    "newLine": "lf",
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "outDir": "dist",
+    "pretty": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "target": "ES2019",
+    "tsBuildInfoFile": ".vscode/.tsbuildinfo",
+    "types" : ["node", "mocha"]
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "asset",
+    "app/public",
+    "app/views",
+    "dist",
+    "node_modules*",
+    "test",
+    "**/*.d.ts",
+    "**/*.spec.ts"
+  ]
+}

--- a/packages/midway-core/package.json
+++ b/packages/midway-core/package.json
@@ -8,7 +8,7 @@
     "build": "midway-bin build -c",
     "lint": "eslint --fix --cache {src,test}/**/*.ts",
     "lint:nofix": "eslint --cache {src,test}/**/*.ts",
-    "test": "npm run lint:nofix && midway-bin clean && NODE_ENV=test midway-bin test --ts",
+    "test": "npm run lint:nofix && midway-bin clean && cross-env NODE_ENV=test midway-bin test --ts",
     "cov": "midway-bin clean && midway-bin cov --ts",
     "autod": "midway-bin autod"
   },
@@ -25,6 +25,7 @@
   "license": "MIT",
   "devDependencies": {
     "chai": "^4.2.0",
+    "cross-env": "7",
     "midway-bin": "^1.17.1",
     "xmldom": "^0.1.27"
   },

--- a/packages/midway-core/package.json
+++ b/packages/midway-core/package.json
@@ -6,8 +6,9 @@
   "typings": "dist/index.d.ts",
   "scripts": {
     "build": "midway-bin build -c",
-    "lint": "../../node_modules/.bin/tslint --format prose -c ../../tslint.json --fix 'src/**/*.ts' 'test/**/*.ts'",
-    "test": "npm run lint && midway-bin clean && NODE_ENV=test midway-bin test --ts",
+    "lint": "eslint --fix --cache {src,test}/**/*.ts",
+    "lint:nofix": "eslint --cache {src,test}/**/*.ts",
+    "test": "npm run lint:nofix && midway-bin clean && NODE_ENV=test midway-bin test --ts",
     "cov": "midway-bin clean && midway-bin cov --ts",
     "autod": "midway-bin autod"
   },

--- a/packages/midway-core/package.json
+++ b/packages/midway-core/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index",
   "typings": "dist/index.d.ts",
   "scripts": {
-    "build": "npm run lint && midway-bin build -c",
+    "build": "midway-bin build -c",
     "lint": "../../node_modules/.bin/tslint --format prose -c ../../tslint.json --fix 'src/**/*.ts' 'test/**/*.ts'",
     "test": "npm run lint && midway-bin clean && NODE_ENV=test midway-bin test --ts",
     "cov": "midway-bin clean && midway-bin cov --ts",

--- a/packages/midway-core/src/container.ts
+++ b/packages/midway-core/src/container.ts
@@ -1,3 +1,5 @@
+import * as path from 'path';
+
 import { CLASS_KEY_CONSTRUCTOR, CONFIG_KEY, LOGGER_KEY, PLUGIN_KEY } from '@midwayjs/decorator';
 import * as globby from 'globby';
 import {
@@ -18,23 +20,26 @@ import {
   ObjectIdentifier,
   Scope,
   ScopeEnum,
-  XmlObjectDefinition
+  XmlObjectDefinition,
 } from 'injection';
 import * as is from 'is-type-of';
-import * as path from 'path';
+import * as graphviz from 'graphviz';
+import * as camelcase from 'camelcase';
+import * as Debug from 'debug';
+
 import { FUNCTION_INJECT_KEY, MidwayHandlerKey } from './constant';
 
-const graphviz = require('graphviz');
-const camelcase = require('camelcase');
-const debug = require('debug')('midway:container');
+
+const debug = Debug('midway:container');
+
 const CONTROLLERS = 'controllers';
 const MIDDLEWARES = 'middlewares';
 const TYPE_LOGGER = 'logger';
 const TYPE_PLUGIN = 'plugin';
 
 interface FrameworkDecoratorMetadata {
-  key: string;
-  propertyName: string;
+  key: string
+  propertyName: string
 }
 
 class BaseParser {
@@ -173,7 +178,7 @@ export class MidwayContainer extends Container implements IContainer {
     this.handlerMap = new Map();
     super.init();
 
-    if (!this.isTsMode) {
+    if (! this.isTsMode) {
       // xml扩展 <logger name=""/> <plugin name="hsfclient"/>
       this.parser.objectElementParser.registerParser(new LoggerParser());
       this.getManagedResolverFactory().registerResolver(new LoggerResolver(this));
@@ -223,13 +228,14 @@ export class MidwayContainer extends Container implements IContainer {
           '**/run/**',
           '**/public/**',
           '**/view/**',
-          '**/views/**'
+          '**/views/**',
         ].concat(opts.ignore || []),
       });
 
       for (const name of fileResults) {
         const file = path.join(dir, name);
         debug(`binding file => ${file}`);
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
         const exports = require(file);
         this.bindClass(exports);
       }
@@ -239,7 +245,8 @@ export class MidwayContainer extends Container implements IContainer {
   bindClass(exports) {
     if (is.class(exports) || is.function(exports)) {
       this.bindModule(exports);
-    } else {
+    }
+    else {
       for (const m in exports) {
         const module = exports[m];
         if (is.class(module) || is.function(module)) {
@@ -254,26 +261,28 @@ export class MidwayContainer extends Container implements IContainer {
       const providerId = getProviderId(module);
       if (providerId) {
         this.bind(providerId, module);
-      } else {
-        if (!this.isTsMode) {
+      }
+      else {
+        if (! this.isTsMode) {
           // inject by name in js
           this.bind(camelcase(module.name), module);
         }
       }
-    } else {
+    }
+    else {
       const info: {
-        id: ObjectIdentifier,
-        provider: (context?: IApplicationContext) => any,
-        scope?: Scope,
-        isAutowire?: boolean
+        id: ObjectIdentifier;
+        provider: (context?: IApplicationContext) => any;
+        scope?: Scope;
+        isAutowire?: boolean;
       } = module[FUNCTION_INJECT_KEY];
       if (info && info.id) {
-        if (!info.scope) {
+        if (! info.scope) {
           info.scope = ScopeEnum.Request;
         }
         this.bind(info.id, module, {
           scope: info.scope,
-          isAutowire: info.isAutowire
+          isAutowire: info.isAutowire,
         });
       }
     }
@@ -291,7 +300,8 @@ export class MidwayContainer extends Container implements IContainer {
       let constructorMetaData;
       try {
         constructorMetaData = getClassMetadata(CLASS_KEY_CONSTRUCTOR, target);
-      } catch (e) {
+      }
+      catch (e) {
         debug(`beforeEachCreated error ${e.stack}`);
       }
       // lack of field
@@ -331,7 +341,7 @@ export class MidwayContainer extends Container implements IContainer {
       this.defineGetterPropertyValue(loggerSetterProps, instance, this.findHandlerHook(MidwayHandlerKey.LOGGER));
 
       // 表示非ts annotation模式
-      if (!this.isTsMode && !pluginSetterProps && !loggerSetterProps && definition.isAutowire()) {
+      if (! this.isTsMode && ! pluginSetterProps && ! loggerSetterProps && definition.isAutowire()) {
         // this.$$xxx = null; 用来注入config
         // this.$xxx = null; 用来注入 logger 或者 插件
         Autowire.patchDollar(instance, context, (key: string) => {
@@ -343,7 +353,9 @@ export class MidwayContainer extends Container implements IContainer {
             if (v) {
               return v;
             }
-          } catch (e) {
+          }
+          catch (e) {
+            // void
           }
           return this.findHandlerHook(MidwayHandlerKey.LOGGER)(key);
         });
@@ -365,7 +377,7 @@ export class MidwayContainer extends Container implements IContainer {
           Object.defineProperty(instance, prop.propertyName, {
             get: () => getterHandler(prop.key, instance),
             configurable: false,
-            enumerable: true
+            enumerable: true,
           });
         }
       }
@@ -381,7 +393,7 @@ export class MidwayContainer extends Container implements IContainer {
 
     // Override the default scope to request
     const objDefOptions: ObjectDefinitionOptions = getObjectDefinition(target);
-    if (objDefOptions && !objDefOptions.scope) {
+    if (objDefOptions && ! objDefOptions.scope) {
       debug(`register @scope to default value(request), id=${objectDefinition.id}`);
       objectDefinition.scope = ScopeEnum.Request;
     }
@@ -391,18 +403,19 @@ export class MidwayContainer extends Container implements IContainer {
     const g = graphviz.digraph('G');
 
     for (const [id, module] of this.dependencyMap.entries()) {
-      g.addNode(id, {label: `${id}(${module.name})\nscope:${module.scope}`, fontsize: '10'});
+      g.addNode(id, { label: `${id}(${module.name})\nscope:${module.scope}`, fontsize: '10' });
       module.properties.forEach((depId) => {
-        g.addEdge(id, depId, {label: `properties`, fontsize: '8'});
+        g.addEdge(id, depId, { label: 'properties', fontsize: '8' });
       });
       module.constructorArgs.forEach((depId) => {
-        g.addEdge(id, depId, {label: 'constructor', fontsize: '8'});
+        g.addEdge(id, depId, { label: 'constructor', fontsize: '8' });
       });
     }
 
     try {
       return g.to_dot();
-    } catch (err) {
+    }
+    catch (err) {
       console.error('generate injection dependency tree fail, err = ', err.message);
     }
   }

--- a/packages/midway-core/src/index.ts
+++ b/packages/midway-core/src/index.ts
@@ -1,5 +1,5 @@
 export { ContainerLoader } from './loader';
 export { MidwayContainer } from './container';
-export { MidwayRequestContainer }  from './requestContainer';
+export { MidwayRequestContainer } from './requestContainer';
 export * from './providerWrapper';
 export * from './constant';

--- a/packages/midway-core/src/loader.ts
+++ b/packages/midway-core/src/loader.ts
@@ -1,8 +1,10 @@
 import * as path from 'path';
+
 import { MidwayContainer } from './container';
 
+
 function buildLoadDir(baseDir, dir) {
-  if (!path.isAbsolute(dir)) {
+  if (! path.isAbsolute(dir)) {
     return path.join(baseDir, dir);
   }
   return dir;
@@ -16,7 +18,7 @@ export class ContainerLoader {
   isTsMode;
   preloadModules;
 
-  constructor({baseDir, isTsMode = true, preloadModules = []}) {
+  constructor({ baseDir, isTsMode = true, preloadModules = [] }) {
     this.baseDir = baseDir;
     this.isTsMode = isTsMode;
     this.preloadModules = preloadModules;
@@ -49,22 +51,22 @@ export class ContainerLoader {
     ignore?: string;
     configLocations?: string[];
   } = {}) {
-    if (!this.isTsMode && loadOpts.disableAutoLoad === undefined) {
+    if (! this.isTsMode && loadOpts.disableAutoLoad === undefined) {
       // disable auto load in js mode by default
       loadOpts.disableAutoLoad = true;
     }
 
     // if not disable auto load
-    if (!loadOpts.disableAutoLoad) {
+    if (! loadOpts.disableAutoLoad) {
       // use baseDir in parameter first
       const baseDir = loadOpts.baseDir || this.baseDir;
       const defaultLoadDir = this.isTsMode ? [baseDir] : ['app', 'lib'];
       this.applicationContext.load({
-        loadDir: (loadOpts.loadDir || defaultLoadDir).map(dir => {
+        loadDir: (loadOpts.loadDir || defaultLoadDir).map((dir) => {
           return buildLoadDir(baseDir, dir);
         }),
         pattern: loadOpts.pattern,
-        ignore: loadOpts.ignore
+        ignore: loadOpts.ignore,
       });
     }
 

--- a/packages/midway-core/src/providerWrapper.ts
+++ b/packages/midway-core/src/providerWrapper.ts
@@ -1,12 +1,14 @@
 import { IApplicationContext, ObjectIdentifier, Scope } from 'injection';
+
 import { FUNCTION_INJECT_KEY } from './constant';
 
-export function providerWrapper(wrapperInfo: Array<{
+
+export function providerWrapper(wrapperInfo: {
   id: ObjectIdentifier;
   provider: (context: IApplicationContext) => any;
   scope?: Scope;
   isAutowire?: boolean;
-}>): void {
+}[]): void {
   for (const info of wrapperInfo) {
     Object.defineProperty(info.provider, FUNCTION_INJECT_KEY, {
       value: info,

--- a/packages/midway-core/src/requestContainer.ts
+++ b/packages/midway-core/src/requestContainer.ts
@@ -1,5 +1,7 @@
 import { ManagedValue, VALUE_TYPE } from 'injection';
+
 import { MidwayContainer } from './container';
+
 
 export class MidwayRequestContainer extends MidwayContainer {
 
@@ -25,7 +27,8 @@ export class MidwayRequestContainer extends MidwayContainer {
     this.registerObject('logger', ctx.logger);
   }
 
-  get<T = any>(identifier: any, args?: any): T {
+  // eslint-disable-next-line @typescript-eslint/type-annotation-spacing
+  get<T = any>(identifier: any, args?: any):T {
     if (typeof identifier !== 'string') {
       identifier = this.getIdentifier(identifier);
     }
@@ -43,6 +46,7 @@ export class MidwayRequestContainer extends MidwayContainer {
     }
   }
 
+  // eslint-disable-next-line @typescript-eslint/type-annotation-spacing
   async getAsync<T = any>(identifier: any, args?: any): Promise<T> {
     if (typeof identifier !== 'string') {
       identifier = this.getIdentifier(identifier);

--- a/packages/midway-core/src/requestContainer.ts
+++ b/packages/midway-core/src/requestContainer.ts
@@ -42,7 +42,7 @@ export class MidwayRequestContainer extends MidwayContainer {
     }
 
     if (this.parent) {
-      return this.parent.get(identifier, args);
+      return this.parent.get<T>(identifier, args);
     }
   }
 

--- a/packages/midway-core/test/base.test.ts
+++ b/packages/midway-core/test/base.test.ts
@@ -1,5 +1,8 @@
+/* eslint-disable @typescript-eslint/ban-ts-ignore */
 import * as assert from 'assert';
+
 import * as extend2 from 'extend2';
+
 
 describe('/test/base.test.ts', () => {
   it('should proxy app when set property', () => {
@@ -10,10 +13,11 @@ describe('/test/base.test.ts', () => {
       defineProperty(target, prop, attributes) {
         pluginContext[prop] = attributes.value;
         return Object.defineProperty(target, prop, attributes);
-      }
+      },
     });
 
-    app['test'] = 1;
+    // @ts-ignore
+    app.test = 1;
 
     Object.defineProperty(app, 'key', {
       value: 123,
@@ -21,15 +25,17 @@ describe('/test/base.test.ts', () => {
       configurable: false,
     });
 
-    assert(pluginContext['test'] === 1);
-    assert(pluginContext['key'] === 123);
+    // @ts-ignore
+    assert(pluginContext.test === 1);
+    // @ts-ignore
+    assert(pluginContext.key === 123);
   });
 
   it('should test merge array', () => {
     const target = extend2(true, {
-      a: [1, 2, 3, {}]
+      a: [1, 2, 3, {} ],
     }, {
-      a: [3, 4]
+      a: [3, 4],
     });
     assert(target.a.length === 2);
   });

--- a/packages/midway-core/test/fixtures/base-app-async/src/config/config.default.ts
+++ b/packages/midway-core/test/fixtures/base-app-async/src/config/config.default.ts
@@ -8,5 +8,5 @@ export const hello = {
 
 export const plugins = {
   bucLogin: false,
-  plugin2: true
+  plugin2: true,
 };

--- a/packages/midway-core/test/fixtures/base-app-async/src/config/plugin.ts
+++ b/packages/midway-core/test/fixtures/base-app-async/src/config/plugin.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 
+
 module.exports = {
   // 默认开启的插件
 
@@ -9,5 +10,5 @@ module.exports = {
   plugin2: {
     enable: true,
     path: path.join(__dirname, '../plugins/plugin2'),
-  }
+  },
 };

--- a/packages/midway-core/test/fixtures/base-app-async/src/lib/service.ts
+++ b/packages/midway-core/test/fixtures/base-app-async/src/lib/service.ts
@@ -1,5 +1,6 @@
-import {config, plugin} from '../../../../../src/decorators';
-import {provide, async, init} from 'injection';
+import { provide, async, init } from 'injection';
+
+import { config, plugin } from '../../../../../src/decorators';
 
 @async()
 @provide()
@@ -13,7 +14,7 @@ export class BaseService {
 
   @init()
   async init() {
-    await new Promise(resolve => {
+    await new Promise((resolve) => {
       setTimeout(() => {
         this.config.c = 10;
         resolve();

--- a/packages/midway-core/test/fixtures/base-app-constructor/src/config/config.default.ts
+++ b/packages/midway-core/test/fixtures/base-app-constructor/src/config/config.default.ts
@@ -8,5 +8,5 @@ export const hello = {
 
 export const plugins = {
   bucLogin: false,
-  plugin2: true
+  plugin2: true,
 };

--- a/packages/midway-core/test/fixtures/base-app-constructor/src/config/plugin.ts
+++ b/packages/midway-core/test/fixtures/base-app-constructor/src/config/plugin.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 
+
 module.exports = {
   // 默认开启的插件
 
@@ -9,5 +10,5 @@ module.exports = {
   plugin2: {
     enable: true,
     path: path.join(__dirname, '../plugins/plugin2'),
-  }
+  },
 };

--- a/packages/midway-core/test/fixtures/base-app-constructor/src/lib/service.ts
+++ b/packages/midway-core/test/fixtures/base-app-constructor/src/lib/service.ts
@@ -1,17 +1,20 @@
-import {config, plugin, logger} from '@midwayjs/decorator';
-import {provide, async, init, inject} from 'injection';
+/* eslint-disable no-shadow */
+/* eslint-disable @typescript-eslint/no-use-before-define */
+import { config, plugin, logger } from '@midwayjs/decorator';
+import { provide, async, init, inject } from 'injection';
+
 
 @provide()
 export class A {
   config = {
-    c: 20
+    c: 20,
   };
 }
 
 @provide()
 export class B {
   config = {
-    c: 40
+    c: 40,
   };
 }
 
@@ -24,14 +27,14 @@ export class BaseService {
   logger;
 
   constructor(
-    @inject() a,
+  @inject() a,
     @config('hello') config,
     @inject() b,
     @plugin('plugin2') plugin2,
-    @logger() logger
+    @logger() logger,
   ) {
     this.config = Object.assign(config, {
-      c: a.config.c + b.config.c + config.c
+      c: a.config.c + b.config.c + config.c,
     });
     this.plugin2 = plugin2;
     this.logger = logger;
@@ -39,7 +42,7 @@ export class BaseService {
 
   @init()
   async init() {
-    await new Promise(resolve => {
+    await new Promise((resolve) => {
       setTimeout(() => {
         resolve();
       }, 100);

--- a/packages/midway-core/test/fixtures/base-app-decorator/src/app/controller/api.ts
+++ b/packages/midway-core/test/fixtures/base-app-decorator/src/app/controller/api.ts
@@ -1,4 +1,5 @@
-import {BaseService} from '../../lib/service';
+import { BaseService } from '../../lib/service';
+
 
 exports.index = async (ctx, next) => {
   const context = ctx.app.applicationContext;

--- a/packages/midway-core/test/fixtures/base-app-decorator/src/config/config.default.ts
+++ b/packages/midway-core/test/fixtures/base-app-decorator/src/config/config.default.ts
@@ -8,5 +8,5 @@ export const hello = {
 
 export const plugins = {
   bucLogin: false,
-  plugin2: true
+  plugin2: true,
 };

--- a/packages/midway-core/test/fixtures/base-app-decorator/src/config/plugin.ts
+++ b/packages/midway-core/test/fixtures/base-app-decorator/src/config/plugin.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 
+
 module.exports = {
   // 默认开启的插件
 
@@ -9,5 +10,5 @@ module.exports = {
   plugin2: {
     enable: true,
     path: path.join(__dirname, '../plugins/plugin2'),
-  }
+  },
 };

--- a/packages/midway-core/test/fixtures/base-app-decorator/src/lib/service.ts
+++ b/packages/midway-core/test/fixtures/base-app-decorator/src/lib/service.ts
@@ -1,5 +1,7 @@
-import {config, plugin, logger} from '@midwayjs/decorator';
-import {provide, async} from 'injection';
+import { config, plugin, logger } from '@midwayjs/decorator';
+import { provide, async } from 'injection';
+
+
 @async()
 @provide()
 export class BaseService {

--- a/packages/midway-core/test/fixtures/base-app-function/src/app/controller/error.ts
+++ b/packages/midway-core/test/fixtures/base-app-function/src/app/controller/error.ts
@@ -3,7 +3,8 @@ exports.error = async (ctx, next) => {
   const baseService = await context.getAsync('baseService');
   try {
     await baseService.sayAuto();
-  } catch (e) {
+  }
+  catch (e) {
     ctx.body = e.message;
     return;
   }

--- a/packages/midway-core/test/fixtures/base-app-function/src/config/config.default.ts
+++ b/packages/midway-core/test/fixtures/base-app-function/src/config/config.default.ts
@@ -8,7 +8,7 @@ export const hello = {
 
 export const plugins = {
   bucLogin: false,
-  plugin2: true
+  plugin2: true,
 };
 
 export const adapterName = 'google';

--- a/packages/midway-core/test/fixtures/base-app-function/src/config/plugin.ts
+++ b/packages/midway-core/test/fixtures/base-app-function/src/config/plugin.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 
+
 module.exports = {
   // 默认开启的插件
 
@@ -9,5 +10,5 @@ module.exports = {
   plugin2: {
     enable: true,
     path: path.join(__dirname, '../plugins/plugin2'),
-  }
+  },
 };

--- a/packages/midway-core/test/fixtures/base-app-function/src/lib/factory.ts
+++ b/packages/midway-core/test/fixtures/base-app-function/src/lib/factory.ts
@@ -1,5 +1,7 @@
-import {providerWrapper} from '../../../../../src/';
-import {IApplicationContext} from 'injection';
+import { IApplicationContext } from 'injection';
+
+import { providerWrapper } from '../../../../../src';
+
 
 export function adapterFactory(context: IApplicationContext) {
   return async (adapterName: string) => {
@@ -16,6 +18,6 @@ export function adapterFactory(context: IApplicationContext) {
 providerWrapper([
   {
     id: 'adapterFactory',
-    provider: adapterFactory
-  }
+    provider: adapterFactory,
+  },
 ]);

--- a/packages/midway-core/test/fixtures/base-app-function/src/lib/otherFactory.ts
+++ b/packages/midway-core/test/fixtures/base-app-function/src/lib/otherFactory.ts
@@ -1,5 +1,7 @@
-import {providerWrapper} from '../../../../../src/';
-import {IApplicationContext} from 'injection';
+import { IApplicationContext } from 'injection';
+
+import { providerWrapper } from '../../../../../src';
+
 
 class MyTestObj {
   _notfound = null;
@@ -22,7 +24,7 @@ class MyTestAuto {
   }
 
   say() {
-    if (this.baiduAdapter == null) {
+    if (this.baiduAdapter === null) {
       throw new Error('baiduAdapter is null');
     }
     return `hello ${this._name}.`;
@@ -52,22 +54,22 @@ export function otherFactory3(context: IApplicationContext) {
 providerWrapper([
   {
     id: 'otherFactory',
-    provider: otherFactory
+    provider: otherFactory,
   },
   {
     id: 'otherFactory1',
-    provider: otherFactory1
+    provider: otherFactory1,
   },
   {
     // 用于测试自动装配是否成功
     id: 'otherFactory2',
     provider: otherFactory2,
-    isAutowire: true
+    isAutowire: true,
   },
   {
     // 用于测试自动装配是否成功
     id: 'otherFactory3',
     provider: otherFactory3,
-    isAutowire: true
-  }
+    isAutowire: true,
+  },
 ]);

--- a/packages/midway-core/test/fixtures/base-app-function/src/lib/service.ts
+++ b/packages/midway-core/test/fixtures/base-app-function/src/lib/service.ts
@@ -1,17 +1,20 @@
-import {config, plugin} from '@midwayjs/decorator';
-import {provide, async, init, inject} from 'injection';
+/* eslint-disable no-shadow */
+/* eslint-disable @typescript-eslint/no-use-before-define */
+import { config, plugin } from '@midwayjs/decorator';
+import { provide, async, init, inject } from 'injection';
+
 
 @provide()
 export class A {
   config = {
-    c: 20
+    c: 20,
   };
 }
 
 @provide()
 export class B {
   config = {
-    c: 40
+    c: 40,
   };
 }
 
@@ -40,13 +43,13 @@ export class BaseService {
   adapter;
 
   constructor(
-    @inject() a,
+  @inject() a,
     @config('hello') config,
     @inject() b,
-    @plugin('plugin2') plugin2
+    @plugin('plugin2') plugin2,
   ) {
     this.config = Object.assign(config, {
-      c: a.config.c + b.config.c + config.c
+      c: a.config.c + b.config.c + config.c,
     });
     this.plugin2 = plugin2;
   }
@@ -65,7 +68,8 @@ export class BaseService {
     try {
       const o2 = await this.other2('ttt');
       await o2.say();
-    } catch (e) {
+    }
+    catch (e) {
       console.log('function inject is not support!', e.stack);
     }
 

--- a/packages/midway-core/test/fixtures/base-app-utils/src/app.ts
+++ b/packages/midway-core/test/fixtures/base-app-utils/src/app.ts
@@ -1,4 +1,5 @@
 module.exports = (app) => {
   const context = app.applicationContext;
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
   context.registerObject('is', require('is-type-of'));
 };

--- a/packages/midway-core/test/fixtures/base-app-utils/src/app/controller/api.ts
+++ b/packages/midway-core/test/fixtures/base-app-utils/src/app/controller/api.ts
@@ -1,5 +1,8 @@
-import {BaseService} from '../../lib/service';
+import { BaseService } from '../../lib/service';
+
+
 const Controller = require('egg').Controller;
+
 
 class ApiController extends Controller {
 

--- a/packages/midway-core/test/fixtures/base-app-utils/src/lib/service.ts
+++ b/packages/midway-core/test/fixtures/base-app-utils/src/lib/service.ts
@@ -1,5 +1,6 @@
-import {config, plugin, logger} from '../../../../../src/decorators';
-import {provide, inject} from 'injection';
+import { provide, inject } from 'injection';
+
+import { config, plugin, logger } from '../../../../../src/decorators';
 
 @provide()
 export class BaseService {

--- a/packages/midway-core/test/fixtures/base-app/src/app/controller/api.ts
+++ b/packages/midway-core/test/fixtures/base-app/src/app/controller/api.ts
@@ -1,5 +1,6 @@
 'use strict';
 
+// eslint-disable-next-line require-yield
 exports.index = function*() {
   this.body = 'hello';
 };

--- a/packages/midway-core/test/fixtures/complex_injection/dbAPI.ts
+++ b/packages/midway-core/test/fixtures/complex_injection/dbAPI.ts
@@ -3,14 +3,14 @@ import { inject, provide, scope, ScopeEnum } from 'injection';
 @provide()
 export class A {
   config = {
-    c: 1
+    c: 1,
   };
 }
 
 @provide()
 export class B {
   config = {
-    c: 2
+    c: 2,
   };
 }
 
@@ -21,7 +21,7 @@ export class DbAPI {
   private config;
 
   constructor(
-    @inject() a,
+  @inject() a,
     hello,
     @inject() b,
   ) {

--- a/packages/midway-core/test/fixtures/complex_injection/userController.ts
+++ b/packages/midway-core/test/fixtures/complex_injection/userController.ts
@@ -1,5 +1,6 @@
-import { UserService } from './userService';
 import { inject, scope, ScopeEnum } from 'injection';
+
+import { UserService } from './userService';
 
 @scope(ScopeEnum.Request)
 export class UserController {
@@ -14,7 +15,7 @@ export class UserController {
   userService: UserService;
 
   async index() {
-    const {ctx} = this;
+    const { ctx } = this;
     ctx.body = await this.userService.getUsers();
     ctx.status = 200;
   }

--- a/packages/midway-core/test/fixtures/complex_injection/userService.ts
+++ b/packages/midway-core/test/fixtures/complex_injection/userService.ts
@@ -4,7 +4,7 @@ import { scope, ScopeEnum } from 'injection';
 export class UserService {
 
   async getUsers() {
-    return new Promise(resolve => {
+    return new Promise((resolve) => {
       setTimeout(() => {
         resolve(['harry', 'jiakun.du']);
       }, 100);

--- a/packages/midway-core/test/fixtures/ts-app-inject/app.ts
+++ b/packages/midway-core/test/fixtures/ts-app-inject/app.ts
@@ -1,4 +1,5 @@
 import { inject, provide } from 'injection';
+
 import { Loader } from './loader';
 
 @provide()

--- a/packages/midway-core/test/fixtures/ts-app-inject/loader.ts
+++ b/packages/midway-core/test/fixtures/ts-app-inject/loader.ts
@@ -1,19 +1,20 @@
-import {provide} from 'injection';
+import { provide } from 'injection';
+
 
 export interface Loader {
-  getConfig();
+  getConfig()
 }
 
 @provide('loader')
 export class BaseLoader implements Loader {
   getConfig() {
-    return {a: 1, b: 2};
+    return { a: 1, b: 2 };
   }
 }
 
 @provide('easyLoader')
 export class EasyLoader extends BaseLoader implements Loader {
   getConfig() {
-    return {a: 3, b: 4};
+    return { a: 3, b: 4 };
   }
 }

--- a/packages/midway-core/test/loader.test.ts
+++ b/packages/midway-core/test/loader.test.ts
@@ -1,8 +1,11 @@
-import { CONFIG_KEY, LOGGER_KEY, PLUGIN_KEY } from '@midwayjs/decorator';
 import * as assert from 'assert';
 import * as path from 'path';
-import { ContainerLoader, MidwayRequestContainer } from '../src';
+
+import { CONFIG_KEY, LOGGER_KEY, PLUGIN_KEY } from '@midwayjs/decorator';
 import { provide } from 'injection';
+
+import { ContainerLoader, MidwayRequestContainer } from '../src';
+
 
 @provide()
 class TestModule {
@@ -15,7 +18,7 @@ describe('/test/loader.test.ts', () => {
 
   it('should create new loader', async () => {
     const loader = new ContainerLoader({
-      baseDir: path.join(__dirname, './fixtures/base-app/src')
+      baseDir: path.join(__dirname, './fixtures/base-app/src'),
     });
     loader.initialize();
     loader.loadDirectory();
@@ -30,7 +33,7 @@ describe('/test/loader.test.ts', () => {
 
   it('should load ts file and use config, plugin decorator', async () => {
     const loader = new ContainerLoader({
-      baseDir: path.join(__dirname, './fixtures/base-app-decorator/src')
+      baseDir: path.join(__dirname, './fixtures/base-app-decorator/src'),
     });
     loader.initialize();
     loader.loadDirectory();
@@ -38,12 +41,12 @@ describe('/test/loader.test.ts', () => {
 
     // register handler for container
     loader.registerHook(CONFIG_KEY, (key, target) => {
-      assert(target instanceof require('./fixtures/base-app-decorator/src/lib/service')['BaseService']);
+      assert(target instanceof require('./fixtures/base-app-decorator/src/lib/service').BaseService);
       return 'hello';
     });
 
     loader.registerHook(PLUGIN_KEY, (key, target) => {
-      return {b: 2};
+      return { b: 2 };
     });
 
     loader.registerHook(LOGGER_KEY, (key, target) => {
@@ -56,7 +59,7 @@ describe('/test/loader.test.ts', () => {
     assert(baseService.logger === console);
     assert(baseService.plugin2.b === 2);
 
-    const context = {logger: console};
+    const context = { logger: console };
     const requestCtx = new MidwayRequestContainer(appCtx, context);
     const baseServiceCtx = await requestCtx.getAsync('baseService');
     const baseServiceCtx1 = await requestCtx.getAsync('baseService');
@@ -68,7 +71,7 @@ describe('/test/loader.test.ts', () => {
 
   it('load ts file support constructor inject', async () => {
     const loader = new ContainerLoader({
-      baseDir: path.join(__dirname, './fixtures/base-app-constructor/src')
+      baseDir: path.join(__dirname, './fixtures/base-app-constructor/src'),
     });
     loader.initialize();
     loader.loadDirectory();
@@ -76,21 +79,22 @@ describe('/test/loader.test.ts', () => {
 
     // register handler for container
     loader.registerHook(CONFIG_KEY, (key) => {
-      return {c: 60};
+      return { c: 60 };
     });
 
     loader.registerHook(PLUGIN_KEY, (key) => {
-      return {text: 2};
+      return { text: 2 };
     });
 
     loader.registerHook(LOGGER_KEY, (key) => {
       return console;
     });
 
-    const context = {logger: console};
+    const context = { logger: console };
     const requestCtx = new MidwayRequestContainer(loader.getApplicationContext(), context);
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
     const module = require(path.join(__dirname, './fixtures/base-app-constructor/src/lib/service'));
-    const baseServiceCtx = await requestCtx.getAsync(module['BaseService']);
+    const baseServiceCtx = await requestCtx.getAsync(module.BaseService);
     assert(baseServiceCtx.config.c === 120);
     assert(baseServiceCtx.plugin2.text === 2);
     assert(baseServiceCtx.logger === console);
@@ -98,7 +102,7 @@ describe('/test/loader.test.ts', () => {
 
   it('should auto load function file and inject by function name', async () => {
     const loader = new ContainerLoader({
-      baseDir: path.join(__dirname, './fixtures/base-app-function/src')
+      baseDir: path.join(__dirname, './fixtures/base-app-function/src'),
     });
     loader.initialize();
     loader.loadDirectory();
@@ -106,18 +110,18 @@ describe('/test/loader.test.ts', () => {
 
     // register handler for container
     loader.registerHook(CONFIG_KEY, (key) => {
-      return {c: 60};
+      return { c: 60 };
     });
 
     loader.registerHook(PLUGIN_KEY, (key) => {
-      return {text: 2};
+      return { text: 2 };
     });
 
     loader.registerHook(LOGGER_KEY, (key) => {
       return console;
     });
 
-    const context = {logger: console};
+    const context = { logger: console };
     const requestCtx = new MidwayRequestContainer(loader.getApplicationContext(), context);
     const baseServiceCtx = await requestCtx.getAsync('baseService');
     assert(baseServiceCtx.factory('google'));
@@ -129,7 +133,7 @@ describe('/test/loader.test.ts', () => {
       isTsMode: false,
     });
     loader.initialize();
-    loader.loadDirectory({disableAutoLoad: false});
+    loader.loadDirectory({ disableAutoLoad: false });
     await loader.refresh();
     const appCtx = loader.getApplicationContext();
     assert(await appCtx.getAsync('app'));
@@ -146,7 +150,8 @@ describe('/test/loader.test.ts', () => {
     const appCtx = loader.getApplicationContext();
     try {
       await appCtx.getAsync('app');
-    } catch (err) {
+    }
+    catch (err) {
       assert(err);
     }
   });
@@ -154,9 +159,7 @@ describe('/test/loader.test.ts', () => {
   it('should load preload module', async () => {
     const loader = new ContainerLoader({
       baseDir: path.join(__dirname, './fixtures/base-app/src'),
-      preloadModules: [
-        TestModule
-      ]
+      preloadModules: [TestModule],
     });
     loader.initialize();
     loader.loadDirectory();

--- a/packages/midway-core/test/midwayContainer.test.ts
+++ b/packages/midway-core/test/midwayContainer.test.ts
@@ -1,19 +1,21 @@
+import * as path from 'path';
+
 import { expect } from 'chai';
 
-import * as path from 'path';
 import { MidwayContainer, MidwayHandlerKey } from '../src';
-import { App } from './fixtures/ts-app-inject/app';
 
+import { App } from './fixtures/ts-app-inject/app';
 import { UserService } from './fixtures/complex_injection/userService';
 import { UserController } from './fixtures/complex_injection/userController';
 import { A, B, DbAPI } from './fixtures/complex_injection/dbAPI';
+
 
 describe('/test/midwayContainer.test.ts', () => {
 
   it('should scan app dir and inject automatic', () => {
     const container = new MidwayContainer();
     container.load({
-      loadDir: path.join(__dirname, './fixtures/ts-app-inject')
+      loadDir: path.join(__dirname, './fixtures/ts-app-inject'),
     });
 
     const app = container.get('app') as App;
@@ -26,7 +28,7 @@ describe('/test/midwayContainer.test.ts', () => {
   it('should load js dir and inject with $', () => {
     const container = new MidwayContainer(undefined, undefined, false);
     container.load({
-      loadDir: path.join(__dirname, './fixtures/js-app-inject')
+      loadDir: path.join(__dirname, './fixtures/js-app-inject'),
     });
 
     const app = container.get('app') as App;
@@ -37,17 +39,18 @@ describe('/test/midwayContainer.test.ts', () => {
     const container = new MidwayContainer(path.join(__dirname, './fixtures/js-app-xml'), undefined, false);
     container.configLocations = ['resources/main.xml'];
 
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
     container.props.putObject(require('./fixtures/js-app-xml/config/config.default'));
 
-    container.registerDataHandler(MidwayHandlerKey.CONFIG, key => {
+    container.registerDataHandler(MidwayHandlerKey.CONFIG, (key) => {
       return container.props.get(key);
     });
-    container.registerDataHandler(MidwayHandlerKey.PLUGIN, key => {
+    container.registerDataHandler(MidwayHandlerKey.PLUGIN, (key) => {
       return {
-        text: 't'
+        text: 't',
       };
     });
-    container.registerDataHandler(MidwayHandlerKey.LOGGER, key => {
+    container.registerDataHandler(MidwayHandlerKey.LOGGER, (key) => {
       return console;
     });
 
@@ -57,7 +60,7 @@ describe('/test/midwayContainer.test.ts', () => {
     expect(my).not.null;
     expect(my.$$mytest).not.null;
     expect(my.$$mytest).eq('this is my test');
-    expect(my.$plugin2).deep.eq({text: 't'});
+    expect(my.$plugin2).deep.eq({ text: 't' });
   });
 
   describe('dependency tree', () => {

--- a/packages/midway-core/tsconfig.eslint.json
+++ b/packages/midway-core/tsconfig.eslint.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts",
+    "test_browser/**/*.ts"
+  ],
+  "exclude": [
+    "asset",
+    "app/public",
+    "app/views",
+    "dist",
+    "node_modules*",
+    "**/*.d.ts",
+    "**/*.spec.ts"
+  ]
+}

--- a/packages/midway-decorator/package.json
+++ b/packages/midway-decorator/package.json
@@ -6,8 +6,9 @@
   "typings": "dist/index.d.ts",
   "scripts": {
     "build": "midway-bin build -c",
-    "lint": "../../node_modules/.bin/tslint --format prose -c ../../tslint.json --fix 'src/**/*.ts' 'test/**/*.ts'",
-    "test": "npm run lint && midway-bin clean && NODE_ENV=test midway-bin test --ts",
+    "lint": "eslint --fix --cache {src,test}/**/*.ts",
+    "lint:nofix": "eslint --cache {src,test}/**/*.ts",
+    "test": "npm run lint:nofix && midway-bin clean && cross-env NODE_ENV=test midway-bin test --ts",
     "cov": "midway-bin cov --ts",
     "ci": "npm run test",
     "autod": "midway-bin autod"
@@ -16,6 +17,7 @@
     "injection": "^1.8.0"
   },
   "devDependencies": {
+    "cross-env": "7",
     "midway-bin": "^1.17.1"
   },
   "keywords": [

--- a/packages/midway-decorator/package.json
+++ b/packages/midway-decorator/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index",
   "typings": "dist/index.d.ts",
   "scripts": {
-    "build": "npm run lint && midway-bin build -c",
+    "build": "midway-bin build -c",
     "lint": "../../node_modules/.bin/tslint --format prose -c ../../tslint.json --fix 'src/**/*.ts' 'test/**/*.ts'",
     "test": "npm run lint && midway-bin clean && NODE_ENV=test midway-bin test --ts",
     "cov": "midway-bin cov --ts",

--- a/packages/midway-decorator/src/common/priority.ts
+++ b/packages/midway-decorator/src/common/priority.ts
@@ -1,8 +1,11 @@
 import { saveClassMetadata } from 'injection';
+
 import { PRIORITY_KEY } from '../constant';
 
-export function priority(priority: number): ClassDecorator {
+
+export function priority(input: number): ClassDecorator {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return (target: any) => {
-    saveClassMetadata(PRIORITY_KEY, priority, target);
+    saveClassMetadata(PRIORITY_KEY, input, target);
   };
 }

--- a/packages/midway-decorator/src/common/schedule.ts
+++ b/packages/midway-decorator/src/common/schedule.ts
@@ -1,29 +1,32 @@
 import { saveClassMetadata, saveModule, scope, ScopeEnum } from 'injection';
+
 import { SCHEDULE_KEY } from '../constant';
 
+
 export interface CommonSchedule {
-  exec(ctx?);
+  exec(ctx?)
 }
 
 export interface ScheduleOpts {
-  type: string;
-  cron?: string;
-  interval?: number | string;
-  immediate?: boolean;
-  disable?: boolean;
-  env?: [string];
+  type: string
+  cron?: string
+  interval?: number | string
+  immediate?: boolean
+  disable?: boolean
+  env?: [string]
   cronOptions?: {
-    currentDate?: string | number | Date
-    startDate?: string | number | Date
-    endDate?: string | number | Date
-    iterator?: boolean
-    utc?: boolean
-    tz?: string
-  };
+    currentDate?: string | number | Date;
+    startDate?: string | number | Date;
+    endDate?: string | number | Date;
+    iterator?: boolean;
+    utc?: boolean;
+    tz?: string;
+  }
 }
 
 export function schedule(scheduleOpts: ScheduleOpts | string) {
-  return function (target: any): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return function(target: any): void {
     saveModule(SCHEDULE_KEY, target);
     saveClassMetadata(SCHEDULE_KEY, scheduleOpts, target);
     scope(ScopeEnum.Request)(target);

--- a/packages/midway-decorator/src/faas/fun.ts
+++ b/packages/midway-decorator/src/faas/fun.ts
@@ -1,7 +1,10 @@
 import { saveClassMetadata, saveModule, scope, ScopeEnum } from 'injection';
+
 import { FUNC_KEY } from '../constant';
 
+
 export function func(funHandler: string): ClassDecorator {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return (target: any) => {
     // 保存到扫描列表
     saveModule(FUNC_KEY, target);

--- a/packages/midway-decorator/src/faas/handler.ts
+++ b/packages/midway-decorator/src/faas/handler.ts
@@ -1,5 +1,7 @@
 import { savePropertyDataToClass } from 'injection';
+
 import { HANDLER_KEY } from '../constant';
+
 
 export function handler(handlerMapping: string): MethodDecorator {
   return (target: object, propertykey: string, descriptor: PropertyDescriptor) => {

--- a/packages/midway-decorator/src/framework/config.ts
+++ b/packages/midway-decorator/src/framework/config.ts
@@ -1,18 +1,24 @@
 import { attachClassMetadata } from 'injection';
+
 import { CONFIG_KEY } from '../constant';
 import { attachConstructorDataOnClass } from '../utils';
 
+
 export function config(identifier?: string) {
-  return function (target: any, targetKey: string, index?: number): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return function(target: any, targetKey: string, index?: number): void {
     if (typeof index === 'number') {
       attachConstructorDataOnClass(identifier, target, CONFIG_KEY, index);
-    } else {
-      if (!identifier) {
-        identifier = targetKey;
+    }
+    else {
+      let idf = identifier;
+
+      if (! idf) {
+        idf = targetKey;
       }
       attachClassMetadata(CONFIG_KEY, {
-        key: identifier,
-        propertyName: targetKey
+        key: idf,
+        propertyName: targetKey,
       }, target);
     }
   };

--- a/packages/midway-decorator/src/framework/logger.ts
+++ b/packages/midway-decorator/src/framework/logger.ts
@@ -1,18 +1,24 @@
 import { attachClassMetadata } from 'injection';
+
 import { LOGGER_KEY } from '../constant';
 import { attachConstructorDataOnClass } from '../utils';
 
+
 export function logger(identifier?: string) {
-  return function (target: any, targetKey: string, index?: number): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return function(target: any, targetKey: string, index?: number): void {
     if (typeof index === 'number') {
       attachConstructorDataOnClass(identifier, target, LOGGER_KEY, index);
-    } else {
-      if (!identifier) {
-        identifier = targetKey;
+    }
+    else {
+      let id = identifier;
+
+      if (! id) {
+        id = targetKey;
       }
       attachClassMetadata(LOGGER_KEY, {
-        key: identifier,
-        propertyName: targetKey
+        key: id,
+        propertyName: targetKey,
       }, target);
     }
   };

--- a/packages/midway-decorator/src/framework/plugin.ts
+++ b/packages/midway-decorator/src/framework/plugin.ts
@@ -1,18 +1,24 @@
 import { attachClassMetadata } from 'injection';
+
 import { PLUGIN_KEY } from '../constant';
 import { attachConstructorDataOnClass } from '../utils';
 
+
 export function plugin(identifier?: string) {
-  return function (target: any, targetKey: string, index?: number): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return function(target: any, targetKey: string, index?: number): void {
     if (typeof index === 'number') {
       attachConstructorDataOnClass(identifier, target, PLUGIN_KEY, index);
-    } else {
-      if (!identifier) {
-        identifier = targetKey;
+    }
+    else {
+      let id = identifier;
+
+      if (! id) {
+        id = targetKey;
       }
       attachClassMetadata(PLUGIN_KEY, {
-        key: identifier,
-        propertyName: targetKey
+        key: id,
+        propertyName: targetKey,
       }, target);
     }
   };

--- a/packages/midway-decorator/src/interface.ts
+++ b/packages/midway-decorator/src/interface.ts
@@ -1,2 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 export type KoaMiddleware <T = any> = (context: T, next: () => Promise<any>) => void;
-export type KoaMiddlewareParamArray <T = any> = Array<string | KoaMiddleware<T>>;
+export type KoaMiddlewareParamArray <T = any> = (string | KoaMiddleware<T>)[];
+

--- a/packages/midway-decorator/src/utils.ts
+++ b/packages/midway-decorator/src/utils.ts
@@ -1,23 +1,26 @@
 import { getParamNames, getClassMetadata, saveClassMetadata } from 'injection';
+
 import { CLASS_KEY_CONSTRUCTOR } from './constant';
 
-export function attachConstructorDataOnClass(identifier, clz, type, index) {
 
-  if (!identifier) {
+export function attachConstructorDataOnClass(identifier, clz, type, index) {
+  let id = identifier;
+
+  if (! id) {
     const args = getParamNames(clz);
     if (clz.length === args.length && index < clz.length) {
-      identifier = args[index];
+      id = args[index];
     }
   }
 
   // save constructor index on class
   let constructorMetaValue = getClassMetadata(CLASS_KEY_CONSTRUCTOR, clz);
-  if (!constructorMetaValue) {
+  if (! constructorMetaValue) {
     constructorMetaValue = {};
   }
   constructorMetaValue[index] = {
-    key: identifier,
-    type
+    key: id,
+    type,
   };
   saveClassMetadata(CLASS_KEY_CONSTRUCTOR, constructorMetaValue, clz);
 }

--- a/packages/midway-decorator/src/web/controller.ts
+++ b/packages/midway-decorator/src/web/controller.ts
@@ -1,25 +1,27 @@
 import { saveClassMetadata, saveModule, scope, ScopeEnum } from 'injection';
+
 import { CONTROLLER_KEY } from '../constant';
 import { KoaMiddlewareParamArray } from '../interface';
 
+
 export interface ControllerOption {
-  prefix: string;
+  prefix: string
   routerOptions: {
     sensitive?: boolean;
-    middleware?: KoaMiddlewareParamArray
-  };
+    middleware?: KoaMiddlewareParamArray;
+  }
 }
 
 export function controller(prefix: string, routerOptions: {
-  sensitive?: boolean,
-  middleware?: KoaMiddlewareParamArray
- } = {middleware: [], sensitive: true}
-  ): ClassDecorator {
+  sensitive?: boolean;
+  middleware?: KoaMiddlewareParamArray;
+} = { middleware: [], sensitive: true }): ClassDecorator {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return (target: any) => {
     saveModule(CONTROLLER_KEY, target);
     saveClassMetadata(CONTROLLER_KEY, {
       prefix,
-      routerOptions
+      routerOptions,
     } as ControllerOption, target);
     scope(ScopeEnum.Request)(target);
   };

--- a/packages/midway-decorator/src/web/paramMapping.ts
+++ b/packages/midway-decorator/src/web/paramMapping.ts
@@ -1,9 +1,12 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { attachPropertyDataToClass } from 'injection';
+
 import { WEB_ROUTER_PARAM_KEY } from '../constant';
 
+
 interface GetFileStreamOptions {
-  requireFile?: boolean; // required file submit, default is true
-  defCharset?: string;
+  requireFile?: boolean // required file submit, default is true
+  defCharset?: string
   limits?: {
     fieldNameSize?: number;
     fieldSize?: number;
@@ -12,18 +15,18 @@ interface GetFileStreamOptions {
     files?: number;
     parts?: number;
     headerPairs?: number;
-  };
+  }
   checkFile?(
     fieldname: string,
     file: any,
     filename: string,
     encoding: string,
     mimetype: string
-  ): void | Error;
+  ): void | Error
 }
 
 interface GetFilesStreamOptions extends GetFileStreamOptions {
-  autoFields?: boolean;
+  autoFields?: boolean
 }
 
 export enum RouteParamTypes {
@@ -38,14 +41,14 @@ export enum RouteParamTypes {
 }
 
 export interface RouterParamValue {
-  index?: number;
-  type?: RouteParamTypes;
-  data?: any;
-  extractValue?: (ctx, next) => Promise<any>;
+  index?: number
+  type?: RouteParamTypes
+  data?: any
+  extractValue?: (ctx, next) => Promise<any>
 }
 
 export const extractValue = function extractValue(key, data) {
-  return async function (ctx, next) {
+  return async function(ctx, next) {
     switch (key) {
       case RouteParamTypes.NEXT:
         return next;
@@ -69,13 +72,13 @@ export const extractValue = function extractValue(key, data) {
   };
 };
 
-const createParamMapping = function (type: RouteParamTypes) {
+const createParamMapping = function(type: RouteParamTypes) {
   return (data?: any) => (target, key, index) => {
     attachPropertyDataToClass(WEB_ROUTER_PARAM_KEY, {
       index,
       type,
       data,
-      extractValue: extractValue(type, data)
+      extractValue: extractValue(type, data),
     }, target, key);
   };
 };

--- a/packages/midway-decorator/src/web/requestMapping.ts
+++ b/packages/midway-decorator/src/web/requestMapping.ts
@@ -2,15 +2,17 @@
  * 'HEAD', 'OPTIONS', 'GET', 'PUT', 'PATCH', 'POST', 'DELETE' 封装
  */
 import { attachClassMetadata } from 'injection';
+
 import { WEB_ROUTER_KEY } from '../constant';
 import { KoaMiddlewareParamArray } from '../interface';
 
+
 export interface RouterOption {
-  path?: string;
-  requestMethod: string;
-  routerName?: string;
-  method: string;
-  middleware?: KoaMiddlewareParamArray;
+  path?: string
+  requestMethod: string
+  routerName?: string
+  method: string
+  middleware?: KoaMiddlewareParamArray
 }
 
 export const RequestMethod = {
@@ -33,14 +35,14 @@ const defaultMetadata = {
   [PATH_METADATA]: '/',
   [METHOD_METADATA]: RequestMethod.GET,
   [ROUTER_NAME_METADATA]: null,
-  [ROUTER_MIDDLEWARE]: []
+  [ROUTER_MIDDLEWARE]: [],
 };
 
 export interface RequestMappingMetadata {
-  [PATH_METADATA]?: string;
-  [METHOD_METADATA]: string;
-  [ROUTER_NAME_METADATA]?: string;
-  [ROUTER_MIDDLEWARE]?: KoaMiddlewareParamArray;
+  [PATH_METADATA]?: string
+  [METHOD_METADATA]: string
+  [ROUTER_NAME_METADATA]?: string
+  [ROUTER_MIDDLEWARE]?: KoaMiddlewareParamArray
 }
 
 export const RequestMapping = (
@@ -57,7 +59,7 @@ export const RequestMapping = (
       requestMethod,
       routerName,
       method: key,
-      middleware
+      middleware,
     } as RouterOption, target);
 
     return descriptor;
@@ -69,7 +71,7 @@ const createMappingDecorator = (method: string) => (
   routerOptions: {
     routerName?: string;
     middleware?: KoaMiddlewareParamArray;
-  } = {middleware: []}
+  } = { middleware: [] },
 ): MethodDecorator => {
   return RequestMapping({
     [PATH_METADATA]: path,

--- a/packages/midway-decorator/tsconfig.eslint.json
+++ b/packages/midway-decorator/tsconfig.eslint.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts",
+    "test_browser/**/*.ts"
+  ],
+  "exclude": [
+    "asset",
+    "app/public",
+    "app/views",
+    "dist",
+    "node_modules*",
+    "**/*.d.ts",
+    "**/*.spec.ts"
+  ]
+}

--- a/packages/midway-definition/package.json
+++ b/packages/midway-definition/package.json
@@ -4,7 +4,7 @@
   "description": "declare all midway dependencies by typescript definition",
   "typings": "dist/index.d.ts",
   "scripts": {
-    "build": "npm run lint && midway-bin build -c",
+    "build": "midway-bin build -c",
     "lint": "../../node_modules/.bin/tslint --format prose -c ../../tslint.json --fix 'src/**/*.ts' 'test/**/*.ts'",
     "test": "npm run lint && midway-bin clean && NODE_ENV=test midway-bin test --ts",
     "cov": "midway-bin cov --ts",

--- a/packages/midway-definition/package.json
+++ b/packages/midway-definition/package.json
@@ -7,7 +7,7 @@
     "build": "midway-bin build -c",
     "lint": "eslint --fix --cache typings/**/*.ts",
     "lint:nofix": "eslint --cache typings/**/*.ts",
-    "test": "npm run lint:nofix && midway-bin clean && NODE_ENV=test midway-bin test --ts",
+    "test": "npm run lint:nofix && midway-bin clean && cross-env NODE_ENV=test midway-bin test --ts",
     "cov": "midway-bin cov --ts",
     "ci": "npm run test",
     "autod": "midway-bin autod"
@@ -17,6 +17,7 @@
     "egg-logger": "^2.3.2"
   },
   "devDependencies": {
+    "cross-env": "7",
     "midway-bin": "^1.17.1"
   },
   "keywords": [

--- a/packages/midway-definition/package.json
+++ b/packages/midway-definition/package.json
@@ -5,8 +5,9 @@
   "typings": "dist/index.d.ts",
   "scripts": {
     "build": "midway-bin build -c",
-    "lint": "../../node_modules/.bin/tslint --format prose -c ../../tslint.json --fix 'src/**/*.ts' 'test/**/*.ts'",
-    "test": "npm run lint && midway-bin clean && NODE_ENV=test midway-bin test --ts",
+    "lint": "eslint --fix --cache typings/**/*.ts",
+    "lint:nofix": "eslint --cache typings/**/*.ts",
+    "test": "npm run lint:nofix && midway-bin clean && NODE_ENV=test midway-bin test --ts",
     "cov": "midway-bin cov --ts",
     "ci": "npm run test",
     "autod": "midway-bin autod"

--- a/packages/midway-definition/tsconfig.eslint.json
+++ b/packages/midway-definition/tsconfig.eslint.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts",
+    "test_browser/**/*.ts",
+    "typings/**/*.ts"
+  ],
+  "exclude": [
+    "asset",
+    "app/public",
+    "app/views",
+    "dist",
+    "node_modules*",
+    "**/*.spec.ts"
+  ]
+}

--- a/packages/midway-definition/typings/egg/index.d.ts
+++ b/packages/midway-definition/typings/egg/index.d.ts
@@ -1,5 +1,8 @@
+/* eslint-disable @typescript-eslint/interface-name-prefix */
+/* eslint-disable @typescript-eslint/no-empty-interface */
 import * as egg from 'egg';
 import * as eggLogger from 'egg-logger';
+
 
 export declare namespace Egg {
   export interface Context extends egg.Context {}

--- a/packages/midway-init/.eslintrc
+++ b/packages/midway-init/.eslintrc
@@ -1,8 +1,0 @@
-{
-  "extends": "eslint-config-egg",
-  "rules": {
-    "no-console": "off",
-    "no-else-return": "off",
-    "no-empty-function": "off"
-  }
-}

--- a/packages/midway-init/bin/midway-init.js
+++ b/packages/midway-init/bin/midway-init.js
@@ -1,10 +1,17 @@
 #!/usr/bin/env node
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable brace-style */
+/* eslint-disable @typescript-eslint/brace-style */
+/* eslint-disable indent */
+/* eslint-disable @typescript-eslint/indent */
 
-'use strict';
 
 const childProcess = require('child_process');
+
 const { Confirm } = require('enquirer');
+
 const Command = require('..');
+
 
 (async () => {
   const args = process.argv.slice(2);
@@ -18,7 +25,7 @@ const Command = require('..');
     });
     const isContinue = await prompt.run();
 
-    if (!isContinue) {
+    if (! isContinue) {
       return;
     }
   }
@@ -26,7 +33,8 @@ const Command = require('..');
   try {
     const cmd = new Command();
     await cmd.run(process.cwd(), args);
-  } catch (err) {
+  }
+  catch (err) {
     console.error(err.stack);
     process.exit(1);
   }
@@ -35,7 +43,7 @@ const Command = require('..');
 // 判断是否处于内网环境
 function isInternal() {
   try {
-    const { stdout } = childProcess.spawnSync('tnpm', [ 'view', '@ali/midway-init', '--json' ], {
+    const { stdout } = childProcess.spawnSync('tnpm', ['view', '@ali/midway-init', '--json'], {
       timeout: 3000,
     });
 
@@ -43,10 +51,12 @@ function isInternal() {
 
     if (npmData.name === '@ali/midway-init') {
       return true;
-    } else {
+    }
+    else {
       return false;
     }
-  } catch (err) {
+  }
+  catch (err) {
     return false;
   }
 }

--- a/packages/midway-init/lib/command.js
+++ b/packages/midway-init/lib/command.js
@@ -1,16 +1,20 @@
-'use strict';
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable brace-style */
 
 const path = require('path');
-const { LightGenerator } = require('light-generator');
-const { Input, Select, Form } = require('enquirer');
-const chalk = require('chalk');
-const { getParser } = require('./parser');
 const { EventEmitter } = require('events');
 const fs = require('fs');
 const os = require('os');
 
+const { LightGenerator } = require('light-generator');
+const { Input, Select, Form } = require('enquirer');
+const chalk = require('chalk');
+
+const { getParser } = require('./parser');
+
+
 async function sleep(timeout) {
-  return new Promise(resolve => {
+  return new Promise((resolve) => {
     setTimeout(() => {
       resolve();
     }, timeout);
@@ -42,10 +46,13 @@ class MidwayInitCommand extends EventEmitter {
     return this._innerPrompt;
   }
 
-  async beforePromptSubmit() {}
+  async beforePromptSubmit() {
+    return;
+  }
 
   async run(cwd, args) {
-    const argv = (this.argv = getParser().parse(args || []));
+    const argv = getParser().parse(args || []);
+    this.argv = argv;
     this.cwd = cwd;
 
     this.templateList = await this.getTemplateList();
@@ -63,7 +70,8 @@ class MidwayInitCommand extends EventEmitter {
       // support --type argument
       this.templateName = argv.type;
       await this.createFromTemplate();
-    } else if (argv.template) {
+    }
+    else if (argv.template) {
       // support --template argument
       // ready targetDir
       await this.createTargetDir();
@@ -73,24 +81,26 @@ class MidwayInitCommand extends EventEmitter {
         targetPath: this.targetPath,
       });
       await this.execBoilerplate(generator);
-    } else if (argv.package) {
+    }
+    else if (argv.package) {
       // support --package argument
       await this.createFromTemplate(argv.package);
-    } else {
+    }
+    else {
       this.prompt = new Select({
         name: 'templateName',
         message: 'Hello, traveller.\n  Which template do you like?',
-        choices: Object.keys(this.templateList).map(template => {
+        choices: Object.keys(this.templateList).map((template) => {
           return (
             `${template} - ${this.templateList[template].description}` +
             (this.templateList[template].author
               ? `(by @${chalk.underline.bold(
-                this.templateList[template].author
+                this.templateList[template].author,
               )})`
               : '')
           );
         }),
-        result: value => {
+        result: (value) => {
           return value.split(' - ')[0];
         },
         show: this.showPrompt,
@@ -117,7 +127,7 @@ class MidwayInitCommand extends EventEmitter {
   }
 
   async getTemplateList() {
-    if (!this.templateName) {
+    if (! this.templateName) {
       return require(defaultOptions.templateListPath);
     }
   }
@@ -136,7 +146,7 @@ class MidwayInitCommand extends EventEmitter {
     }
     await sleep(1000);
     this.log(
-      'Initialization program has been executed successfully,enjoy it...'
+      'Initialization program has been executed successfully,enjoy it...',
     );
     console.log();
   }
@@ -146,7 +156,7 @@ class MidwayInitCommand extends EventEmitter {
   }
 
   async createTargetDir() {
-    if (!this.targetPath) {
+    if (! this.targetPath) {
       this.prompt = new Input({
         message: 'The directory where the boilerplate should be created',
         initial: 'my_midway_app',
@@ -166,7 +176,7 @@ class MidwayInitCommand extends EventEmitter {
       this.prompt = new Form({
         name: 'user',
         message: 'Please provide the following information:',
-        choices: argsKeys.map(argsKey => {
+        choices: argsKeys.map((argsKey) => {
           return {
             name: `${argsKey}`,
             message: `${args[argsKey].desc}`,
@@ -179,12 +189,13 @@ class MidwayInitCommand extends EventEmitter {
       const parameters = await this.prompt.run();
       // remove undefined property
       Object.keys(parameters).forEach(
-        key => parameters[key] === undefined && delete parameters[key]
+        key => parameters[key] === undefined && delete parameters[key],
       );
       await this.readyGenerate(async () => {
         await generator.run(parameters);
       });
-    } else {
+    }
+    else {
       await this.readyGenerate(async () => {
         await generator.run();
       });
@@ -192,7 +203,7 @@ class MidwayInitCommand extends EventEmitter {
   }
 
   getAbsoluteDir(dir) {
-    if (!path.isAbsolute(dir)) {
+    if (! path.isAbsolute(dir)) {
       dir = path.join(process.cwd(), dir);
     }
     return dir;
@@ -202,8 +213,10 @@ class MidwayInitCommand extends EventEmitter {
    * log with prefix
    */
   log() {
+    // eslint-disable-next-line prefer-rest-params
     const args = Array.prototype.slice.call(arguments);
     args[0] = chalk.green('✔ ') + chalk.bold(args[0]);
+    // eslint-disable-next-line prefer-spread
     console.log.apply(console, args);
   }
 
@@ -230,7 +243,8 @@ class MidwayInitCommand extends EventEmitter {
       default: {
         if (/^https?:/.test(key)) {
           return key.replace(/\/$/, '');
-        } else {
+        }
+        else {
           // support .npmrc
           const home = os.homedir();
           let url =

--- a/packages/midway-init/lib/parser.js
+++ b/packages/midway-init/lib/parser.js
@@ -1,6 +1,7 @@
-'use strict';
+/* eslint-disable @typescript-eslint/no-var-requires */
 
 const yargs = require('yargs');
+
 
 const getParserOptions = () => {
   return {

--- a/packages/midway-init/package.json
+++ b/packages/midway-init/package.json
@@ -9,8 +9,8 @@
   },
   "main": "lib/command.js",
   "devDependencies": {
-    "eslint": "^6.1.0",
-    "eslint-config-egg": "^7.0.0",
+    "eslint": "6",
+    "eslint-config-egg": "7",
     "midway-bin": "^1.17.1",
     "mz-modules": "^2.1.0",
     "power-assert": "^1.6.1"
@@ -29,11 +29,11 @@
     "boilerplate.json"
   ],
   "scripts": {
-    "lint": "eslint bin lib test",
-    "lint-fix": "npm run lint -- --fix",
-    "test": "npm run lint && midway-bin test",
+    "lint": "eslint --fix --cache {bin,lib,test}/**/*.js",
+    "lint:nofix": "eslint --cache {bin,lib,test}/**/*.js",
+    "test": "npm run lint:nofix && midway-bin test",
     "cov": "midway-bin cov",
-    "ci": "npm run lint && midway-bin cov",
+    "ci": "npm run lint:nofix && midway-bin cov",
     "autod": "midway-bin autod"
   },
   "engines": {

--- a/packages/midway-init/test/fixtures/simple-test/boilerplate/config/config.default.js
+++ b/packages/midway-init/test/fixtures/simple-test/boilerplate/config/config.default.js
@@ -1,3 +1,3 @@
-'use strict';
+
 
 exports.project = '{{name}}';

--- a/packages/midway-init/test/fixtures/simple-test/index.js
+++ b/packages/midway-init/test/fixtures/simple-test/index.js
@@ -1,4 +1,3 @@
-'use strict';
 
 module.exports = {
   name: {

--- a/packages/midway-init/test/helper.js
+++ b/packages/midway-init/test/helper.js
@@ -1,6 +1,7 @@
-'use strict';
-
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable brace-style */
 const Command = require('../lib/command');
+
 
 class TestCommand extends Command {
 
@@ -19,13 +20,16 @@ class TestCommand extends Command {
       if (value) {
         for (const flag of value) {
           if (Array.isArray(flag)) {
+            // eslint-disable-next-line prefer-spread
             await this.prompt.keypress.apply(this.prompt, flag);
-          } else if (typeof flag === 'string') {
+          }
+          else if (typeof flag === 'string') {
             try {
               for (const key of flag.split('')) {
                 await this.prompt.keypress(key);
               }
-            } catch (err) {
+            }
+            catch (err) {
               console.error(err);
             }
           }

--- a/packages/midway-init/test/init.test.js
+++ b/packages/midway-init/test/init.test.js
@@ -1,12 +1,17 @@
-'use strict';
+/* eslint-disable @typescript-eslint/no-var-requires */
 
 const fs = require('fs');
 const path = require('path');
-const rimraf = require('mz-modules/rimraf');
 const assert = require('assert');
-const { TestCommand } = require('./helper');
-const tmp = path.join(__dirname, '../.tmp');
+
 const { LightGenerator } = require('light-generator');
+const rimraf = require('mz-modules/rimraf');
+
+const { TestCommand } = require('./helper');
+
+
+const tmp = path.join(__dirname, '../.tmp');
+
 
 describe('test/init.test.js', () => {
   beforeEach(() => rimraf(tmp));
@@ -16,11 +21,11 @@ describe('test/init.test.js', () => {
     const targetDir = path.join(tmp, 'test');
     const command = new TestCommand();
     command.mockPrompt([
-      [ null, { name: 'return' }],
+      [null, { name: 'return' } ],
       targetDir,
       [
         'my_project',
-        [ null, { name: 'down' }],
+        [null, { name: 'down' } ],
         'test',
       ],
     ]);
@@ -37,11 +42,11 @@ describe('test/init.test.js', () => {
     const targetDir = path.join(tmp, 'test');
     const command = new TestCommand();
     command.mockPrompt([
-      [ null, { name: 'return' }],
+      [null, { name: 'return' } ],
       '.tmp/test',
       [
         'my_project',
-        [ null, { name: 'down' }],
+        [null, { name: 'down' } ],
         'test',
       ],
     ]);
@@ -61,7 +66,7 @@ describe('test/init.test.js', () => {
       '.tmp/test',
       [
         'my_project',
-        [ null, { name: 'down' }],
+        [null, { name: 'down' } ],
         'test',
       ],
     ]);
@@ -80,7 +85,7 @@ describe('test/init.test.js', () => {
     command.mockPrompt([
       [
         'my_project',
-        [ null, { name: 'down' }],
+        [null, { name: 'down' } ],
         'test',
       ],
     ]);
@@ -99,7 +104,7 @@ describe('test/init.test.js', () => {
     command.mockPrompt([
       [
         'my_project',
-        [ null, { name: 'down' }],
+        [null, { name: 'down' } ],
         'test',
       ],
     ]);
@@ -115,7 +120,7 @@ describe('test/init.test.js', () => {
     command.mockPrompt([
       [
         'my_project',
-        [ null, { name: 'down' }],
+        [null, { name: 'down' } ],
         'test',
       ],
     ]);
@@ -135,7 +140,7 @@ describe('test/init.test.js', () => {
     command.mockPrompt([
       [
         'my_project',
-        [ null, { name: 'down' }],
+        [null, { name: 'down' } ],
         'test',
       ],
     ]);
@@ -152,7 +157,7 @@ describe('test/init.test.js', () => {
     command.mockPrompt([
       [
         'my_project',
-        [ null, { name: 'down' }],
+        [null, { name: 'down' } ],
         'test',
       ],
     ]);
@@ -169,7 +174,7 @@ describe('test/init.test.js', () => {
     command.mockPrompt([
       [
         'my_project',
-        [ null, { name: 'down' }],
+        [null, { name: 'down' } ],
         'test',
       ],
     ]);
@@ -186,7 +191,7 @@ describe('test/init.test.js', () => {
     command.mockPrompt([
       [
         'my_project',
-        [ null, { name: 'down' }],
+        [null, { name: 'down' } ],
         'test',
       ],
     ]);

--- a/packages/midway-init/tsconfig.eslint.json
+++ b/packages/midway-init/tsconfig.eslint.json
@@ -1,0 +1,20 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts",
+    "test_browser/**/*.ts",
+    "bin/**/*.js",
+    "lib/**/*.js",
+    "test/**/*.js"
+  ],
+  "exclude": [
+    "asset",
+    "app/public",
+    "app/views",
+    "dist",
+    "node_modules*",
+    "**/*.d.ts",
+    "**/*.spec.ts"
+  ]
+}

--- a/packages/midway-init/tsconfig.json
+++ b/packages/midway-init/tsconfig.json
@@ -1,0 +1,34 @@
+{
+  "compilerOptions": {
+    "declaration": false,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "incremental": true,
+    "module": "commonjs",
+    "newLine": "lf",
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "outDir": "dist",
+    "pretty": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "target": "ES2019",
+    "tsBuildInfoFile": ".vscode/.tsbuildinfo",
+    "types" : ["node", "mocha"]
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "asset",
+    "app/public",
+    "app/views",
+    "dist",
+    "node_modules*",
+    "test",
+    "**/*.d.ts",
+    "**/*.spec.ts"
+  ]
+}

--- a/packages/midway-mock/package.json
+++ b/packages/midway-mock/package.json
@@ -8,7 +8,7 @@
   "main": "dist/index",
   "typings": "dist/index.d.ts",
   "scripts": {
-    "build": "npm run lint && midway-bin build -c",
+    "build": "midway-bin build -c",
     "lint": "../../node_modules/.bin/tslint --format prose -c ../../tslint.json --fix 'src/**/*.ts'",
     "devtest": "midway-bin test --ts",
     "test": "npm run lint && midway-bin clean && midway-bin test --ts",

--- a/packages/midway-mock/package.json
+++ b/packages/midway-mock/package.json
@@ -9,9 +9,10 @@
   "typings": "dist/index.d.ts",
   "scripts": {
     "build": "midway-bin build -c",
-    "lint": "../../node_modules/.bin/tslint --format prose -c ../../tslint.json --fix 'src/**/*.ts'",
+    "lint": "eslint --fix --cache {src,test}/**/*.ts",
+    "lint:nofix": "eslint --cache {src,test}/**/*.ts",
     "devtest": "midway-bin test --ts",
-    "test": "npm run lint && midway-bin clean && midway-bin test --ts",
+    "test": "npm run lint:nofix && midway-bin clean && midway-bin test --ts",
     "cov": "midway-bin cov --ts",
     "ci": "midway-bin test",
     "autod": "midway-bin autod"
@@ -34,6 +35,7 @@
   "license": "MIT",
   "devDependencies": {
     "@midwayjs/decorator": "^1.17.1",
+    "egg": "^2.26.0",
     "injection": "^1.8.0",
     "midway-bin": "^1.17.1"
   },

--- a/packages/midway-mock/src/app/extend/application.ts
+++ b/packages/midway-mock/src/app/extend/application.ts
@@ -1,12 +1,14 @@
 import { MockApplication } from 'egg-mock';
 import { ApplicationContext } from 'injection';
 
+
 interface Application extends MockApplication {
-  applicationContext: ApplicationContext;
+  applicationContext: ApplicationContext
   _mockFn(
     service: string,
     methodName: string,
-    fn: () => any): void;
+    fn: () => any,
+  ): void
 }
 
 export function mockClassFunction(
@@ -21,7 +23,8 @@ export function mockClassFunction(
   const def = applicationContext.registry.getDefinition(className);
   if (! def) {
     throw new TypeError(`def undefined with className: "${className}", methodName: "${methodName}"`);
-  } else {
+  }
+  else {
     const clazz = def.path;
     if (clazz && typeof clazz === 'function') {
       this._mockFn(clazz.prototype, methodName, fn);

--- a/packages/midway-mock/src/bootstrap.ts
+++ b/packages/midway-mock/src/bootstrap.ts
@@ -1,6 +1,8 @@
 import * as assert from 'power-assert';
+
 import { MidwayMockApplication } from './interface';
 import { MidwayMock, mm as mock } from './mock';
+
 
 // 由于使用Object.assign，丢了默认的mm执行函数，所以使用default输出mm
 export const mm: MidwayMock['default'] = mock.default;

--- a/packages/midway-mock/src/interface.ts
+++ b/packages/midway-mock/src/interface.ts
@@ -1,29 +1,30 @@
 import { MockApplication, MockOption } from 'egg-mock';
 import { IApplicationContext } from 'injection';
 
+
 export interface MidwayApplicationOptions extends MockOption {
-  baseDir?: string;
-  framework?: string;
-  plugin?: any;
-  plugins?: any;
-  container?: any;
-  typescript?: boolean;
-  worker?: number;
+  baseDir?: string
+  framework?: string
+  plugin?: any
+  plugins?: any
+  container?: any
+  typescript?: boolean
+  worker?: number
 }
 
 export interface MidwayMockApplication extends MockApplication {
-  applicationContext: IApplicationContext;
-  pluginContext: IApplicationContext;
-  appDir: string;
-  baseDir: string;
-  enablePlugins: any;
-  getApplicationContext(): IApplicationContext;
-  getPluginContext(): IApplicationContext;
-  getPlugin(pluginName: string): any;
-  getLogger(name?: string): any;
-  getConfig(key?: string): any;
+  applicationContext: IApplicationContext
+  pluginContext: IApplicationContext
+  appDir: string
+  baseDir: string
+  enablePlugins: any
+  getApplicationContext(): IApplicationContext
+  getPluginContext(): IApplicationContext
+  getPlugin(pluginName: string): any
+  getLogger(name?: string): any
+  getConfig(key?: string): any
   /**
    * Mock class function
    */
-  mockClassFunction(className: string, methodName: string, fn: any): any;
+  mockClassFunction(className: string, methodName: string, fn: any): any
 }

--- a/packages/midway-mock/src/mock.ts
+++ b/packages/midway-mock/src/mock.ts
@@ -1,48 +1,42 @@
+/* eslint-disable @typescript-eslint/ban-ts-ignore */
 import * as mock from 'egg-mock';
 import { resolveModule } from 'midway-bin';
 
 import { MidwayApplicationOptions, MidwayMockApplication } from './interface';
 
+
 export interface MidwayMock extends mock.EggMock {
-  container: typeof mockContainer;
-  default: mock.EggMock;
-  app: (option?: MidwayApplicationOptions) => MidwayMockApplication;
-  cluster: (option?: MidwayApplicationOptions) => MidwayMockApplication;
+  container: typeof mockContainer
+  default: mock.EggMock
+  app: (option?: MidwayApplicationOptions) => MidwayMockApplication
+  cluster: (option?: MidwayApplicationOptions) => MidwayMockApplication
   // [prop: string]: any
 }
 
-/**
- * 只初始化app级别的container
- * agent相关的逻辑使用mm2.app
- * @param options 参数
- */
-function mockContainer(options: MidwayApplicationOptions): MockContainer {
-  return new MockContainer(options);
-}
-
 const defaultFramework: string = resolveModule('midway') || resolveModule('midway-mirror');
+
 
 export const mm = Object.assign({}, mock, {
   container: mockContainer,
 }) as MidwayMock;
 
 mm.app = (options): MidwayMockApplication => {
-  if (process.env.MIDWAY_BASE_DIR && !options.baseDir) { options.baseDir = process.env.MIDWAY_BASE_DIR; }
-  if (process.env.MIDWAY_FRAMEWORK_PATH && !options.framework) { options.framework = process.env.MIDWAY_FRAMEWORK_PATH; }
+  if (process.env.MIDWAY_BASE_DIR && ! options.baseDir) { options.baseDir = process.env.MIDWAY_BASE_DIR; }
+  if (process.env.MIDWAY_FRAMEWORK_PATH && ! options.framework) { options.framework = process.env.MIDWAY_FRAMEWORK_PATH; }
   // @ts-ignore
   return mock.app(Object.assign({
     framework: options.framework || defaultFramework,
-    typescript: !!require.extensions['.ts'],
+    typescript: !! require.extensions['.ts'],
   }, options));
 };
 
 mm.cluster = (options) => {
-  if (process.env.MIDWAY_BASE_DIR && !options.baseDir) { options.baseDir = process.env.MIDWAY_BASE_DIR; }
-  if (process.env.MIDWAY_FRAMEWORK_PATH && !options.framework) { options.framework = process.env.MIDWAY_FRAMEWORK_PATH; }
+  if (process.env.MIDWAY_BASE_DIR && ! options.baseDir) { options.baseDir = process.env.MIDWAY_BASE_DIR; }
+  if (process.env.MIDWAY_FRAMEWORK_PATH && ! options.framework) { options.framework = process.env.MIDWAY_FRAMEWORK_PATH; }
   // @ts-ignore
   return mock.cluster(Object.assign({
     framework: options.framework || defaultFramework,
-    typescript: !!require.extensions['.ts'],
+    typescript: !! require.extensions['.ts'],
   }, options));
 };
 
@@ -66,3 +60,13 @@ export class MockContainer {
     return this.app.applicationContext.get(id);
   }
 }
+
+/**
+ * 只初始化app级别的container
+ * agent相关的逻辑使用mm2.app
+ * @param options 参数
+ */
+function mockContainer(options: MidwayApplicationOptions): MockContainer {
+  return new MockContainer(options);
+}
+

--- a/packages/midway-mock/test/fixtures/base-app-decorator/src/config/config.default.ts
+++ b/packages/midway-mock/test/fixtures/base-app-decorator/src/config/config.default.ts
@@ -8,5 +8,5 @@ export const hello = {
 
 export const plugins = {
   bucLogin: false,
-  plugin2: true
+  plugin2: true,
 };

--- a/packages/midway-mock/test/fixtures/base-app-decorator/src/config/plugin.ts
+++ b/packages/midway-mock/test/fixtures/base-app-decorator/src/config/plugin.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 
+
 module.exports = {
   // 默认开启的插件
 
@@ -9,5 +10,5 @@ module.exports = {
   plugin2: {
     enable: true,
     path: path.join(__dirname, '../plugins/plugin2'),
-  }
+  },
 };

--- a/packages/midway-mock/test/fixtures/base-app-decorator/src/lib/service.ts
+++ b/packages/midway-mock/test/fixtures/base-app-decorator/src/lib/service.ts
@@ -1,5 +1,6 @@
-import {async, init, provide, inject} from 'injection';
-import {config, plugin} from '@midwayjs/decorator';
+import { async, init, provide, inject } from 'injection';
+import { config, plugin } from '@midwayjs/decorator';
+
 
 @async()
 @provide()
@@ -15,7 +16,7 @@ export class BaseService {
 
   @init()
   async init() {
-    await new Promise(resolve => {
+    await new Promise((resolve) => {
       setTimeout(() => {
         this.config.c = 10;
         resolve();

--- a/packages/midway-mock/test/index.test.ts
+++ b/packages/midway-mock/test/index.test.ts
@@ -1,11 +1,15 @@
+import * as assert from 'assert';
 import * as path from 'path';
-const fixtures = path.join(__dirname, 'fixtures');
-// app dir
-process.env.MIDWAY_BASE_DIR = path.join(fixtures, 'base-app-decorator');
 
-import { app, mm } from '../bootstrap';
-const assert = require('assert');
-import { mm as mock, MockContainer } from '../src/';
+// eslint-disable-next-line import/order
+import { mm as mock, MockContainer } from '../src';
+
+// 以下两行必须在前!
+const fixtures = path.join(__dirname, 'fixtures');
+process.env.MIDWAY_BASE_DIR = path.join(fixtures, 'base-app-decorator'); // app dir
+// eslint-disable-next-line import/first
+import { app, mm } from '../src/bootstrap';
+
 
 describe('test/index.test.ts', () => {
   afterEach(mm.restore);
@@ -18,12 +22,12 @@ describe('test/index.test.ts', () => {
       return 'mock_test' + ts;
     });
     const service: any = await app.applicationContext.getAsync('baseService');
-    assert(service.getData() === ('mock_test' + ts));
+    assert(service.getData() === 'mock_test' + ts);
 
     mm.restore();
-    assert(service.getData() !== ('mock_test' + ts));
+    assert(service.getData() !== 'mock_test' + ts);
     const service1: any = await app.applicationContext.getAsync('baseService');
-    assert(service1.getData() !== ('mock_test' + ts));
+    assert(service1.getData() !== 'mock_test' + ts);
   });
 
   it('should use bootstrap to get app', () => {
@@ -46,32 +50,32 @@ describe('test/index.test.ts', () => {
   });
 
   it('should use mm.app to get app', () => {
-    const app = mock.app({
+    const appInst = mock.app({
       baseDir: process.env.MIDWAY_BASE_DIR,
       framework: process.env.MIDWAY_FRAMEWORK_PATH,
     });
-    return app.ready();
+    return appInst.ready();
   });
 
   it('should use mm.cluster to get app by default options', () => {
     mm(process.env, 'MIDWAY_FRAMEWORK_PATH', path.join(__dirname, '../../midway'));
-    const app = mock.cluster({});
-    return app.ready();
+    const appInst = mock.cluster({});
+    return appInst.ready();
   });
 
   it('should use mm.cluster to get app', () => {
-    const app = mock.cluster({
+    const appInst = mock.cluster({
       baseDir: process.env.MIDWAY_BASE_DIR,
       framework: process.env.MIDWAY_FRAMEWORK_PATH,
     });
-    return app.ready();
+    return appInst.ready();
   });
 
   it('should init container from app', async () => {
-    const app = new MockContainer({
+    const appInst = new MockContainer({
       baseDir: process.env.MIDWAY_BASE_DIR,
       framework: process.env.MIDWAY_FRAMEWORK_PATH,
     });
-    return app.ready();
+    return appInst.ready();
   });
 });

--- a/packages/midway-mock/test/mock_container.test.ts
+++ b/packages/midway-mock/test/mock_container.test.ts
@@ -1,8 +1,11 @@
-import { BaseService } from './fixtures/base-app-decorator/src/lib/service';
+import * as assert from 'assert';
+import * as path from 'path';
+
 import { mm } from '../src';
 
-import * as path from 'path';
-const assert = require('assert');
+import { BaseService } from './fixtures/base-app-decorator/src/lib/service';
+
+
 const fixtures = path.join(__dirname, 'fixtures');
 
 describe('test/mock_container.test.ts', () => {
@@ -12,15 +15,15 @@ describe('test/mock_container.test.ts', () => {
     before(() => {
       container = mm.container({
         baseDir: path.join(fixtures, 'base-app-decorator'),
-        typescript: true
+        typescript: true,
       });
     });
     afterEach(mm.restore);
 
     it('should mock service success', async () => {
       const service = await container.getAsync(BaseService);
-      mm.default(service, 'getData', async name => {
-        return new Promise(resolve => {
+      mm.default(service, 'getData', async (name) => {
+        return new Promise((resolve) => {
           setTimeout(() => {
             resolve(`hello ${name}`);
           }, 100);

--- a/packages/midway-mock/tsconfig.eslint.json
+++ b/packages/midway-mock/tsconfig.eslint.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts",
+    "test_browser/**/*.ts"
+  ],
+  "exclude": [
+    "asset",
+    "app/public",
+    "app/views",
+    "dist",
+    "node_modules*",
+    "**/*.d.ts",
+    "**/*.spec.ts"
+  ]
+}

--- a/packages/midway-schedule/agent.ts
+++ b/packages/midway-schedule/agent.ts
@@ -1,20 +1,21 @@
 import { SCHEDULE_KEY, ScheduleOpts } from '@midwayjs/decorator';
 import { getClassMetadata, getProviderId, listModule } from 'injection';
 
+
 export = (agent) => {
 
-  if (!agent.schedule) {
+  if (! agent.schedule) {
     return;
   }
 
   // ugly!! just support all and worker strategy
-  class AllStrategy extends agent['TimerScheduleStrategy'] {
+  class AllStrategy extends agent.TimerScheduleStrategy {
     handler() {
       this.sendAll();
     }
   }
 
-  class WorkerStrategy extends agent['TimerScheduleStrategy'] {
+  class WorkerStrategy extends agent.TimerScheduleStrategy {
     handler() {
       this.sendOne();
     }
@@ -35,7 +36,7 @@ export = (agent) => {
       }
       const key = provideId + '#' + scheduleModule.name;
       const Strategy = strategyMap.get(type);
-      if (!Strategy) {
+      if (! Strategy) {
         const err = new Error(`schedule type [${type}] is not defined`);
         err.name = 'MidwayScheduleError';
         throw err;

--- a/packages/midway-schedule/app.ts
+++ b/packages/midway-schedule/app.ts
@@ -2,10 +2,11 @@ import { ScheduleOpts, SCHEDULE_KEY } from '@midwayjs/decorator';
 import { getClassMetadata, listModule, getProviderId } from 'injection';
 import * as is from 'is-type-of';
 
+
 export = (app) => {
 
   // egg-schedule 的 app 里没有 schedule
-  if (!app.runSchedule) {
+  if (! app.runSchedule) {
     return;
   }
 
@@ -23,7 +24,7 @@ export = (app) => {
 
       const env = app.config.env;
       const envList = opts.env;
-      if (is.array(envList) && !envList.includes(env)) {
+      if (is.array(envList) && ! envList.includes(env)) {
         app.coreLogger.info(
           `[midway-schedule]: ignore schedule ${key} due to \`schedule.env\` not match`,
         );

--- a/packages/midway-schedule/package.json
+++ b/packages/midway-schedule/package.json
@@ -13,7 +13,7 @@
     ]
   },
   "scripts": {
-    "build": "npm run lint && midway-bin build -c",
+    "build": "midway-bin build -c",
     "lint": "../../node_modules/.bin/tslint --format prose -c ../../tslint.json src/**/*.ts test/**/*.ts",
     "test": "npm run lint && midway-bin clean && NODE_ENV=unittest midway-bin test --ts",
     "autod": "midway-bin autod"

--- a/packages/midway-schedule/package.json
+++ b/packages/midway-schedule/package.json
@@ -14,8 +14,9 @@
   },
   "scripts": {
     "build": "midway-bin build -c",
-    "lint": "../../node_modules/.bin/tslint --format prose -c ../../tslint.json src/**/*.ts test/**/*.ts",
-    "test": "npm run lint && midway-bin clean && NODE_ENV=unittest midway-bin test --ts",
+    "lint": "eslint --fix --cache {src,test}/**/*.ts app.ts agent.ts",
+    "lint:nofix": "eslint --cache {src,test}/**/*.ts app.ts agent.ts",
+    "test": "npm run lint:nofix && midway-bin clean && NODE_ENV=unittest midway-bin test --ts",
     "autod": "midway-bin autod"
   },
   "keywords": [],

--- a/packages/midway-schedule/package.json
+++ b/packages/midway-schedule/package.json
@@ -16,12 +16,13 @@
     "build": "midway-bin build -c",
     "lint": "eslint --fix --cache {src,test}/**/*.ts app.ts agent.ts",
     "lint:nofix": "eslint --cache {src,test}/**/*.ts app.ts agent.ts",
-    "test": "npm run lint:nofix && midway-bin clean && NODE_ENV=unittest midway-bin test --ts",
+    "test": "npm run lint:nofix && midway-bin clean && cross-env NODE_ENV=unittest midway-bin test --ts",
     "autod": "midway-bin autod"
   },
   "keywords": [],
   "license": "MIT",
   "devDependencies": {
+    "cross-env": "7",
     "midway-bin": "^1.17.1",
     "midway-mock": "^1.18.0"
   },

--- a/packages/midway-schedule/test/fixtures/app-load-schedule/src/schedule/hello.ts
+++ b/packages/midway-schedule/test/fixtures/app-load-schedule/src/schedule/hello.ts
@@ -1,5 +1,6 @@
-import { provide } from 'injection';
 import { schedule } from '@midwayjs/decorator';
+import { provide } from 'injection';
+
 
 @provide()
 @schedule({

--- a/packages/midway-schedule/test/fixtures/worker-non-default-class/src/schedule/interval.ts
+++ b/packages/midway-schedule/test/fixtures/worker-non-default-class/src/schedule/interval.ts
@@ -1,7 +1,6 @@
-'use strict';
-
-import { provide } from 'injection';
 import { schedule } from '@midwayjs/decorator';
+import { provide } from 'injection';
+
 
 @provide()
 @schedule({

--- a/packages/midway-schedule/test/fixtures/worker/src/schedule/interval.ts
+++ b/packages/midway-schedule/test/fixtures/worker/src/schedule/interval.ts
@@ -1,5 +1,5 @@
-import { provide } from 'injection';
 import { schedule, CommonSchedule } from '@midwayjs/decorator';
+import { provide } from 'injection';
 
 @provide()
 @schedule({

--- a/packages/midway-schedule/test/schedule.test.ts
+++ b/packages/midway-schedule/test/schedule.test.ts
@@ -1,11 +1,10 @@
-'use strict';
-
-import { clearAllModule } from 'injection';
-import { mm } from 'midway-mock';
-
+import * as fs from 'fs';
 import * as path from 'path';
-const fs = require('fs');
-const assert = require('assert');
+import * as assert from 'assert';
+
+import { mm } from 'midway-mock';
+import { clearAllModule } from 'injection';
+
 
 describe('test/schedule.test.ts', () => {
   let application;
@@ -21,12 +20,10 @@ describe('test/schedule.test.ts', () => {
         typescript: true,
       });
       await application.ready();
-      const list = Object.keys(application.schedules).filter((key) =>
-        key.includes('HelloCron'),
-      );
+      const list = Object.keys(application.schedules).filter(key => key.includes('HelloCron'));
       assert(list.length === 1);
       const item = application.schedules[list[0]];
-      assert.deepEqual(item.schedule, {type: 'worker', interval: 2333});
+      assert.deepEqual(item.schedule, { type: 'worker', interval: 2333 });
     });
 
     it('should support interval with @schedule decorator (both app/schedule & lib/schedule)', async () => {
@@ -59,7 +56,7 @@ describe('test/schedule.test.ts', () => {
 
   describe('app.runSchedule', () => {
     it('should run schedule not exist throw error', async () => {
-      application = mm.app({ baseDir: 'worker', typescript: true, });
+      application = mm.app({ baseDir: 'worker', typescript: true });
       await application.ready();
       await application.runSchedule('intervalCron#IntervalCron');
       await sleep(1000);
@@ -83,11 +80,11 @@ function getLogContent(name) {
     name,
     'logs',
     name,
-    `midway-web.log`,
+    'midway-web.log',
   );
   return fs.readFileSync(logPath, 'utf8');
 }
 
 function contains(content, match) {
-  return content.split('\n').filter((line) => line.indexOf(match) >= 0).length;
+  return content.split('\n').filter(line => line.indexOf(match) >= 0).length;
 }

--- a/packages/midway-schedule/tsconfig.eslint.json
+++ b/packages/midway-schedule/tsconfig.eslint.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts",
+    "test_browser/**/*.ts",
+    "*.ts"
+  ],
+  "exclude": [
+    "asset",
+    "app/public",
+    "app/views",
+    "dist",
+    "node_modules*",
+    "**/*.d.ts",
+    "**/*.spec.ts"
+  ]
+}

--- a/packages/midway-web/package.json
+++ b/packages/midway-web/package.json
@@ -6,8 +6,9 @@
   "typings": "dist/index.d.ts",
   "scripts": {
     "build": "midway-bin build -c",
-    "lint": "../../node_modules/.bin/tslint --format prose -c ../../tslint.json --fix 'src/**/*.ts' 'test/**/*.ts'",
-    "test": "npm run lint && midway-bin clean && NODE_ENV=test midway-bin test --ts",
+    "lint": "eslint --fix --cache {src,test,config}/**/*.ts",
+    "lint:nofix": "eslint --cache {src,test,config}/**/*.ts",
+    "test": "npm run lint:nofix && midway-bin clean && NODE_ENV=test midway-bin test --ts",
     "cov": "midway-bin cov --ts",
     "ci": "npm run test",
     "autod": "midway-bin autod"

--- a/packages/midway-web/package.json
+++ b/packages/midway-web/package.json
@@ -8,7 +8,7 @@
     "build": "midway-bin build -c",
     "lint": "eslint --fix --cache {src,test,config}/**/*.ts",
     "lint:nofix": "eslint --cache {src,test,config}/**/*.ts",
-    "test": "npm run lint:nofix && midway-bin clean && NODE_ENV=test midway-bin test --ts",
+    "test": "npm run lint:nofix && midway-bin clean && cross-env NODE_ENV=test midway-bin test --ts",
     "cov": "midway-bin cov --ts",
     "ci": "npm run test",
     "autod": "midway-bin autod"
@@ -30,6 +30,7 @@
   "devDependencies": {
     "@types/react": "^16.0.38",
     "@types/react-dom": "^16.0.4",
+    "cross-env": "7",
     "is-type-of": "^1.2.1",
     "midway-bin": "^1.17.1",
     "midway-mock": "^1.18.0",

--- a/packages/midway-web/package.json
+++ b/packages/midway-web/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index",
   "typings": "dist/index.d.ts",
   "scripts": {
-    "build": "npm run lint && midway-bin build -c",
+    "build": "midway-bin build -c",
     "lint": "../../node_modules/.bin/tslint --format prose -c ../../tslint.json --fix 'src/**/*.ts' 'test/**/*.ts'",
     "test": "npm run lint && midway-bin clean && NODE_ENV=test midway-bin test --ts",
     "cov": "midway-bin cov --ts",

--- a/packages/midway-web/src/index.ts
+++ b/packages/midway-web/src/index.ts
@@ -1,10 +1,16 @@
 export * from 'injection';
 export * from 'midway-core';
 export * from '@midwayjs/decorator';
+
 export * from './interface';
-export {AgentWorkerLoader, AppWorkerLoader} from './loader/loader';
-export {Application, Agent} from './midway';
-export {MidwayWebLoader} from './loader/webLoader';
+export {
+  AgentWorkerLoader, AppWorkerLoader,
+} from './loader/loader';
+export {
+  Application,
+  Agent,
+} from './midway';
+export { MidwayWebLoader } from './loader/webLoader';
 
 export {
   Context,

--- a/packages/midway-web/src/interface.ts
+++ b/packages/midway-web/src/interface.ts
@@ -1,22 +1,23 @@
-import {Context} from 'egg';
-import {EggLoaderOptions} from 'egg-core';
-import {IApplicationContext} from 'injection';
-import {KoaMiddleware, KoaMiddlewareParamArray} from '@midwayjs/decorator';
+import { KoaMiddleware, KoaMiddlewareParamArray } from '@midwayjs/decorator';
+import { Context } from 'egg';
+import { EggLoaderOptions } from 'egg-core';
+import { IApplicationContext } from 'injection';
+
 
 export type Middleware = KoaMiddleware<Context>;
 export type MiddlewareParamArray = KoaMiddlewareParamArray<Context>;
 
 export interface WebMiddleware {
-  resolve(): Middleware;
+  resolve(): Middleware
 }
 
 export interface MidwayLoaderOptions extends EggLoaderOptions {
-  logger: any;
-  plugins?: any;
-  baseDir: string;
-  app: any;
-  typescript?: boolean;
-  srcDir?: string;
-  targetDir?: string;
-  container?: IApplicationContext;
+  logger: any
+  plugins?: any
+  baseDir: string
+  app: any
+  typescript?: boolean
+  srcDir?: string
+  targetDir?: string
+  container?: IApplicationContext
 }

--- a/packages/midway-web/src/loader/loader.ts
+++ b/packages/midway-web/src/loader/loader.ts
@@ -1,5 +1,6 @@
 import { MidwayWebLoader } from './webLoader';
 
+
 export class AppWorkerLoader extends MidwayWebLoader {
 
   /**

--- a/packages/midway-web/src/loader/webLoader.ts
+++ b/packages/midway-web/src/loader/webLoader.ts
@@ -1,4 +1,7 @@
-import { EggRouter as Router } from '@eggjs/router';
+/* eslint-disable @typescript-eslint/ban-ts-ignore */
+import * as fs from 'fs';
+import * as path from 'path';
+
 import {
   CONTROLLER_KEY,
   ControllerOption,
@@ -8,17 +11,21 @@ import {
   WEB_ROUTER_PARAM_KEY,
   RouterParamValue,
 } from '@midwayjs/decorator';
-import * as extend from 'extend2';
-import * as fs from 'fs';
-import { getClassMetadata, getPropertyDataFromClass, getProviderId, listModule } from 'injection';
 import { ContainerLoader, MidwayHandlerKey, MidwayContainer } from 'midway-core';
-import * as path from 'path';
-import { Middleware, MiddlewareParamArray, MidwayLoaderOptions, WebMiddleware } from '../interface';
-import { isTypeScriptEnvironment, safelyGet } from '../utils';
+import * as Debug from 'debug';
+import * as EggCore from 'egg-core';
+import { EggRouter as Router } from '@eggjs/router';
+import * as extend from 'extend2';
+import { getClassMetadata, getPropertyDataFromClass, getProviderId, listModule } from 'injection';
 import { EggAppInfo } from 'egg';
 
-const debug = require('debug')(`midway:loader:${process.pid}`);
-const EggLoader = require('egg-core').EggLoader;
+import { Middleware, MiddlewareParamArray, MidwayLoaderOptions, WebMiddleware } from '../interface';
+import { isTypeScriptEnvironment, safelyGet } from '../utils';
+
+
+const debug = Debug(`midway:loader:${process.pid}`);
+const EggLoader = EggCore.EggLoader;
+
 
 const TS_SRC_DIR = 'src';
 const TS_TARGET_DIR = 'dist';
@@ -28,10 +35,10 @@ export class MidwayWebLoader extends EggLoader {
   public appDir: string;
   public appInfo: EggAppInfo;
   private controllerIds: string[] = [];
-  private prioritySortRouters: Array<{
-    priority: number,
-    router: Router,
-  }> = [];
+  private prioritySortRouters: {
+    priority: number;
+    router: Router;
+  }[] = [];
   private containerLoader: ContainerLoader;
 
   constructor(options: MidwayLoaderOptions) {
@@ -42,7 +49,8 @@ export class MidwayWebLoader extends EggLoader {
    * 判断是否是 ts 模式，在构造器内就会被执行
    */
   get isTsMode(): boolean {
-    return !!this.app.options.typescript;
+    // @ts-ignore
+    return !! this.app.options.typescript;
   }
 
   get applicationContext(): MidwayContainer {
@@ -107,28 +115,35 @@ export class MidwayWebLoader extends EggLoader {
   protected registerTypescriptDirectory(): void {
     const app = this.app;
     // 处理 ts 的初始路径
+    // @ts-ignore
     this.appDir = this.baseDir = app.options.baseDir;
     if (this.isTsMode) {
+      // @ts-ignore
       let dirSuffix = app.options.targetDir || TS_TARGET_DIR;
       if (isTypeScriptEnvironment()) {
+        // @ts-ignore
         dirSuffix = app.options.srcDir || TS_SRC_DIR;
         // 打开 egg 加载 ts 的开关
         process.env.EGG_TYPESCRIPT = 'true';
-        debug(`typescript mode = true`);
+        debug('typescript mode = true');
       }
 
+      // @ts-ignore
       const dir = path.join(app.options.baseDir, dirSuffix);
+      // @ts-ignore
       this.baseDir = app.options.baseDir = this.options.baseDir = dir;
+      // @ts-ignore
       this.options.logger.info(`in typescript current dir change to ${dir}`);
       debug(`in typescript current dir change to ${dir}`);
     }
   }
 
   protected getEggPaths(): string[] {
-    if (!this.appDir) {
+    if (! this.appDir) {
       // register appDir here
       this.registerTypescriptDirectory();
     }
+    // @ts-ignore
     return super.getEggPaths();
   }
 
@@ -140,7 +155,8 @@ export class MidwayWebLoader extends EggLoader {
       serverEnv = fs.readFileSync(envPath, 'utf8').trim();
     }
 
-    if (!serverEnv) {
+    if (! serverEnv) {
+      // @ts-ignore
       serverEnv = super.getServerEnv();
     }
 
@@ -148,7 +164,7 @@ export class MidwayWebLoader extends EggLoader {
   }
 
   protected getAppInfo(): EggAppInfo {
-    if (!this.appInfo) {
+    if (! this.appInfo) {
       const appInfo: EggAppInfo | undefined = super.getAppInfo();
       // ROOT == HOME in prod env
       this.appInfo = extend(true, appInfo, {
@@ -161,8 +177,9 @@ export class MidwayWebLoader extends EggLoader {
 
   protected loadApplicationContext(): void {
     // this.app.options.container 测试用例编写方便点
+    // @ts-ignore
     const containerConfig = this.config.container || this.app.options.container || {};
-    if (!containerConfig.loadDir) {
+    if (! containerConfig.loadDir) {
       // 如果没有配置，默认就把扫描目录改到 /src or /dist
       containerConfig.baseDir = this.baseDir;
     }
@@ -170,7 +187,7 @@ export class MidwayWebLoader extends EggLoader {
     // 如果是typescript会加上 dist 或者 src 目录
     this.containerLoader = new ContainerLoader({
       baseDir: this.appDir,
-      isTsMode: this.isTsMode
+      isTsMode: this.isTsMode,
     });
     this.containerLoader.initialize();
     this.applicationContext.registerObject('appDir', this.appDir);
@@ -187,9 +204,12 @@ export class MidwayWebLoader extends EggLoader {
     });
 
     this.containerLoader.registerHook(MidwayHandlerKey.LOGGER, (key: string) => {
+      // @ts-ignore
       if (this.app.getLogger) {
+        // @ts-ignore
         return this.app.getLogger(key);
       }
+      // @ts-ignore
       return this.options.logger;
     });
   }
@@ -228,10 +248,11 @@ export class MidwayWebLoader extends EggLoader {
             this.generateController(
               `${controllerId}.${webRouter.method}`,
               routeArgsInfo,
-            )
+            ),
           ];
 
           // apply controller from request context
+          // eslint-disable-next-line prefer-spread
           newRouter[webRouter.requestMethod].apply(newRouter, routerArgs);
         }
       }
@@ -256,7 +277,8 @@ export class MidwayWebLoader extends EggLoader {
         if (typeof middleware === 'function') {
           // web function middleware
           handlerCallback(middleware);
-        } else {
+        }
+        else {
           const middlewareImpl: WebMiddleware | void = await this.applicationContext.getAsync(middleware);
           if (middlewareImpl && typeof middlewareImpl.resolve === 'function') {
             handlerCallback(middlewareImpl.resolve());
@@ -297,6 +319,7 @@ export class MidwayWebLoader extends EggLoader {
         }));
       }
       const controller = await ctx.requestContext.getAsync(controllerId);
+      // eslint-disable-next-line prefer-spread
       return controller[methodName].apply(controller, args);
     };
   }

--- a/packages/midway-web/src/loader/webLoader.ts
+++ b/packages/midway-web/src/loader/webLoader.ts
@@ -61,6 +61,19 @@ export class MidwayWebLoader extends EggLoader {
     return this.containerLoader.getPluginContext();
   }
 
+  public getAppInfo(): EggAppInfo {
+    if (! this.appInfo) {
+      const appInfo: EggAppInfo | undefined = super.getAppInfo();
+      // ROOT == HOME in prod env
+      this.appInfo = extend(true, appInfo, {
+        root: appInfo.env === 'local' || appInfo.env === 'unittest' ? this.appDir : appInfo.root,
+        appDir: this.appDir,
+      });
+    }
+    return this.appInfo;
+  }
+
+
   // loadPlugin -> loadConfig -> afterLoadConfig
   protected loadConfig(): void {
     this.loadPlugin();
@@ -161,18 +174,6 @@ export class MidwayWebLoader extends EggLoader {
     }
 
     return serverEnv;
-  }
-
-  protected getAppInfo(): EggAppInfo {
-    if (! this.appInfo) {
-      const appInfo: EggAppInfo | undefined = super.getAppInfo();
-      // ROOT == HOME in prod env
-      this.appInfo = extend(true, appInfo, {
-        root: appInfo.env === 'local' || appInfo.env === 'unittest' ? this.appDir : appInfo.root,
-        appDir: this.appDir,
-      });
-    }
-    return this.appInfo;
   }
 
   protected loadApplicationContext(): void {

--- a/packages/midway-web/src/midway.ts
+++ b/packages/midway-web/src/midway.ts
@@ -1,14 +1,18 @@
-import { Agent, Application } from 'egg';
-import { Logger } from 'egg-logger';
-import { AgentWorkerLoader, AppWorkerLoader } from './loader/loader';
 import * as fs from 'fs';
 import * as path from 'path';
+
+import { Agent, Application } from 'egg';
+import { Logger } from 'egg-logger';
 import { EggRouter as Router } from '@eggjs/router';
+
+import { AgentWorkerLoader, AppWorkerLoader } from './loader/loader';
+
 
 const MIDWAY_PATH = path.dirname(__dirname);
 
+// eslint-disable-next-line @typescript-eslint/no-extra-parens
 class MidwayApplication extends (Application as {
-  new(...x)
+  new(...x);
 }) {
 
   Router = Router;
@@ -87,14 +91,16 @@ class MidwayApplication extends (Application as {
       const rundir = this.config.rundir;
       const dumpFile = path.join(rundir, `${this.type}_dependency_${process.pid}`);
       fs.writeFileSync(dumpFile, tree);
-    } catch (err) {
+    }
+    catch (err) {
       this.coreLogger.warn(`dump dependency dot error: ${err.message}`);
     }
   }
 }
 
+// eslint-disable-next-line @typescript-eslint/no-extra-parens
 class MidwayAgent extends (Agent as {
-  new(...x)
+  new(...x);
 }) {
 
   get [Symbol.for('egg#loader')]() {
@@ -163,7 +169,8 @@ class MidwayAgent extends (Agent as {
       const rundir = this.config.rundir;
       const dumpFile = path.join(rundir, `${this.type}_dependency_${process.pid}`);
       fs.writeFileSync(dumpFile, tree);
-    } catch (err) {
+    }
+    catch (err) {
       this.coreLogger.warn(`dump dependency dot error: ${err.message}`);
     }
   }
@@ -171,5 +178,5 @@ class MidwayAgent extends (Agent as {
 
 export {
   MidwayApplication as Application,
-  MidwayAgent as Agent
+  MidwayAgent as Agent,
 };

--- a/packages/midway-web/src/utils.ts
+++ b/packages/midway-web/src/utils.ts
@@ -1,7 +1,8 @@
 const STRIP_COMMENTS = /((\/\/.*$)|(\/\*[\s\S]*?\*\/))/mg;
 const ARGUMENT_NAMES = /([^\s,]+)/g;
 
-export function getParamNames(func: () => any): RegExpMatchArray {
+
+export function getParamNames(func: (...args: any[]) => any): RegExpMatchArray {
   const fnStr = func.toString().replace(STRIP_COMMENTS, '');
   let result = fnStr.slice(fnStr.indexOf('(') + 1, fnStr.indexOf(')')).match(ARGUMENT_NAMES);
   if (result === null) {

--- a/packages/midway-web/src/utils.ts
+++ b/packages/midway-web/src/utils.ts
@@ -28,7 +28,7 @@ export function getMethodNames(obj: object): string[] {
     proto = Object.getPrototypeOf(proto);
     const allOwnKeysOnPrototype: string[] = Object.getOwnPropertyNames(proto);
     // get methods from es6 class
-    allOwnKeysOnPrototype.forEach(k => {
+    allOwnKeysOnPrototype.forEach((k) => {
       if (typeof obj[k] === 'function' && k !== 'constructor') {
         result.push(k);
       }
@@ -37,13 +37,13 @@ export function getMethodNames(obj: object): string[] {
   while (proto && proto !== Object.prototype);
 
   // leave out those methods on Object's prototype
-  return result.filter(k => {
+  return result.filter((k) => {
     return ownKeysOnObjectPrototype.indexOf(k) === -1;
   });
 }
 
 export function isTypeScriptEnvironment(): boolean {
-  return !!require.extensions['.ts'] || process.env.MIDWAY_TS_MODE === 'true';
+  return !! require.extensions['.ts'] || process.env.MIDWAY_TS_MODE === 'true';
 }
 
 /**
@@ -68,7 +68,8 @@ export function safelyGet(list: string | string[], obj?: object): any {
   for (const key of pathArrValue) {
     if (typeof willReturn === 'undefined' || willReturn === null) {
       return void 0;
-    } else if (typeof willReturn !== 'object') {
+    }
+    else if (typeof willReturn !== 'object') {
       return void 0;
     }
     willReturn = willReturn[key];

--- a/packages/midway-web/test/enhance.test.ts
+++ b/packages/midway-web/test/enhance.test.ts
@@ -133,7 +133,7 @@ describe('/test/enhance.test.ts', () => {
     });
   });
 
-  describe.only('load ts file and use config, plugin decorator', () => {
+  describe('load ts file and use config, plugin decorator', () => {
     let app;
     before(() => {
       app = utils.app('enhance/base-app-decorator', {

--- a/packages/midway-web/test/enhance.test.ts
+++ b/packages/midway-web/test/enhance.test.ts
@@ -133,7 +133,7 @@ describe('/test/enhance.test.ts', () => {
     });
   });
 
-  describe('load ts file and use config, plugin decorator', () => {
+  describe.only('load ts file and use config, plugin decorator', () => {
     let app;
     before(() => {
       app = utils.app('enhance/base-app-decorator', {

--- a/packages/midway-web/test/enhance.test.ts
+++ b/packages/midway-web/test/enhance.test.ts
@@ -1,12 +1,14 @@
-const assert = require('assert');
-const request = require('supertest');
 import * as path from 'path';
-const utils = require('./utils');
-const mm = require('mm');
-const pedding = require('pedding');
-const rimraf = require('mz-modules/rimraf');
+import * as assert from 'assert';
 
 import { clearAllModule } from 'injection';
+import * as request from 'supertest';
+import * as mm from 'mm';
+import * as pedding from 'pedding';
+import * as rimraf from 'mz-modules/rimraf';
+
+import * as utils from './utils';
+
 
 describe('/test/enhance.test.ts', () => {
 
@@ -16,7 +18,7 @@ describe('/test/enhance.test.ts', () => {
     let app;
     before(() => {
       app = utils.app('enhance/base-app', {
-        typescript: true
+        typescript: true,
       });
       return app.ready();
     });
@@ -39,7 +41,7 @@ describe('/test/enhance.test.ts', () => {
     let app;
     before(() => {
       app = utils.app('enhance/base-app-controller', {
-        typescript: true
+        typescript: true,
       });
       return app.ready();
     });
@@ -60,7 +62,7 @@ describe('/test/enhance.test.ts', () => {
         .expect('hello', done);
     });
 
-    it('should load controller use controller decorator prefix /', done => {
+    it('should load controller use controller decorator prefix /', (done) => {
       request(app.callback())
         .get('/')
         .expect(200)
@@ -72,7 +74,7 @@ describe('/test/enhance.test.ts', () => {
     let app;
     before(() => {
       app = utils.app('enhance/base-app-controller-default-export', {
-        typescript: true
+        typescript: true,
       });
       return app.ready();
     });
@@ -94,10 +96,11 @@ describe('/test/enhance.test.ts', () => {
       let suc = false;
       try {
         app = utils.app('enhance/base-app-controller-conflicts', {
-          typescript: true
+          typescript: true,
         });
         await app.ready();
-      } catch (e) {
+      }
+      catch (e) {
         suc = true;
       }
       assert.ok(suc);
@@ -108,7 +111,7 @@ describe('/test/enhance.test.ts', () => {
     let app;
     before(() => {
       app = utils.app('enhance/base-app-default-scope', {
-        typescript: true
+        typescript: true,
       });
       return app.ready();
     });
@@ -134,7 +137,7 @@ describe('/test/enhance.test.ts', () => {
     let app;
     before(() => {
       app = utils.app('enhance/base-app-decorator', {
-        typescript: true
+        typescript: true,
       });
       return app.ready();
     });
@@ -151,20 +154,20 @@ describe('/test/enhance.test.ts', () => {
         .expect(/3t/, done);
     });
 
-    it('should hello controller be ok', done => {
+    it('should hello controller be ok', (done) => {
       request(app.callback())
         .get('/hello/say')
         .expect(200)
         .expect('service,hello,a,b', done);
     });
 
-    it('should config controller be ok', done => {
+    it('should config controller be ok', (done) => {
       done = pedding(2, done);
 
       request(app.callback())
         .get('/config/test')
         .expect(200)
-        .expect({ a: 1, b: true, c: 2}, done);
+        .expect({ a: 1, b: true, c: 2 }, done);
 
       request(app.callback())
         .get('/config/test2')
@@ -180,12 +183,12 @@ describe('/test/enhance.test.ts', () => {
       await request(app.callback())
         .get('/param/12/test?name=1')
         .expect(200)
-        .expect({id: '12', name: '1'});
+        .expect({ id: '12', name: '1' });
 
       await request(app.callback())
         .get('/param/query?name=1')
         .expect(200)
-        .expect({name: '1'});
+        .expect({ name: '1' });
 
       await request(app.callback())
         .get('/param/query_id?id=1')
@@ -195,7 +198,7 @@ describe('/test/enhance.test.ts', () => {
       await request(app.callback())
         .get('/param/param/12/test/456')
         .expect(200)
-        .expect({id: '12', userId: '456'});
+        .expect({ id: '12', userId: '456' });
 
       await request(app.callback())
         .get('/param/param/12')
@@ -207,7 +210,7 @@ describe('/test/enhance.test.ts', () => {
         .type('form')
         .send({ id: '1' })
         .expect(200)
-        .expect({id: '1'});
+        .expect({ id: '1' });
 
       await request(app.callback())
         .get('/param/body_id')
@@ -270,7 +273,7 @@ describe('/test/enhance.test.ts', () => {
     let app;
     before(() => {
       app = utils.app('enhance/base-app-utils', {
-        typescript: true
+        typescript: true,
       });
       return app.ready();
     });
@@ -289,7 +292,7 @@ describe('/test/enhance.test.ts', () => {
     let app;
     before(() => {
       app = utils.app('enhance/base-app-async', {
-        typescript: true
+        typescript: true,
       });
       return app.ready();
     });
@@ -304,13 +307,13 @@ describe('/test/enhance.test.ts', () => {
     });
   });
 
-  describe('ts directory different from other', function () {
+  describe('ts directory different from other', function() {
 
     let app;
     before(() => {
       mm(process.env, 'HOME', '');
       app = utils.app('enhance/base-app', {
-        typescript: true
+        typescript: true,
       });
       return app.ready();
     });
@@ -319,9 +322,9 @@ describe('/test/enhance.test.ts', () => {
 
     it('should appDir not equal baseDir', () => {
       const appInfo = app.loader.getAppInfo();
-      assert(appInfo['name'] === app.name);
-      assert(appInfo['baseDir'] === app.baseDir);
-      assert(appInfo['baseDir'] === app.appDir + '/src');
+      assert(appInfo.name === app.name);
+      assert(appInfo.baseDir === app.baseDir);
+      assert(appInfo.baseDir === app.appDir + '/src');
     });
   });
 
@@ -329,7 +332,7 @@ describe('/test/enhance.test.ts', () => {
     let app;
     before(() => {
       app = utils.app('enhance/base-app-constructor', {
-        typescript: true
+        typescript: true,
       });
       return app.ready();
     });
@@ -348,7 +351,7 @@ describe('/test/enhance.test.ts', () => {
     let app;
     before(() => {
       app = utils.app('enhance/base-app-function', {
-        typescript: true
+        typescript: true,
       });
       return app.ready();
     });
@@ -367,7 +370,7 @@ describe('/test/enhance.test.ts', () => {
     let app;
     before(() => {
       app = utils.app('enhance/base-app-router', {
-        typescript: true
+        typescript: true,
       });
       return app.ready();
     });
@@ -397,7 +400,7 @@ describe('/test/enhance.test.ts', () => {
     let app;
     before(() => {
       app = utils.app('enhance/base-app-router-priority', {
-        typescript: true
+        typescript: true,
       });
       return app.ready();
     });
@@ -427,7 +430,7 @@ describe('/test/enhance.test.ts', () => {
     let app;
     before(() => {
       app = utils.app('enhance/loader-duplicate', {
-        typescript: true
+        typescript: true,
       });
       return app.ready();
     });
@@ -446,7 +449,7 @@ describe('/test/enhance.test.ts', () => {
     let app;
     before(() => {
       app = utils.app('enhance/base-app-controller-tsx', {
-        typescript: true
+        typescript: true,
       });
       return app.ready();
     });
@@ -466,7 +469,7 @@ describe('/test/enhance.test.ts', () => {
     let app;
     before(() => {
       app = utils.app('enhance/base-app-middleware', {
-        typescript: true
+        typescript: true,
       });
       return app.ready();
     });

--- a/packages/midway-web/test/fixtures/enhance/base-app-async/src/config/config.default.ts
+++ b/packages/midway-web/test/fixtures/enhance/base-app-async/src/config/config.default.ts
@@ -8,5 +8,5 @@ export const hello = {
 
 export const plugins = {
   bucLogin: false,
-  plugin2: true
+  plugin2: true,
 };

--- a/packages/midway-web/test/fixtures/enhance/base-app-async/src/config/plugin.ts
+++ b/packages/midway-web/test/fixtures/enhance/base-app-async/src/config/plugin.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 
+
 module.exports = {
   // 默认开启的插件
 
@@ -9,5 +10,5 @@ module.exports = {
   plugin2: {
     enable: true,
     path: path.join(__dirname, '../plugins/plugin2'),
-  }
+  },
 };

--- a/packages/midway-web/test/fixtures/enhance/base-app-async/src/lib/service.ts
+++ b/packages/midway-web/test/fixtures/enhance/base-app-async/src/lib/service.ts
@@ -1,5 +1,6 @@
-import {config, plugin} from '@midwayjs/decorator';
-import {provide, async, init} from 'injection';
+import { config, plugin } from '@midwayjs/decorator';
+import { provide, async, init } from 'injection';
+
 
 @async()
 @provide()
@@ -13,7 +14,7 @@ export class BaseService {
 
   @init()
   async init() {
-    await new Promise(resolve => {
+    await new Promise((resolve) => {
       setTimeout(() => {
         this.config.c = 10;
         resolve();

--- a/packages/midway-web/test/fixtures/enhance/base-app-constructor/src/config/config.default.ts
+++ b/packages/midway-web/test/fixtures/enhance/base-app-constructor/src/config/config.default.ts
@@ -8,5 +8,5 @@ export const hello = {
 
 export const plugins = {
   bucLogin: false,
-  plugin2: true
+  plugin2: true,
 };

--- a/packages/midway-web/test/fixtures/enhance/base-app-constructor/src/config/plugin.ts
+++ b/packages/midway-web/test/fixtures/enhance/base-app-constructor/src/config/plugin.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 
+
 module.exports = {
   // 默认开启的插件
 
@@ -9,5 +10,5 @@ module.exports = {
   plugin2: {
     enable: true,
     path: path.join(__dirname, '../plugins/plugin2'),
-  }
+  },
 };

--- a/packages/midway-web/test/fixtures/enhance/base-app-constructor/src/lib/service.ts
+++ b/packages/midway-web/test/fixtures/enhance/base-app-constructor/src/lib/service.ts
@@ -1,17 +1,18 @@
-import {config, plugin} from '@midwayjs/decorator';
-import {provide, async, init, inject} from 'injection';
+import { config, plugin } from '@midwayjs/decorator';
+import { provide, async, init, inject } from 'injection';
+
 
 @provide()
 export class A {
   config = {
-    c: 20
+    c: 20,
   };
 }
 
 @provide()
 export class B {
   config = {
-    c: 40
+    c: 40,
   };
 }
 
@@ -23,20 +24,20 @@ export class BaseService {
   plugin2;
 
   constructor(
-    @inject() a,
-    @config('hello') config,
+  @inject() a,
+    @config('hello') configInput,
     @inject() b,
-    @plugin('plugin2') plugin2
+    @plugin('plugin2') plugin2,
   ) {
-    this.config = Object.assign(config, {
-      c: a.config.c + b.config.c + config.c
+    this.config = Object.assign(configInput, {
+      c: a.config.c + b.config.c + configInput.c,
     });
     this.plugin2 = plugin2;
   }
 
   @init()
   async init() {
-    await new Promise(resolve => {
+    await new Promise((resolve) => {
       setTimeout(() => {
         resolve();
       }, 100);

--- a/packages/midway-web/test/fixtures/enhance/base-app-controller-conflicts/src/app/controller/api.ts
+++ b/packages/midway-web/test/fixtures/enhance/base-app-controller-conflicts/src/app/controller/api.ts
@@ -1,9 +1,12 @@
 'use strict';
 
-import { inject, provide, scope, ScopeEnum } from 'injection';
-import { controller, get } from '../../../../../../../src/';
+import * as assert from 'assert';
 
-const assert = require('assert');
+import { inject, provide, scope, ScopeEnum } from 'injection';
+
+// eslint-disable-next-line import/named
+import { controller, get } from '../../../../../../../src';
+
 
 @provide()
 @scope(ScopeEnum.Request)

--- a/packages/midway-web/test/fixtures/enhance/base-app-controller-conflicts/src/app/controller/my.ts
+++ b/packages/midway-web/test/fixtures/enhance/base-app-controller-conflicts/src/app/controller/my.ts
@@ -1,5 +1,7 @@
 import { provide } from 'injection';
-import { controller, get } from '../../../../../../../src/';
+
+// eslint-disable-next-line import/named
+import { controller, get } from '../../../../../../../src';
 
 @provide()
 @controller('/')

--- a/packages/midway-web/test/fixtures/enhance/base-app-controller-default-export/src/app/controller/api.ts
+++ b/packages/midway-web/test/fixtures/enhance/base-app-controller-default-export/src/app/controller/api.ts
@@ -1,9 +1,11 @@
 'use strict';
+import * as assert from 'assert';
 
 import { inject, provide, scope, ScopeEnum } from 'injection';
-import { controller, get } from '../../../../../../../src/';
 
-const assert = require('assert');
+// eslint-disable-next-line import/named
+import { controller, get } from '../../../../../../../src';
+
 
 @provide()
 @scope(ScopeEnum.Request)

--- a/packages/midway-web/test/fixtures/enhance/base-app-controller-default-export/src/app/controller/my.ts
+++ b/packages/midway-web/test/fixtures/enhance/base-app-controller-default-export/src/app/controller/my.ts
@@ -1,5 +1,8 @@
 import { provide } from 'injection';
-import { controller, get } from '../../../../../../../src/';
+
+// eslint-disable-next-line import/named
+import { controller, get } from '../../../../../../../src';
+
 
 @provide()
 @controller('/')

--- a/packages/midway-web/test/fixtures/enhance/base-app-controller/src/app/controller/api.ts
+++ b/packages/midway-web/test/fixtures/enhance/base-app-controller/src/app/controller/api.ts
@@ -1,9 +1,13 @@
 'use strict';
 
-import { inject, provide, scope, ScopeEnum } from 'injection';
-import { controller, get } from '../../../../../../../src/';
+import * as assert from 'assert';
 
-const assert = require('assert');
+import { inject, provide, scope, ScopeEnum } from 'injection';
+
+// eslint-disable-next-line import/named
+import { controller, get } from '../../../../../../../src';
+
+
 
 @provide()
 @scope(ScopeEnum.Request)

--- a/packages/midway-web/test/fixtures/enhance/base-app-controller/src/app/controller/my.ts
+++ b/packages/midway-web/test/fixtures/enhance/base-app-controller/src/app/controller/my.ts
@@ -1,5 +1,7 @@
 import { provide } from 'injection';
-import { controller, get } from '../../../../../../../src/';
+
+// eslint-disable-next-line import/named
+import { controller, get } from '../../../../../../../src';
 
 @provide()
 @controller('/')

--- a/packages/midway-web/test/fixtures/enhance/base-app-decorator/src/app/controller/config.ts
+++ b/packages/midway-web/test/fixtures/enhance/base-app-decorator/src/app/controller/config.ts
@@ -1,4 +1,6 @@
-import {provide, inject} from 'injection';
+import { provide, inject } from 'injection';
+
+// eslint-disable-next-line import/named
 import { controller, get, config } from '../../../../../../../src';
 
 @provide()
@@ -26,25 +28,25 @@ export class ConfigController {
   b: boolean;
 
   constructor(
-      // should be true
-      @config('plugins.plugin2') pluginFlag: boolean
+  // should be true
+  @config('plugins.plugin2') pluginFlag: boolean,
   ) {
     this.b = pluginFlag;
   }
 
   @get('/test')
   async test() {
-      const data =  {
-          a: this.a,
-          b: this.b,
-          c: this.c,
-          d: this.d,
-      };
-      this.ctx.body = data;
+    const data = {
+      a: this.a,
+      b: this.b,
+      c: this.c,
+      d: this.d,
+    };
+    this.ctx.body = data;
   }
 
   @get('/test2')
   async test2() {
-      this.ctx.body = this.plugins;
+    this.ctx.body = this.plugins;
   }
 }

--- a/packages/midway-web/test/fixtures/enhance/base-app-decorator/src/app/controller/hello.ts
+++ b/packages/midway-web/test/fixtures/enhance/base-app-decorator/src/app/controller/hello.ts
@@ -1,4 +1,6 @@
-import {provide, inject} from 'injection';
+import { provide, inject } from 'injection';
+
+// eslint-disable-next-line import/named
 import { controller, get } from '../../../../../../../src';
 import { BaseService } from '../../lib/service';
 import { HelloService } from '../../lib/HelloService';

--- a/packages/midway-web/test/fixtures/enhance/base-app-decorator/src/app/controller/param.ts
+++ b/packages/midway-web/test/fixtures/enhance/base-app-decorator/src/app/controller/param.ts
@@ -1,9 +1,13 @@
-import { provide, inject } from 'injection';
-import { controller, config, get, post, query, param, files, file, session, body, headers } from '../../../../../../../src';
 import * as path from 'path';
 import * as fs from 'fs';
 
+import { provide, inject } from 'injection';
 import * as pump from 'mz-modules/pump';
+
+import {
+  // eslint-disable-next-line import/named
+  controller, config, get, post, query, param, files, file, session, body, headers,
+} from '../../../../../../../src';
 
 @provide()
 @controller('/param')
@@ -16,16 +20,16 @@ export class ParamController {
   ctx: any;
 
   @get('/query')
-  async query(@query() query) {
-      this.ctx.body = query;
+  async query(@query('query') queryInput) {
+    this.ctx.body = queryInput;
   }
 
   @get('/:id/test')
-  async test(@query() query, @param('id') id) {
+  async test(@query('query') queryInput, @param('id') id) {
     const data = {
-        id,
-        ...query
-      };
+      id,
+      ...queryInput,
+    };
     this.ctx.body = data;
   }
 
@@ -35,9 +39,9 @@ export class ParamController {
   }
 
   @get('/param/:id/test/:userId')
-  async param(@param() param) {
+  async param(@param('param') paramInput) {
     // service,hello,a,b
-    this.ctx.body = param;
+    this.ctx.body = paramInput;
   }
 
   @get('/param/:id')
@@ -46,8 +50,8 @@ export class ParamController {
   }
 
   @post('/body')
-  async body(@body() body) {
-    this.ctx.body = body;
+  async body(@body('body') bodyInput) {
+    this.ctx.body = bodyInput;
   }
 
   @get('/body_id')
@@ -70,26 +74,26 @@ export class ParamController {
     let stream = await parts();
 
     while (stream) {
-        const filename = stream.filename.toLowerCase();
-        const target = path.join(this.baseDir, 'app/public', filename);
-        const writeStream = fs.createWriteStream(target);
-        await pump(stream, writeStream);
-        stream = await parts();
+      const filename = stream.filename.toLowerCase();
+      const target = path.join(this.baseDir, 'app/public', filename);
+      const writeStream = fs.createWriteStream(target);
+      await pump(stream, writeStream);
+      stream = await parts();
     }
 
     this.ctx.body = 'ok';
   }
 
   @get('/session')
-  async session(@session() session) {
+  async session(@session('session') sessionInput) {
     // service,hello,a,b
-    this.ctx.body = session;
+    this.ctx.body = sessionInput;
   }
 
   @get('/headers')
-  async header(@headers() headers) {
+  async header(@headers('headers') headersInput) {
     // service,hello,a,b
-    this.ctx.body = headers.host.substring(0, 3);
+    this.ctx.body = headersInput.host.substring(0, 3);
   }
 
   @get('/headers_host')

--- a/packages/midway-web/test/fixtures/enhance/base-app-decorator/src/app/controller/param.ts
+++ b/packages/midway-web/test/fixtures/enhance/base-app-decorator/src/app/controller/param.ts
@@ -20,15 +20,15 @@ export class ParamController {
   ctx: any;
 
   @get('/query')
-  async query(@query('query') queryInput) {
-    this.ctx.body = queryInput;
+  async query(@query() input) {
+    this.ctx.body = input;
   }
 
   @get('/:id/test')
-  async test(@query('query') queryInput, @param('id') id) {
+  async test(@query() input, @param('id') id) {
     const data = {
       id,
-      ...queryInput,
+      ...input,
     };
     this.ctx.body = data;
   }
@@ -39,7 +39,7 @@ export class ParamController {
   }
 
   @get('/param/:id/test/:userId')
-  async param(@param('param') paramInput) {
+  async param(@param() paramInput) {
     // service,hello,a,b
     this.ctx.body = paramInput;
   }
@@ -50,8 +50,8 @@ export class ParamController {
   }
 
   @post('/body')
-  async body(@body('body') bodyInput) {
-    this.ctx.body = bodyInput;
+  async body(@body() bodyObj) {
+    this.ctx.body = bodyObj;
   }
 
   @get('/body_id')
@@ -85,15 +85,15 @@ export class ParamController {
   }
 
   @get('/session')
-  async session(@session('session') sessionInput) {
+  async session(@session() sessionObj) {
     // service,hello,a,b
-    this.ctx.body = sessionInput;
+    this.ctx.body = sessionObj;
   }
 
   @get('/headers')
-  async header(@headers('headers') headersInput) {
+  async header(@headers() headersObj) {
     // service,hello,a,b
-    this.ctx.body = headersInput.host.substring(0, 3);
+    this.ctx.body = headersObj.host.substring(0, 3);
   }
 
   @get('/headers_host')

--- a/packages/midway-web/test/fixtures/enhance/base-app-decorator/src/config/config.default.ts
+++ b/packages/midway-web/test/fixtures/enhance/base-app-decorator/src/config/config.default.ts
@@ -5,11 +5,11 @@ export const hello = {
   b: 2,
   d: [1, 2, 3],
   e: {
-    f: 2
-  }
+    f: 2,
+  },
 };
 
 export const plugins = {
   bucLogin: false,
-  plugin2: true
+  plugin2: true,
 };

--- a/packages/midway-web/test/fixtures/enhance/base-app-decorator/src/config/plugin.ts
+++ b/packages/midway-web/test/fixtures/enhance/base-app-decorator/src/config/plugin.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 
+
 module.exports = {
   // 默认开启的插件
 
@@ -9,5 +10,5 @@ module.exports = {
   plugin2: {
     enable: true,
     path: path.join(__dirname, '../plugins/plugin2'),
-  }
+  },
 };

--- a/packages/midway-web/test/fixtures/enhance/base-app-decorator/src/lib/HelloService.ts
+++ b/packages/midway-web/test/fixtures/enhance/base-app-decorator/src/lib/HelloService.ts
@@ -1,4 +1,5 @@
-import {provide, inject} from 'injection';
+import { provide, inject } from 'injection';
+
 import { BaseService } from './service';
 
 @provide()
@@ -11,7 +12,7 @@ export class HelloService {
   service: BaseService;
 
   async say() {
-    if (!this.service) {
+    if (! this.service) {
       throw new Error('inject baseService fail!');
     }
     return `${this.xxx.join(',')}`;

--- a/packages/midway-web/test/fixtures/enhance/base-app-decorator/src/lib/service.ts
+++ b/packages/midway-web/test/fixtures/enhance/base-app-decorator/src/lib/service.ts
@@ -1,5 +1,6 @@
-import {config, plugin} from '@midwayjs/decorator';
-import {provide} from 'injection';
+import { config, plugin } from '@midwayjs/decorator';
+import { provide } from 'injection';
+
 
 @provide()
 export class BaseService {

--- a/packages/midway-web/test/fixtures/enhance/base-app-default-scope/src/app/controller/api.ts
+++ b/packages/midway-web/test/fixtures/enhance/base-app-default-scope/src/app/controller/api.ts
@@ -1,8 +1,11 @@
 'use strict';
 
-import { provide } from 'injection';
-import { controller, get } from '../../../../../../../src/';
 import * as assert from 'assert';
+
+import { provide } from 'injection';
+
+// eslint-disable-next-line import/named
+import { controller, get } from '../../../../../../../src';
 
 @provide()
 export class BaseApi {

--- a/packages/midway-web/test/fixtures/enhance/base-app-function/src/config/config.default.ts
+++ b/packages/midway-web/test/fixtures/enhance/base-app-function/src/config/config.default.ts
@@ -8,7 +8,7 @@ export const hello = {
 
 export const plugins = {
   bucLogin: false,
-  plugin2: true
+  plugin2: true,
 };
 
 export const adapterName = 'google';

--- a/packages/midway-web/test/fixtures/enhance/base-app-function/src/config/plugin.ts
+++ b/packages/midway-web/test/fixtures/enhance/base-app-function/src/config/plugin.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 
+
 module.exports = {
   // 默认开启的插件
 
@@ -9,5 +10,5 @@ module.exports = {
   plugin2: {
     enable: true,
     path: path.join(__dirname, '../plugins/plugin2'),
-  }
+  },
 };

--- a/packages/midway-web/test/fixtures/enhance/base-app-function/src/lib/adapter.ts
+++ b/packages/midway-web/test/fixtures/enhance/base-app-function/src/lib/adapter.ts
@@ -1,4 +1,4 @@
-import {provide} from 'injection';
+import { provide } from 'injection';
 
 @provide()
 export class GoogleAdapter {

--- a/packages/midway-web/test/fixtures/enhance/base-app-function/src/lib/factory.ts
+++ b/packages/midway-web/test/fixtures/enhance/base-app-function/src/lib/factory.ts
@@ -1,6 +1,7 @@
 import { providerWrapper } from 'midway-core';
 import { IApplicationContext } from 'injection';
 
+
 export function adapterFactory(context: IApplicationContext) {
   return async (adapterName: string) => {
     if (adapterName === 'google') {
@@ -16,7 +17,7 @@ export function adapterFactory(context: IApplicationContext) {
 export function contextHandler(context) {
   return async () => {
     const ctx = await context.getAsync('ctx');
-    return !!ctx.logger;
+    return !! ctx.logger;
   };
 }
 
@@ -27,6 +28,6 @@ providerWrapper([
   },
   {
     id: 'contextHandler',
-    provider: contextHandler
-  }
+    provider: contextHandler,
+  },
 ]);

--- a/packages/midway-web/test/fixtures/enhance/base-app-function/src/lib/service.ts
+++ b/packages/midway-web/test/fixtures/enhance/base-app-function/src/lib/service.ts
@@ -1,17 +1,18 @@
 import { config, plugin } from '@midwayjs/decorator';
 import { async, init, inject, provide } from 'injection';
 
+
 @provide()
 export class A {
   config = {
-    c: 20
+    c: 20,
   };
 }
 
 @provide()
 export class B {
   config = {
-    c: 40
+    c: 40,
   };
 }
 
@@ -34,13 +35,14 @@ export class BaseService {
   adapter;
 
   constructor(
-    @inject() a,
+  @inject() a,
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define, no-shadow
     @config('hello') config,
     @inject() b,
-    @plugin('plugin2') plugin2
+    @plugin('plugin2') plugin2,
   ) {
     this.config = Object.assign(config, {
-      c: a.config.c + b.config.c + config.c
+      c: a.config.c + b.config.c + config.c,
     });
     this.plugin2 = plugin2;
   }

--- a/packages/midway-web/test/fixtures/enhance/base-app-middleware/src/web/controller/my.ts
+++ b/packages/midway-web/test/fixtures/enhance/base-app-middleware/src/web/controller/my.ts
@@ -1,5 +1,8 @@
 import { inject, provide } from 'injection';
-import { controller, get, post } from '../../../../../../../src/';
+
+// eslint-disable-next-line import/named
+import { controller, get, post } from '../../../../../../../src';
+
 
 const mw = async (ctx, next) => {
   ctx.home = ctx.home + '4444';
@@ -14,13 +17,13 @@ const newMiddleware = (data) => {
 };
 
 @provide()
-@controller('/', {middleware: ['homeMiddleware', mw]})
+@controller('/', { middleware: ['homeMiddleware', mw] })
 export class My {
 
   @inject()
   ctx;
 
-  @get('/', {middleware: ['apiMiddleware', newMiddleware('5555')]})
+  @get('/', { middleware: ['apiMiddleware', newMiddleware('5555')] })
   @post('/api/data')
   async index() {
     this.ctx.body = this.ctx.home + (this.ctx.api || '');

--- a/packages/midway-web/test/fixtures/enhance/base-app-middleware/src/web/middleware/api.ts
+++ b/packages/midway-web/test/fixtures/enhance/base-app-middleware/src/web/middleware/api.ts
@@ -1,6 +1,8 @@
 import { config } from '@midwayjs/decorator';
 import { provide } from 'injection';
+
 import { WebMiddleware } from '../../../../../../../src';
+
 
 @provide()
 export class ApiMiddleware implements WebMiddleware {

--- a/packages/midway-web/test/fixtures/enhance/base-app-middleware/src/web/middleware/home.ts
+++ b/packages/midway-web/test/fixtures/enhance/base-app-middleware/src/web/middleware/home.ts
@@ -1,11 +1,12 @@
 import { provide } from 'injection';
+
 import { WebMiddleware } from '../../../../../../../src';
 
 @provide()
 export class HomeMiddleware implements WebMiddleware {
 
   resolve() {
-    return async function (ctx, next) {
+    return async function(ctx, next) {
       ctx.home = '1111';
       await next();
     };

--- a/packages/midway-web/test/fixtures/enhance/base-app-router-priority/src/app/controller/aaa.ts
+++ b/packages/midway-web/test/fixtures/enhance/base-app-router-priority/src/app/controller/aaa.ts
@@ -1,5 +1,7 @@
 import { provide } from 'injection';
-import { controller, get } from '../../../../../../../src/';
+
+// eslint-disable-next-line import/named
+import { controller, get } from '../../../../../../../src';
 
 @provide()
 @controller('/api')

--- a/packages/midway-web/test/fixtures/enhance/base-app-router-priority/src/app/controller/home.ts
+++ b/packages/midway-web/test/fixtures/enhance/base-app-router-priority/src/app/controller/home.ts
@@ -1,5 +1,7 @@
 import { provide } from 'injection';
-import { controller, get, priority } from '../../../../../../../src/';
+
+// eslint-disable-next-line import/named
+import { controller, get, priority } from '../../../../../../../src';
 
 @provide()
 @priority(-1)

--- a/packages/midway-web/test/fixtures/enhance/base-app-router/src/app/controller/home.ts
+++ b/packages/midway-web/test/fixtures/enhance/base-app-router/src/app/controller/home.ts
@@ -1,5 +1,7 @@
 import { provide } from 'injection';
-import { controller, get } from '../../../../../../../src/';
+
+// eslint-disable-next-line import/named
+import { controller, get } from '../../../../../../../src';
 
 @provide()
 @controller('/')

--- a/packages/midway-web/test/fixtures/enhance/base-app-utils/src/app.ts
+++ b/packages/midway-web/test/fixtures/enhance/base-app-utils/src/app.ts
@@ -1,4 +1,5 @@
 module.exports = (app) => {
   const context = app.getApplicationContext();
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
   context.registerObject('is', require('is-type-of'));
 };

--- a/packages/midway-web/test/fixtures/enhance/base-app-utils/src/app/controller/api.ts
+++ b/packages/midway-web/test/fixtures/enhance/base-app-utils/src/app/controller/api.ts
@@ -1,7 +1,6 @@
-'use strict';
+import { controller, get, config } from '@midwayjs/decorator';
+import { inject, provide } from 'injection';
 
-import {inject, provide} from 'injection';
-import {controller, get, config} from '@midwayjs/decorator';
 
 @provide()
 export class BaseApi {

--- a/packages/midway-web/test/fixtures/enhance/base-app-utils/src/app/router.ts
+++ b/packages/midway-web/test/fixtures/enhance/base-app-utils/src/app/router.ts
@@ -1,5 +1,5 @@
 module.exports = function(app) {
-  const {applicationContext} = app;
+  const { applicationContext } = app;
   const apiController = applicationContext.get('baseApi');
   app.get('/api/index', apiController.index);
 };

--- a/packages/midway-web/test/fixtures/enhance/base-app/src/app/controller/api.ts
+++ b/packages/midway-web/test/fixtures/enhance/base-app/src/app/controller/api.ts
@@ -1,5 +1,6 @@
 'use strict';
 
+// eslint-disable-next-line require-yield
 exports.index = function*() {
   this.body = 'hello';
 };

--- a/packages/midway-web/test/fixtures/enhance/loader-duplicate/src/app.ts
+++ b/packages/midway-web/test/fixtures/enhance/loader-duplicate/src/app.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 
+
 export = (app) => {
   app.beforeStart(() => {
     app.loader.loadController({

--- a/packages/midway-web/test/fixtures/enhance/loader-duplicate/src/app/controller/my.ts
+++ b/packages/midway-web/test/fixtures/enhance/loader-duplicate/src/app/controller/my.ts
@@ -1,5 +1,7 @@
 import { provide } from 'injection';
-import { controller, get } from '../../../../../../../src/';
+
+// eslint-disable-next-line import/named
+import { controller, get } from '../../../../../../../src';
 
 @provide()
 @controller('/')

--- a/packages/midway-web/test/fixtures/enhance/ts-app-inject/app.ts
+++ b/packages/midway-web/test/fixtures/enhance/ts-app-inject/app.ts
@@ -1,4 +1,5 @@
 import { inject, provide } from 'injection';
+
 import { Loader } from './loader';
 
 @provide()

--- a/packages/midway-web/test/fixtures/enhance/ts-app-inject/loader.ts
+++ b/packages/midway-web/test/fixtures/enhance/ts-app-inject/loader.ts
@@ -1,19 +1,20 @@
-import {provide} from 'injection';
+import { provide } from 'injection';
+
 
 export interface Loader {
-  getConfig();
+  getConfig()
 }
 
 @provide('loader')
 export class BaseLoader implements Loader {
   getConfig() {
-    return {a: 1, b: 2};
+    return { a: 1, b: 2 };
   }
 }
 
 @provide('easyLoader')
 export class EasyLoader extends BaseLoader implements Loader {
   getConfig() {
-    return {a: 3, b: 4};
+    return { a: 3, b: 4 };
   }
 }

--- a/packages/midway-web/test/fixtures/issue/base-app-extend-context/src/app/controller/User.ts
+++ b/packages/midway-web/test/fixtures/issue/base-app-extend-context/src/app/controller/User.ts
@@ -1,4 +1,5 @@
-import { controller, get, provide, Context, inject } from '../../../../../../../src/';
+// eslint-disable-next-line import/named
+import { controller, get, provide, Context, inject } from '../../../../../../../src';
 
 @provide()
 @controller('/api/user')

--- a/packages/midway-web/test/fixtures/issue/base-app-extend-context/src/app/extend/application.ts
+++ b/packages/midway-web/test/fixtures/issue/base-app-extend-context/src/app/extend/application.ts
@@ -1,4 +1,6 @@
-import { Application } from '../../../../../../../src/';
+// eslint-disable-next-line import/named
+import { Application } from '../../../../../../../src';
+
 
 const VALIDATOR: any = Symbol('Application#_validator');
 
@@ -8,8 +10,9 @@ export = {
     console.log('app[VALIDATOR]', app);
     if (app instanceof Application) {
       return app[VALIDATOR];
-    } else {
+    }
+    else {
       throw new Error('not same');
     }
-  }
+  },
 };

--- a/packages/midway-web/test/fixtures/issue/base-app-lazyload-ctx/src/Service.ts
+++ b/packages/midway-web/test/fixtures/issue/base-app-lazyload-ctx/src/Service.ts
@@ -1,4 +1,5 @@
 import { inject, provide } from 'injection';
+
 import { CodeService } from './app/service/CodeService';
 import { UserService } from './app/service/UserService';
 

--- a/packages/midway-web/test/fixtures/issue/base-app-lazyload-ctx/src/app/controller/Code.ts
+++ b/packages/midway-web/test/fixtures/issue/base-app-lazyload-ctx/src/app/controller/Code.ts
@@ -1,4 +1,5 @@
-import { controller, get, provide, Context, inject } from '../../../../../../../src/';
+// eslint-disable-next-line import/named
+import { controller, get, provide, Context, inject } from '../../../../../../../src';
 import { Service } from '../../Service';
 
 @provide()

--- a/packages/midway-web/test/fixtures/issue/base-app-lazyload-ctx/src/app/controller/User.ts
+++ b/packages/midway-web/test/fixtures/issue/base-app-lazyload-ctx/src/app/controller/User.ts
@@ -1,4 +1,5 @@
-import { controller, get, provide, Context, inject } from '../../../../../../../src/';
+// eslint-disable-next-line import/named
+import { controller, get, provide, Context, inject } from '../../../../../../../src';
 import { Service } from '../../Service';
 
 @provide()

--- a/packages/midway-web/test/fixtures/issue/base-app-lazyload-ctx/src/app/service/CodeService.ts
+++ b/packages/midway-web/test/fixtures/issue/base-app-lazyload-ctx/src/app/service/CodeService.ts
@@ -1,4 +1,5 @@
 import { inject, provide } from 'injection';
+
 import { Service } from '../../Service';
 import sleep from '../../package/Sleep';
 

--- a/packages/midway-web/test/fixtures/issue/base-app-lazyload-ctx/src/app/service/UserService.ts
+++ b/packages/midway-web/test/fixtures/issue/base-app-lazyload-ctx/src/app/service/UserService.ts
@@ -1,4 +1,5 @@
 import { inject, provide } from 'injection';
+
 import sleep from '../../package/Sleep';
 import { Service } from '../../Service';
 

--- a/packages/midway-web/test/fixtures/issue/base-app-lazyload-ctx/src/package/Sleep.ts
+++ b/packages/midway-web/test/fixtures/issue/base-app-lazyload-ctx/src/package/Sleep.ts
@@ -1,5 +1,5 @@
 export default function sleep(timerout = 1000) {
-  return new Promise(res => {
+  return new Promise((res) => {
     setTimeout(res, timerout);
   });
 }

--- a/packages/midway-web/test/issue.test.ts
+++ b/packages/midway-web/test/issue.test.ts
@@ -1,8 +1,9 @@
-const request = require('supertest');
 import { clearAllModule } from 'injection';
+import * as request from 'supertest';
+import * as pedding from 'pedding';
 
-const utils = require('./utils');
-const pedding = require('pedding');
+import * as utils from './utils';
+
 
 describe('/test/issue.test.ts', () => {
 
@@ -12,7 +13,7 @@ describe('/test/issue.test.ts', () => {
     let app;
     before(() => {
       app = utils.app('issue/base-app-lazyload-ctx', {
-        typescript: true
+        typescript: true,
       });
       return app.ready();
     });
@@ -50,7 +51,7 @@ describe('/test/issue.test.ts', () => {
     let app;
     before(() => {
       app = utils.app('issue/base-app-extend-context', {
-        typescript: true
+        typescript: true,
       });
       return app.ready();
     });

--- a/packages/midway-web/test/tsconfig.json
+++ b/packages/midway-web/test/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "declaration": false, 
+    "inlineSourceMap": false,
+    "module": "commonjs",
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "noUnusedLocals": false,
+    "target": "ESNEXT"
+  },
+  "include": [
+    "**/*.ts"
+  ],
+  "exclude": [
+    "asset/",
+    "node_modules*",
+    "**/*.d.ts",
+    "**/*.spec.ts"
+  ]
+}

--- a/packages/midway-web/test/utils.test.ts
+++ b/packages/midway-web/test/utils.test.ts
@@ -9,7 +9,7 @@ import {
 
 describe('test/utils.test.ts', () => {
   it('#getParamNames', () => {
-    const res = getParamNames(function test(a, b) {
+    const res = getParamNames(function test(a: unknown, b: unknown) {
       console.log(a, b);
     });
     deepEqual(res, ['a', 'b']);

--- a/packages/midway-web/test/utils.test.ts
+++ b/packages/midway-web/test/utils.test.ts
@@ -1,5 +1,11 @@
-const { deepEqual } = require('assert');
-const { getParamNames, getMethodNames, isTypeScriptEnvironment } = require('../src/utils');
+import { deepEqual } from 'assert';
+
+import {
+  getParamNames,
+  getMethodNames,
+  isTypeScriptEnvironment,
+} from '../src/utils';
+
 
 describe('test/utils.test.ts', () => {
   it('#getParamNames', () => {
@@ -10,7 +16,7 @@ describe('test/utils.test.ts', () => {
   });
 
   it('#getParamNames, with null', () => {
-    const res = getParamNames(function test() {});
+    const res = getParamNames(function test() { return; });
     deepEqual(res, []);
   });
 
@@ -31,7 +37,7 @@ describe('test/utils.test.ts', () => {
   it('#isTypeScriptEnvironment with MIDWAY_TS_MODE', () => {
     process.env.MIDWAY_TS_MODE = 'true';
     Object.defineProperty(require.extensions, '.ts', {
-      get () {
+      get() {
         return false;
       },
     });

--- a/packages/midway-web/test/utils.ts
+++ b/packages/midway-web/test/utils.ts
@@ -1,26 +1,27 @@
-'use strict';
+/* eslint-disable no-shadow */
+import * as fs from 'fs';
+import * as path from 'path';
 
-const fs = require('fs');
-const path = require('path');
 import { mm } from 'midway-mock';
+
 
 const logDir = path.join(__dirname, '../logs');
 
 process.setMaxListeners(0);
 
-if (!fs.existsSync(logDir)) {
+if (! fs.existsSync(logDir)) {
   fs.mkdirSync(logDir);
 }
 
 export function app(name, options) {
   options = formatOptions(name, options);
   // mm.consoleLevel(options.consoleLevel || 'NONE');
-  const app: any = mm.app(options);
-  app.close = () => {
-    fs.rmdirSync(path.join(app.baseDir, 'run'));
-    return app.close;
+  const appInst: any = mm.app(options);
+  appInst.close = () => {
+    fs.rmdirSync(path.join(appInst.baseDir, 'run'));
+    return appInst.close;
   };
-  return app;
+  return appInst;
 }
 
 export function cluster(name, options) {

--- a/packages/midway-web/tsconfig.eslint.json
+++ b/packages/midway-web/tsconfig.eslint.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts",
+    "test_browser/**/*.ts"
+  ],
+  "exclude": [
+    "asset",
+    "app/public",
+    "app/views",
+    "dist",
+    "node_modules*",
+    "**/*.d.ts",
+    "**/*.spec.ts"
+  ]
+}

--- a/packages/midway/package.json
+++ b/packages/midway/package.json
@@ -6,7 +6,8 @@
   "typings": "dist/index.d.ts",
   "scripts": {
     "build": "midway-bin build -c",
-    "lint": "../../node_modules/.bin/tslint --format prose -c ../../tslint.json --fix 'src/**/*.ts'",
+    "lint": "eslint --fix --cache {src,test}/**/*.ts",
+    "lint:nofix": "eslint --cache {src,test}/**/*.ts",
     "test": "midway-bin test --ts",
     "cov": "midway-bin cov --ts",
     "ci": "npm run test",

--- a/packages/midway/package.json
+++ b/packages/midway/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index",
   "typings": "dist/index.d.ts",
   "scripts": {
-    "build": "npm run lint && midway-bin build -c",
+    "build": "midway-bin build -c",
     "lint": "../../node_modules/.bin/tslint --format prose -c ../../tslint.json --fix 'src/**/*.ts'",
     "test": "midway-bin test --ts",
     "cov": "midway-bin cov --ts",

--- a/packages/midway/src/index.ts
+++ b/packages/midway/src/index.ts
@@ -1,10 +1,13 @@
+import Master from '../cluster/master';
+
+
 export * from 'midway-web';
-const Master = require('../cluster/master');
 
 /**
  * current version of midway
  * @member {String} Midway#VERSION
  */
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 export const VERSION = require('../package.json').version;
 
 /**

--- a/packages/midway/test/index.test.ts
+++ b/packages/midway/test/index.test.ts
@@ -1,15 +1,18 @@
+import * as path from 'path';
+
 import { expect } from 'chai';
+
 import * as midway from '../src';
 
-import * as path from 'path';
+
 const _ROOT = path.join(__dirname, '../');
 
 describe('/test/index.test.ts', () => {
-  it('should get framework version', function () {
+  it('should get framework version', function() {
     expect(midway.VERSION).to.equal(require(_ROOT + '/package.json').version);
   });
 
-  it('should get framework release name', function () {
+  it('should get framework release name', function() {
     expect(midway.RELEASE).to.exist;
   });
 

--- a/packages/midway/test/master.test.ts
+++ b/packages/midway/test/master.test.ts
@@ -1,5 +1,7 @@
-import { cluster } from './util';
 import { join } from 'path';
+
+import { cluster } from './util';
+
 
 describe('/test/master.test.js', () => {
   let app;

--- a/packages/midway/test/util.ts
+++ b/packages/midway/test/util.ts
@@ -1,4 +1,6 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const { mm } = require('../../midway-mock/dist');
+
 
 export function cluster(name, options?) {
   options = Object.assign(

--- a/packages/midway/test/utils.test.ts
+++ b/packages/midway/test/utils.test.ts
@@ -1,5 +1,7 @@
 import * as assert from 'assert';
+
 import { formatOptions } from '../cluster/utils';
+
 
 describe('/test/utils.test.js', () => {
 

--- a/packages/midway/tsconfig.eslint.json
+++ b/packages/midway/tsconfig.eslint.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts",
+    "test_browser/**/*.ts"
+  ],
+  "exclude": [
+    "asset",
+    "app/public",
+    "app/views",
+    "dist",
+    "node_modules*",
+    "**/*.d.ts",
+    "**/*.spec.ts"
+  ]
+}

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts",
+    "packages/*/src/**/*.ts",
+    "packages/*/test/**/*.ts"
+  ],
+  "exclude": [
+    "asset",
+    "app/public",
+    "app/views",
+    "dist",
+    "node_modules*",
+    "**/*.d.ts",
+    "**/*.spec.ts"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,36 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "incremental": true,
+    "inlineSourceMap": true,
+    "module": "commonjs",
+    "newLine": "lf",
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "outDir": "dist",
+    "pretty": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "stripInternal": true,
+    "target": "ES2019",
+    "tsBuildInfoFile": ".vscode/.tsbuildinfo",
+    "types" : ["node", "mocha"]
+  },
+  "include": [
+    "src/**/*.ts",
+    "packages/*/src/**/*.ts"
+  ],
+  "exclude": [
+    "asset",
+    "app/public",
+    "app/views",
+    "dist",
+    "node_modules*",
+    "test",
+    "**/*.d.ts",
+    "**/*.spec.ts"
+  ]
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
当前已知的明显变化：

- `!` and `!!` 单元操作符后面插入一个空格
- if/else 的 else 在新行上
- try/catch 的 catch 在新行上
- 多元素对象、数组的元素以多行出现时，最后一个元素后面新增一个逗号
- 箭头函数的参数强制小括号包裹 （箭头表达式单个参数省略小括号）

Todo:
1. 以下文件经过处理后 `constructor` 方法第一参数有不正常缩进，为 eslint 无法正确处理 `@config` 等注解导致
    - midway-core\test\fixtures\base-app-constructor\src\lib\service.ts
    - midway-core\test\fixtures\base-app-function\src\lib\service.ts
    - midway-web\test\fixtures\enhance\base-app-constructor\src\lib\service.ts
    - midway-web\test\fixtures\enhance\base-app-function\src\lib\service.ts
2. `midway-init` 的测试用例中依赖 `eslint-config-egg`， 如果改为 `midway-eslint-contrib` 则需要待后者发布 NPM 后才方便修改测试

已知问题：
CI nodejs v8.x 环境无法通过。为 eslint 某插件所致。

