### PR TITLE
chore: remote node_modules for custom container loader

### DIFF
--- a/packages/midway-web/config/config.default.js
+++ b/packages/midway-web/config/config.default.js
@@ -27,7 +27,6 @@ module.exports = (appInfo) => {
 
   exports.container = {
     ignore: [
-      '**/node_modules/**',
       '**/logs/**',
       '**/run/**',
       '**/public/**',


### PR DESCRIPTION
新版本已经移除了 globby，放开 node_modules 的限制。不然老的 container 中无法加载 node_modules 的模块。