### PR TITLE
chore(cluster): remove printing egg versions

### DIFF
--- a/packages/midway/cluster/master.js
+++ b/packages/midway/cluster/master.js
@@ -4,11 +4,7 @@ const formatOptions = require('./utils').formatOptions;
 class Master extends EggMaster {
 
   constructor(options) {
-    options = formatOptions(options);
-    super(options);
-    this.log('[master] egg version %s, egg-core version %s',
-      require('egg/package').version,
-      require('egg-core/package').version);
+    super(formatOptions(options));
   }
 
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->
cluster

##### Description of change
<!-- Provide a description of the change below this comment. -->
The egg is not in dependencies list of midway, and it is not necessary to print egg version information in midway. It's broken on resolving modules with `npm install --legacy-bundling`.
