### PR TITLE
chore(devDeps): upgrade for eslint

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -6,10 +6,6 @@
     "bootstrap": {
       "hoist": true,
       "noCi": true,
-      "nohoist": [
-        "@typescript-eslint/eslint-plugin",
-        "@typescript-eslint/parser"
-      ],
       "npmClientArgs": [
         "--no-package-lock"
       ]

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "autocannon": "^2.4.1",
     "chalk": "^3.0.0",
     "debug": "^4.1.1",
-    "eslint": "6",
+    "eslint": "7",
     "gh-pages": "^2.2.0",
     "lerna": "^3.14.1",
     "lerna-relinker": "^1.4.0",

--- a/packages/eslint-midway-contrib/package.json
+++ b/packages/eslint-midway-contrib/package.json
@@ -34,8 +34,7 @@
   "devDependencies": {
     "@types/tape": "4",
     "eslint": "7",
-    "tape": "5",
-    "typescript": "^3.9.3"
+    "tape": "5"
   },
   "peerDependencies": {
     "eslint": ">=7.0.0"

--- a/packages/eslint-midway-contrib/package.json
+++ b/packages/eslint-midway-contrib/package.json
@@ -25,8 +25,8 @@
   "license": "MIT",
   "author": "waiting",
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "^3.0.0",
-    "@typescript-eslint/parser": "^3.0.0",
+    "@typescript-eslint/eslint-plugin": "^3.0.2",
+    "@typescript-eslint/parser": "^3.0.2",
     "eslint-plugin-import": "^2.20.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-unicorn": "^20.0.0"
@@ -35,7 +35,7 @@
     "@types/tape": "4",
     "eslint": "7",
     "tape": "5",
-    "typescript": ">=3.9"
+    "typescript": "^3.9.3"
   },
   "peerDependencies": {
     "eslint": ">=7.0.0"


### PR DESCRIPTION
- eslint
- @typescript-eslint/eslint-plugin
- @typescript-eslint/parser

lerna.json hoist not need @typescript-eslint/*
ref: https://github.com/typescript-eslint/typescript-eslint/pull/2105

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
升级 top eslint 为 v7，从而不需修改 lerna.json 添加 hoist 条目。
同时升级 typescript-eslint ，即便 eslint v6 时也不会出现无法加载 @typescript-eslint/* 插件问题。

