### PR TITLE
fix: can midway build when tsconfig.json has comments

### DIFF
--- a/packages/midway-bin/lib/cmd/build.js
+++ b/packages/midway-bin/lib/cmd/build.js
@@ -76,7 +76,11 @@ class BuildCommand extends Command {
       console.log(`[midway-bin] tsconfig.json not found in ${cwd}\n`);
       return;
     }
-    const tsConfig = argv.tsConfig || require(projectFile);
+    let tsConfig = argv.tsConfig;
+    if (!tsConfig) {
+      const Hjson = require('hjson');
+      tsConfig = Hjson.parse(fs.readFileSync(projectFile, 'utf-8'));
+    }
     const projectDir = this.projectDir = path.dirname(projectFile);
     let outDir = this.inferCompilerOptions(tsConfig, 'outDir');
     let outDirAbsolute;

--- a/packages/midway-bin/package.json
+++ b/packages/midway-bin/package.json
@@ -31,7 +31,8 @@
     "jest-environment-node": "^24.9.0",
     "mz-modules": "^2.1.0",
     "terser": "^4.6.3",
-    "typedoc": "^0.14.2"
+    "typedoc": "^0.14.2",
+    "hjson": "^3.2.1"
   },
   "devDependencies": {
     "co-mocha": "^1.2.2",

--- a/packages/midway-bin/test/fixtures/ts-dir-tsconfig-comments/src/index.ts
+++ b/packages/midway-bin/test/fixtures/ts-dir-tsconfig-comments/src/index.ts
@@ -1,0 +1,3 @@
+export class Comment{
+  
+}

--- a/packages/midway-bin/test/fixtures/ts-dir-tsconfig-comments/tsconfig.json
+++ b/packages/midway-bin/test/fixtures/ts-dir-tsconfig-comments/tsconfig.json
@@ -1,0 +1,66 @@
+{
+  "compilerOptions": {
+    /* Basic Options */
+    // "incremental": true,                   /* Enable incremental compilation */
+    "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
+    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    "outDir": "./dist",                        /* Redirect output structure to the directory. */
+    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "composite": true,                     /* Enable project compilation */
+    // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true,                           /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    // "noUnusedLocals": true,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+    /* Module Resolution Options */
+    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+    // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
+
+    /* Source Map Options */
+    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+
+    /* Advanced Options */
+    "forceConsistentCasingInFileNames": true  /* Disallow inconsistently-cased references to the same file. */
+  }
+}

--- a/packages/midway-bin/test/lib/cmd/build.test.js
+++ b/packages/midway-bin/test/lib/cmd/build.test.js
@@ -30,6 +30,15 @@ describe('test/lib/cmd/build.test.js', () => {
     await rimraf(path.join(cwd, 'dist'));
   });
 
+  it('should build success with tsconfig comments', async ()=>{
+    const cwd = path.join(__dirname, '../../fixtures/ts-dir-tsconfig-comments')
+    await rimraf(path.join(cwd, 'dist'));
+    const child = coffee.fork(midwayBin, ['build'], { cwd});
+    await child.expect('code', 0).end();
+    assert(fs.existsSync(path.join(cwd, 'dist/index.js')));
+    await rimraf(path.join(cwd, 'dist'));
+  })
+
   it('should auto clean dir before build', async () => {
     const cwd = path.join(__dirname, '../../fixtures/ts-dir');
     const child = coffee.fork(midwayBin, [ 'build' ], { cwd });

--- a/packages/midway-bin/test/lib/util.test.js
+++ b/packages/midway-bin/test/lib/util.test.js
@@ -8,7 +8,7 @@ const util = require('../../lib/util.js');
 describe('test/lib/util.test.js', () => {
 
   it('should return full path of module', function() {
-    const moduleName = 'egg'
+    const moduleName = 'egg-bin'
     const path = util.resolveModule(moduleName)
     console.log('resolved path is:', path)
     assert(path && path.endsWith(`${pathx.sep}${moduleName}`));


### PR DESCRIPTION
fix #423 : 修复midway-bin build的时候，如果tsconfig.json是通过tsc --init创建出来的。