### PR TITLE
fix: lazy get default framework

### DIFF
--- a/packages/midway-mock/src/mock.ts
+++ b/packages/midway-mock/src/mock.ts
@@ -20,7 +20,7 @@ function mockContainer(options: MidwayApplicationOptions): MockContainer {
   return new MockContainer(options);
 }
 
-const defaultFramework: string = resolveModule('midway') || resolveModule('midway-mirror');
+const getDefaultFramework: () => string = () => resolveModule('midway') || resolveModule('midway-mirror');
 
 export const mm = Object.assign({}, mock, {
   container: mockContainer,
@@ -31,7 +31,7 @@ mm.app = (options): MidwayMockApplication => {
   if (process.env.MIDWAY_FRAMEWORK_PATH && !options.framework) { options.framework = process.env.MIDWAY_FRAMEWORK_PATH; }
   // @ts-ignore
   return mock.app(Object.assign({
-    framework: options.framework || defaultFramework,
+    framework: options.framework || getDefaultFramework(),
     typescript: !!require.extensions['.ts'],
   }, options));
 };
@@ -41,7 +41,7 @@ mm.cluster = (options) => {
   if (process.env.MIDWAY_FRAMEWORK_PATH && !options.framework) { options.framework = process.env.MIDWAY_FRAMEWORK_PATH; }
   // @ts-ignore
   return mock.cluster(Object.assign({
-    framework: options.framework || defaultFramework,
+    framework: options.framework || getDefaultFramework(),
     typescript: !!require.extensions['.ts'],
   }, options));
 };


### PR DESCRIPTION
如果使用 @ali/midway 的 test 功能的话，每次执行都会报 warning

![image](https://user-images.githubusercontent.com/6913898/76841513-d9091400-6873-11ea-8bc2-e29c8e6d4a5a.png)

因为 defaultFramework 每次都立刻执行了