### PR TITLE
fix: mock fn

### DIFF
--- a/packages/midway-mock/app/extend/application.js
+++ b/packages/midway-mock/app/extend/application.js
@@ -1,4 +1,4 @@
 "use strict";
 
-module.exports = require('../../dist/app/extend/application')
+module.exports = require('../../dist/app/extend/application');
 

--- a/packages/midway-mock/src/app/extend/application.ts
+++ b/packages/midway-mock/src/app/extend/application.ts
@@ -1,5 +1,4 @@
-import { MidwayMockApplication } from '../../interface';
-
+import { MidwayMockApplication, MockClassFunctionHandler } from '../../interface';
 
 interface MidwayMockApplicationInner extends MidwayMockApplication {
   _mockFn(
@@ -7,18 +6,16 @@ interface MidwayMockApplicationInner extends MidwayMockApplication {
     methodName: string,
     /** {Object|Function|Error} - mock you data */
     fnOrData: any,
-  ): void
+  ): void;
 }
 
-export const mockClassFunction: MidwayMockApplicationInner['mockClassFunction'] = function(
+export const mockClassFunction: MockClassFunctionHandler = function(
   this: MidwayMockApplicationInner,
   className: string,
   methodName: string,
   fnOrData: any,
 ): void {
-
   const { applicationContext } = this;
-
   const def = applicationContext.registry.getDefinition(className);
   if (! def) {
     throw new TypeError(`def undefined with className: "${className}", methodName: "${methodName}"`);
@@ -26,5 +23,4 @@ export const mockClassFunction: MidwayMockApplicationInner['mockClassFunction'] 
     const clazz = def.path;
     this._mockFn(clazz.prototype, methodName, fnOrData);
   }
-}
-
+};

--- a/packages/midway-mock/src/interface.ts
+++ b/packages/midway-mock/src/interface.ts
@@ -11,11 +11,11 @@ export interface MidwayApplicationOptions extends MockOption {
   worker?: number;
 }
 
-type EggContext = Pick<MockApplication, 'mockContext'>;
+type EggContext = ReturnType<MockApplication['mockContext']>;
 
-export type MidwayMockContext = EggContext & {
+export interface MidwayMockContext extends EggContext {
   requestContext: IApplicationContext;
-};
+}
 
 export type FilterPick<T, U> = Pick<T, Exclude<keyof T, U>>;
 

--- a/packages/midway-mock/src/interface.ts
+++ b/packages/midway-mock/src/interface.ts
@@ -11,6 +11,14 @@ export interface MidwayApplicationOptions extends MockOption {
   worker?: number;
 }
 
+type EggContext = Pick<MockApplication, 'mockContext'>;
+
+export type MidwayMockContext = EggContext & {
+  requestContext: IApplicationContext;
+};
+
+export type FilterPick<T, U> = Pick<T, Exclude<keyof T, U>>;
+
 export interface MidwayMockApplication extends MockApplication {
   applicationContext: IApplicationContext;
   pluginContext: IApplicationContext;
@@ -22,6 +30,7 @@ export interface MidwayMockApplication extends MockApplication {
   getPlugin(pluginName: string): any;
   getLogger(name?: string): any;
   getConfig(key?: string): any;
+  mockContext(data?: any): MidwayMockContext;
   /**
    * Mock class function
    */

--- a/packages/midway-mock/src/interface.ts
+++ b/packages/midway-mock/src/interface.ts
@@ -1,29 +1,27 @@
-import { MockOption, MockApplication  } from 'egg-mock';
-import { ApplicationContext, IApplicationContext } from 'injection';
-
+import { MockApplication, MockOption } from 'egg-mock';
+import { IApplicationContext } from 'injection';
 
 export interface MidwayApplicationOptions extends MockOption {
-  baseDir?: string
-  framework?: string
-  plugin?: any
-  plugins?: any
-  container?: any
-  typescript?: boolean
-  worker?: number
+  baseDir?: string;
+  framework?: string;
+  plugin?: any;
+  plugins?: any;
+  container?: any;
+  typescript?: boolean;
+  worker?: number;
 }
 
 export interface MidwayMockApplication extends MockApplication {
-  applicationContext: ApplicationContext
-  pluginContext: IApplicationContext
-  appDir: string
-  baseDir: string
-  enablePlugins: any
-  getApplicationContext(): IApplicationContext
-  getPluginContext(): IApplicationContext
-  getPlugin(pluginName: string): any
-  getLogger(name?: string): any
-  getConfig(key?: string): any
-
+  applicationContext: IApplicationContext;
+  pluginContext: IApplicationContext;
+  appDir: string;
+  baseDir: string;
+  enablePlugins: any;
+  getApplicationContext(): IApplicationContext;
+  getPluginContext(): IApplicationContext;
+  getPlugin(pluginName: string): any;
+  getLogger(name?: string): any;
+  getConfig(key?: string): any;
   /**
    * Mock class function
    */
@@ -34,4 +32,3 @@ export interface MidwayMockApplication extends MockApplication {
     fnOrData: any,
   ): any
 }
-

--- a/packages/midway-mock/src/interface.ts
+++ b/packages/midway-mock/src/interface.ts
@@ -17,7 +17,12 @@ export interface MidwayMockContext extends EggContext {
   requestContext: IApplicationContext;
 }
 
-export type FilterPick<T, U> = Pick<T, Exclude<keyof T, U>>;
+export type MockClassFunctionHandler = (
+  this: MidwayMockApplication,
+  className: string,
+  methodName: string,
+  fnOrData: any,
+) => any;
 
 export interface MidwayMockApplication extends MockApplication {
   applicationContext: IApplicationContext;
@@ -31,13 +36,5 @@ export interface MidwayMockApplication extends MockApplication {
   getLogger(name?: string): any;
   getConfig(key?: string): any;
   mockContext(data?: any): MidwayMockContext;
-  /**
-   * Mock class function
-   */
-  mockClassFunction(
-    this: MidwayMockApplication,
-    className: string,
-    methodName: string,
-    fnOrData: any,
-  ): any
+  mockClassFunction: MockClassFunctionHandler; // Mock class function
 }

--- a/packages/midway-mock/src/mock.ts
+++ b/packages/midway-mock/src/mock.ts
@@ -1,6 +1,6 @@
 import * as mock from 'egg-mock';
 import { resolveModule } from 'midway-bin';
-
+import { join } from 'path';
 import { MidwayApplicationOptions, MidwayMockApplication } from './interface';
 
 export interface MidwayMock extends mock.EggMock {
@@ -26,23 +26,33 @@ export const mm = Object.assign({}, mock, {
   container: mockContainer,
 }) as MidwayMock;
 
-mm.app = (options): MidwayMockApplication => {
+mm.app = (options = {}): MidwayMockApplication => {
   if (process.env.MIDWAY_BASE_DIR && !options.baseDir) { options.baseDir = process.env.MIDWAY_BASE_DIR; }
   if (process.env.MIDWAY_FRAMEWORK_PATH && !options.framework) { options.framework = process.env.MIDWAY_FRAMEWORK_PATH; }
   // @ts-ignore
   return mock.app(Object.assign({
     framework: options.framework || getDefaultFramework(),
     typescript: !!require.extensions['.ts'],
+    plugins: {
+      'midway-mock': {
+        path: join(__dirname, '../')
+      }
+    }
   }, options));
 };
 
-mm.cluster = (options) => {
+mm.cluster = (options = {}) => {
   if (process.env.MIDWAY_BASE_DIR && !options.baseDir) { options.baseDir = process.env.MIDWAY_BASE_DIR; }
   if (process.env.MIDWAY_FRAMEWORK_PATH && !options.framework) { options.framework = process.env.MIDWAY_FRAMEWORK_PATH; }
   // @ts-ignore
   return mock.cluster(Object.assign({
     framework: options.framework || getDefaultFramework(),
     typescript: !!require.extensions['.ts'],
+    plugins: {
+      'midway-mock': {
+        path: join(__dirname, '../')
+      }
+    }
   }, options));
 };
 
@@ -50,7 +60,7 @@ export class MockContainer {
 
   app: MidwayMockApplication;
 
-  constructor(options: MidwayApplicationOptions) {
+  constructor(options: MidwayApplicationOptions = {}) {
     this.app = mm.app(options);
   }
 

--- a/packages/midway-mock/src/mock.ts
+++ b/packages/midway-mock/src/mock.ts
@@ -1,9 +1,9 @@
 import * as mock from 'egg-mock';
 import { resolveModule } from 'midway-bin';
 import { join } from 'path';
-import { MidwayApplicationOptions, MidwayMockApplication, FilterPick } from './interface';
+import { MidwayApplicationOptions, MidwayMockApplication } from './interface';
 
-export interface MidwayMock extends FilterPick<mock.EggMock, 'app' | 'cluster'> {
+export interface MidwayMock extends mock.EggMock {
   container: typeof mockContainer;
   default: mock.EggMock;
   app: (option?: MidwayApplicationOptions) => MidwayMockApplication;

--- a/packages/midway-mock/src/mock.ts
+++ b/packages/midway-mock/src/mock.ts
@@ -1,14 +1,13 @@
 import * as mock from 'egg-mock';
 import { resolveModule } from 'midway-bin';
 import { join } from 'path';
-import { MidwayApplicationOptions, MidwayMockApplication } from './interface';
+import { MidwayApplicationOptions, MidwayMockApplication, FilterPick } from './interface';
 
-export interface MidwayMock extends mock.EggMock {
+export interface MidwayMock extends FilterPick<mock.EggMock, 'app' | 'cluster'> {
   container: typeof mockContainer;
   default: mock.EggMock;
   app: (option?: MidwayApplicationOptions) => MidwayMockApplication;
   cluster: (option?: MidwayApplicationOptions) => MidwayMockApplication;
-  // [prop: string]: any
 }
 
 /**

--- a/packages/midway-mock/test/index.test.ts
+++ b/packages/midway-mock/test/index.test.ts
@@ -12,7 +12,6 @@ describe('test/index.test.ts', () => {
 
   it('should app has mockClassFunction', async () => {
     assert.ok(app.mockClassFunction && typeof app.mockClassFunction === 'function');
-
     const ts = Date.now();
     app.mockClassFunction('baseService', 'getData', () => {
       return 'mock_test' + ts;

--- a/packages/midway-mock/test/index.test.ts
+++ b/packages/midway-mock/test/index.test.ts
@@ -50,7 +50,7 @@ describe('test/index.test.ts', () => {
       framework: process.env.MIDWAY_FRAMEWORK_PATH,
     });
     await app.ready();
-    app.mockContext().
+    assert(app.mockContext().requestContext);
     assert.ok(app.mockClassFunction && typeof app.mockClassFunction === 'function');
     await app.close();
   });

--- a/packages/midway-mock/test/index.test.ts
+++ b/packages/midway-mock/test/index.test.ts
@@ -45,12 +45,14 @@ describe('test/index.test.ts', () => {
     assert(service.getData() !== 'hello' + ts);
   });
 
-  it('should use mm.app to get app', () => {
+  it('should use mm.app to get app', async () => {
     const app = mock.app({
       baseDir: process.env.MIDWAY_BASE_DIR,
       framework: process.env.MIDWAY_FRAMEWORK_PATH,
     });
-    return app.ready();
+    await app.ready();
+    assert.ok(app.mockClassFunction && typeof app.mockClassFunction === 'function');
+    await app.close();
   });
 
   it('should use mm.cluster to get app by default options', () => {

--- a/packages/midway-mock/test/index.test.ts
+++ b/packages/midway-mock/test/index.test.ts
@@ -50,6 +50,7 @@ describe('test/index.test.ts', () => {
       framework: process.env.MIDWAY_FRAMEWORK_PATH,
     });
     await app.ready();
+    app.mockContext().
     assert.ok(app.mockClassFunction && typeof app.mockClassFunction === 'function');
     await app.close();
   });

--- a/packages/midway-web/test/enhance.test.ts
+++ b/packages/midway-web/test/enhance.test.ts
@@ -32,7 +32,7 @@ describe('/test/enhance.test.ts', () => {
     it('mock context', async () => {
       const ctx = app.mockContext();
       const userService = await ctx.requestContext.getAsync('userService');
-      assert((await userService.hello()) === 'world');
+      assert((await userService.hello()) === 'world,0');
     });
 
     it('should load ts directory', done => {

--- a/packages/midway-web/test/enhance.test.ts
+++ b/packages/midway-web/test/enhance.test.ts
@@ -9,14 +9,13 @@ const rimraf = require('mz-modules/rimraf');
 import { clearAllModule } from 'injection';
 
 describe('/test/enhance.test.ts', () => {
-
   afterEach(clearAllModule);
 
   describe('load ts file', () => {
     let app;
     before(() => {
       app = utils.app('enhance/base-app', {
-        typescript: true
+        typescript: true,
       });
       return app.ready();
     });
@@ -24,10 +23,19 @@ describe('/test/enhance.test.ts', () => {
     after(() => app.close());
 
     it('should get config merge', () => {
-      assert(app.config.rundir, path.join(__dirname, './fixtures/enhance/base-app/run'));
+      assert(
+        app.config.rundir,
+        path.join(__dirname, './fixtures/enhance/base-app/run')
+      );
     });
 
-    it('should load ts directory', (done) => {
+    it('mock context', async () => {
+      const ctx = app.mockContext();
+      const userService = await ctx.requestContext.getAsync('userService');
+      assert((await userService.hello()) === 'world');
+    });
+
+    it('should load ts directory', done => {
       request(app.callback())
         .get('/api')
         .expect(200)
@@ -39,21 +47,21 @@ describe('/test/enhance.test.ts', () => {
     let app;
     before(() => {
       app = utils.app('enhance/base-app-controller', {
-        typescript: true
+        typescript: true,
       });
       return app.ready();
     });
 
     after(() => app.close());
 
-    it('should load controller from requestContext', (done) => {
+    it('should load controller from requestContext', done => {
       request(app.callback())
         .get('/api/index')
         .expect(200)
         .expect('index', done);
     });
 
-    it('should load controller use controller decorator', (done) => {
+    it('should load controller use controller decorator', done => {
       request(app.callback())
         .get('/components/')
         .expect(200)
@@ -72,20 +80,19 @@ describe('/test/enhance.test.ts', () => {
     let app;
     before(() => {
       app = utils.app('enhance/base-app-controller-default-export', {
-        typescript: true
+        typescript: true,
       });
       return app.ready();
     });
 
     after(() => app.close());
 
-    it('should load controller', (done) => {
+    it('should load controller', done => {
       request(app.callback())
         .get('/')
         .expect(200)
         .expect('root_test', done);
     });
-
   });
 
   describe('load ts class controller use decorator conflicts', () => {
@@ -94,7 +101,7 @@ describe('/test/enhance.test.ts', () => {
       let suc = false;
       try {
         app = utils.app('enhance/base-app-controller-conflicts', {
-          typescript: true
+          typescript: true,
         });
         await app.ready();
       } catch (e) {
@@ -108,21 +115,21 @@ describe('/test/enhance.test.ts', () => {
     let app;
     before(() => {
       app = utils.app('enhance/base-app-default-scope', {
-        typescript: true
+        typescript: true,
       });
       return app.ready();
     });
 
     after(() => app.close());
 
-    it('should load controller from requestContext', (done) => {
+    it('should load controller from requestContext', done => {
       request(app.callback())
         .get('/api/index')
         .expect(200)
         .expect('index', done);
     });
 
-    it('should load controller use controller decorator', (done) => {
+    it('should load controller use controller decorator', done => {
       request(app.callback())
         .get('/api/test')
         .expect(200)
@@ -134,7 +141,7 @@ describe('/test/enhance.test.ts', () => {
     let app;
     before(() => {
       app = utils.app('enhance/base-app-decorator', {
-        typescript: true
+        typescript: true,
       });
       return app.ready();
     });
@@ -144,7 +151,7 @@ describe('/test/enhance.test.ts', () => {
       app.close();
     });
 
-    it('should load ts directory', (done) => {
+    it('should load ts directory', done => {
       request(app.callback())
         .get('/api')
         .expect(200)
@@ -164,7 +171,7 @@ describe('/test/enhance.test.ts', () => {
       request(app.callback())
         .get('/config/test')
         .expect(200)
-        .expect({ a: 1, b: true, c: 2}, done);
+        .expect({ a: 1, b: true, c: 2 }, done);
 
       request(app.callback())
         .get('/config/test2')
@@ -180,12 +187,12 @@ describe('/test/enhance.test.ts', () => {
       await request(app.callback())
         .get('/param/12/test?name=1')
         .expect(200)
-        .expect({id: '12', name: '1'});
+        .expect({ id: '12', name: '1' });
 
       await request(app.callback())
         .get('/param/query?name=1')
         .expect(200)
-        .expect({name: '1'});
+        .expect({ name: '1' });
 
       await request(app.callback())
         .get('/param/query_id?id=1')
@@ -195,7 +202,7 @@ describe('/test/enhance.test.ts', () => {
       await request(app.callback())
         .get('/param/param/12/test/456')
         .expect(200)
-        .expect({id: '12', userId: '456'});
+        .expect({ id: '12', userId: '456' });
 
       await request(app.callback())
         .get('/param/param/12')
@@ -207,7 +214,7 @@ describe('/test/enhance.test.ts', () => {
         .type('form')
         .send({ id: '1' })
         .expect(200)
-        .expect({id: '1'});
+        .expect({ id: '1' });
 
       await request(app.callback())
         .get('/param/body_id')
@@ -230,21 +237,34 @@ describe('/test/enhance.test.ts', () => {
         .expect(200)
         .expect('127');
 
-      const imagePath = path.join(__dirname, 'fixtures/enhance', 'base-app-decorator', '1.jpg');
-      const imagePath1 = path.join(__dirname, 'fixtures/enhance', 'base-app-decorator', '2.jpg');
+      const imagePath = path.join(
+        __dirname,
+        'fixtures/enhance',
+        'base-app-decorator',
+        '1.jpg'
+      );
+      const imagePath1 = path.join(
+        __dirname,
+        'fixtures/enhance',
+        'base-app-decorator',
+        '2.jpg'
+      );
 
-      await app.httpRequest()
+      await app
+        .httpRequest()
         .post('/param/file')
         .field('name', 'form')
         .attach('file', imagePath)
         .expect('ok');
 
-      await app.httpRequest()
+      await app
+        .httpRequest()
         .get('/public/form.jpg')
         .expect('content-length', '16424')
         .expect(200);
 
-      await app.httpRequest()
+      await app
+        .httpRequest()
         .post('/param/files')
         .field('name1', '1')
         .attach('file1', imagePath)
@@ -253,16 +273,17 @@ describe('/test/enhance.test.ts', () => {
         .field('name3', '3')
         .expect('ok');
 
-      await app.httpRequest()
+      await app
+        .httpRequest()
         .get('/public/1.jpg')
         .expect('content-length', '16424')
         .expect(200);
 
-      await app.httpRequest()
+      await app
+        .httpRequest()
         .get('/public/2.jpg')
         .expect('content-length', '16424')
         .expect(200);
-
     });
   });
 
@@ -270,14 +291,14 @@ describe('/test/enhance.test.ts', () => {
     let app;
     before(() => {
       app = utils.app('enhance/base-app-utils', {
-        typescript: true
+        typescript: true,
       });
       return app.ready();
     });
 
     after(() => app.close());
 
-    it('should load ts directory and inject module', (done) => {
+    it('should load ts directory and inject module', done => {
       request(app.callback())
         .get('/api/test')
         .expect(200)
@@ -289,14 +310,14 @@ describe('/test/enhance.test.ts', () => {
     let app;
     before(() => {
       app = utils.app('enhance/base-app-async', {
-        typescript: true
+        typescript: true,
       });
       return app.ready();
     });
 
     after(() => app.close());
 
-    it('should load ts directory and inject module', (done) => {
+    it('should load ts directory and inject module', done => {
       request(app.callback())
         .get('/api')
         .expect(200)
@@ -304,13 +325,12 @@ describe('/test/enhance.test.ts', () => {
     });
   });
 
-  describe('ts directory different from other', function () {
-
+  describe('ts directory different from other', function() {
     let app;
     before(() => {
       mm(process.env, 'HOME', '');
       app = utils.app('enhance/base-app', {
-        typescript: true
+        typescript: true,
       });
       return app.ready();
     });
@@ -329,14 +349,14 @@ describe('/test/enhance.test.ts', () => {
     let app;
     before(() => {
       app = utils.app('enhance/base-app-constructor', {
-        typescript: true
+        typescript: true,
       });
       return app.ready();
     });
 
     after(() => app.close());
 
-    it('should load ts directory and inject in constructor', (done) => {
+    it('should load ts directory and inject in constructor', done => {
       request(app.callback())
         .get('/api')
         .expect(200)
@@ -348,14 +368,14 @@ describe('/test/enhance.test.ts', () => {
     let app;
     before(() => {
       app = utils.app('enhance/base-app-function', {
-        typescript: true
+        typescript: true,
       });
       return app.ready();
     });
 
     after(() => app.close());
 
-    it('should load ts directory and inject in constructor', (done) => {
+    it('should load ts directory and inject in constructor', done => {
       request(app.callback())
         .get('/api')
         .expect(200)
@@ -367,14 +387,14 @@ describe('/test/enhance.test.ts', () => {
     let app;
     before(() => {
       app = utils.app('enhance/base-app-router', {
-        typescript: true
+        typescript: true,
       });
       return app.ready();
     });
 
     after(() => app.close());
 
-    it('should invoke different router and get same result', (done) => {
+    it('should invoke different router and get same result', done => {
       done = pedding(3, done);
       request(app.callback())
         .get('/')
@@ -397,14 +417,14 @@ describe('/test/enhance.test.ts', () => {
     let app;
     before(() => {
       app = utils.app('enhance/base-app-router-priority', {
-        typescript: true
+        typescript: true,
       });
       return app.ready();
     });
 
     after(() => app.close());
 
-    it('should invoke different router and get same result', (done) => {
+    it('should invoke different router and get same result', done => {
       done = pedding(3, done);
       request(app.callback())
         .get('/hello')
@@ -427,14 +447,14 @@ describe('/test/enhance.test.ts', () => {
     let app;
     before(() => {
       app = utils.app('enhance/loader-duplicate', {
-        typescript: true
+        typescript: true,
       });
       return app.ready();
     });
 
     after(() => app.close());
 
-    it('should fix egg-socket.io load controller directory', (done) => {
+    it('should fix egg-socket.io load controller directory', done => {
       request(app.callback())
         .get('/')
         .expect(200)
@@ -446,46 +466,44 @@ describe('/test/enhance.test.ts', () => {
     let app;
     before(() => {
       app = utils.app('enhance/base-app-controller-tsx', {
-        typescript: true
+        typescript: true,
       });
       return app.ready();
     });
 
     after(() => app.close());
 
-    it('should load tsx controller', (done) => {
+    it('should load tsx controller', done => {
       request(app.callback())
         .get('/')
         .expect(200)
         .expect(/react/, done);
     });
-
   });
 
   describe('support middleware parameter', () => {
     let app;
     before(() => {
       app = utils.app('enhance/base-app-middleware', {
-        typescript: true
+        typescript: true,
       });
       return app.ready();
     });
 
     after(() => app.close());
 
-    it('should load middleware in controller and router', (done) => {
+    it('should load middleware in controller and router', done => {
       request(app.callback())
         .get('/')
         .expect(200)
         .expect('1111444455552224', done);
     });
 
-    it('should support multi-router in one method', (done) => {
+    it('should support multi-router in one method', done => {
       request(app.callback())
         .post('/api/data')
         .expect(200)
         .expect('11114444', done);
     });
-
   });
 });

--- a/packages/midway-web/test/fixtures/enhance/base-app/src/lib/service.ts
+++ b/packages/midway-web/test/fixtures/enhance/base-app/src/lib/service.ts
@@ -1,8 +1,11 @@
-import { Provide } from '@midwayjs/decorator';
+import { Provide, Inject } from '@midwayjs/decorator';
 
 @Provide()
 export class UserService {
+  @Inject()
+  ctx;
+
   async hello() {
-    return 'world';
+    return 'world,' + Object.keys(this.ctx.query).length;
   }
 }

--- a/packages/midway-web/test/fixtures/enhance/base-app/src/lib/service.ts
+++ b/packages/midway-web/test/fixtures/enhance/base-app/src/lib/service.ts
@@ -1,0 +1,8 @@
+import { Provide } from '@midwayjs/decorator';
+
+@Provide()
+export class UserService {
+  async hello() {
+    return 'world';
+  }
+}

--- a/packages/midway-web/test/fixtures/enhance/base-app/src/lib/service.ts
+++ b/packages/midway-web/test/fixtures/enhance/base-app/src/lib/service.ts
@@ -1,8 +1,8 @@
-import { Provide, Inject } from '@midwayjs/decorator';
+import { provide, inject } from '../../../../../../src';
 
-@Provide()
+@provide()
 export class UserService {
-  @Inject()
+  @inject()
   ctx;
 
   async hello() {


### PR DESCRIPTION
- 1、mm.app() 的默认参数可以为空
- 2、fix #433 ，mockContext() 返回合并后的 Context
- 3、fix #438 把midway-mock 增加到 egg 的 load 插件中