### PR TITLE
fix: add lock init for egg app

### DIFF
--- a/packages/egg-layer/framework/config/plugin.js
+++ b/packages/egg-layer/framework/config/plugin.js
@@ -5,3 +5,4 @@ exports.watcher = false;
 exports.development = false;
 exports.logrotator = false;
 exports.schedule = false;
+exports.static = false;

--- a/packages/egg-layer/test/fixtures/eaas-fc/config/plugin.js
+++ b/packages/egg-layer/test/fixtures/eaas-fc/config/plugin.js
@@ -2,6 +2,7 @@
 
 /** @type Egg.EggPlugin */
 module.exports = {
+  static: true,
   // had enabled by egg
   // static: {
   //   enable: true,

--- a/packages/egg-layer/test/fixtures/eaas-scf/config/plugin.js
+++ b/packages/egg-layer/test/fixtures/eaas-scf/config/plugin.js
@@ -2,6 +2,7 @@
 
 /** @type Egg.EggPlugin */
 module.exports = {
+  static: true,
   // had enabled by egg
   // static: {
   //   enable: true,

--- a/packages/faas-cli-command-core/src/plugin.ts
+++ b/packages/faas-cli-command-core/src/plugin.ts
@@ -31,4 +31,11 @@ export class BasePlugin implements IPluginInstance {
   public getStore(key: string, scope?: string) {
     return this.core.store.get(`${scope || this.name}:${key}`);
   }
+
+  setGlobalDependencies(name: string, version?: string) {
+    if (!this.core.service.globalDependencies) {
+      this.core.service.globalDependencies = {};
+    }
+    this.core.service.globalDependencies[name] = version || '*';
+  }
 }

--- a/packages/faas-cli-plugin-aws/src/index.ts
+++ b/packages/faas-cli-plugin-aws/src/index.ts
@@ -571,13 +571,6 @@ export class AWSLambdaPlugin extends BasePlugin {
     ]);
     return this.firstValue(values);
   }
-
-  setGlobalDependencies(name: string, version?: string) {
-    if (!this.core.service.globalDependencies) {
-      this.core.service.globalDependencies = {};
-    }
-    this.core.service.globalDependencies[name] = version || '*';
-  }
 }
 
 function sleep(sec: number) {

--- a/packages/faas-cli-plugin-fc/src/index.ts
+++ b/packages/faas-cli-plugin-fc/src/index.ts
@@ -89,12 +89,4 @@ export class AliyunFCPlugin extends BasePlugin {
     }
     return func;
   }
-
-  // 设置全局依赖，在package的时候会读取
-  setGlobalDependencies(name: string, version?: string) {
-    if (!this.core.service.globalDependencies) {
-      this.core.service.globalDependencies = {};
-    }
-    this.core.service.globalDependencies[name] = version || '*';
-  }
 }

--- a/packages/faas-cli-plugin-package/src/index.ts
+++ b/packages/faas-cli-plugin-package/src/index.ts
@@ -679,6 +679,7 @@ export class PackagePlugin extends BasePlugin {
       this.setGlobalDependencies('@midwayjs/simple-lock');
 
       if (!service.provider.initTimeout || service.provider.initTimeout < 10) {
+        // just for aliyun
         service.provider.initTimeout = 10;
       }
 

--- a/packages/faas-cli-plugin-package/src/index.ts
+++ b/packages/faas-cli-plugin-package/src/index.ts
@@ -562,10 +562,7 @@ export class PackagePlugin extends BasePlugin {
     this.core.cli.log('Aggregation Deploy');
 
     // use picomatch to match url
-    if (!this.core.service.globalDependencies) {
-      this.core.service.globalDependencies = {};
-    }
-    this.core.service.globalDependencies['picomatch'] = '*';
+    this.setGlobalDependencies('picomatch');
     const allAggregationPaths = [];
     let allFuncNames = Object.keys(this.core.service.functions);
     for (const aggregationName in this.core.service.aggregation) {
@@ -678,6 +675,13 @@ export class PackagePlugin extends BasePlugin {
     const service: any = this.core.service;
     if (service?.deployType) {
       this.core.cli.log(` - found deployType: ${service?.deployType}`);
+
+      this.setGlobalDependencies('@midwayjs/simple-lock');
+
+      if (!service.provider.initTimeout || service.provider.initTimeout < 10) {
+        service.provider.initTimeout = 10;
+      }
+
       // add default function
       if (!service.functions || Object.keys(service.functions).length === 0) {
         this.core.cli.log(' - create default functions');

--- a/packages/faas-cli-plugin-package/test/package-app.test.ts
+++ b/packages/faas-cli-plugin-package/test/package-app.test.ts
@@ -40,6 +40,11 @@ describe('/test/package-a[[.test.ts', () => {
           readFileSync(join(buildPath, 'f.yml')).toString('utf8')
         )
       );
+      assert(
+        /initTimeout: 10/.test(
+          readFileSync(join(buildPath, 'f.yml')).toString('utf8')
+        )
+      );
     });
   });
 });

--- a/packages/faas-cli-plugin-scf/src/index.ts
+++ b/packages/faas-cli-plugin-scf/src/index.ts
@@ -89,14 +89,6 @@ export class TencentSCFPlugin extends BasePlugin {
     return func;
   }
 
-  // 设置全局依赖，在package的时候会读取
-  setGlobalDependencies(name: string, version?: string) {
-    if (!this.core.service.globalDependencies) {
-      this.core.service.globalDependencies = {};
-    }
-    this.core.service.globalDependencies[name] = version || '*';
-  }
-
   async getTencentServerless(artifact) {
     Object.assign(
       this.core.service,

--- a/packages/serverless-spec-builder/wrapper_app.ejs
+++ b/packages/serverless-spec-builder/wrapper_app.ejs
@@ -1,4 +1,6 @@
 const { asyncWrapper, start } = require('<%=starter %>');
+const SimpleLock  = require('@midwayjs/simple-lock').default;
+const lock = new SimpleLock();
 const layers = [];
 <% layerDeps.forEach(function(layer){ %>
 try {
@@ -11,10 +13,12 @@ let runtime;
 let inited = false;
 
 const initializeMethod = async (initializeContext = {}) => {
-  runtime = await start({
-    layers: layers,
-    isAppMode: true
-  });
+  return lock.sureOnce(async () => {
+    runtime = await start({
+      layers: layers,
+      isAppMode: true
+    });
+  }, 'APP_START_LOCK_KEY');
 };
 
 exports.<%=initializer%> = asyncWrapper(async (...args) => {


### PR DESCRIPTION
app（egg） 迁移方案会不知道为何在冷启动时初始化多次。报错如下：

```json
{
    "errorMessage": "EMFILE: too many open files, open '/code/package.json'",
    "errorType": "Error",
    "stackTrace": [
        "at openSync (fs.js:457:3)",
        "at readFileSync (fs.js:359:35)",
        "at exports.readJSONSync (/code/node_modules/utility/lib/json.js:19:24)",
        "at EggLoader (/code/node_modules/egg-core/lib/loader/egg_loader.js:45:24)",
        "at AgentWorkerLoader (/code/node_modules/@midwayjs/egg-layer/node_modules/egg/lib/loader/agent_worker_loader.js:9:1)",
        "at EggCore (/code/node_modules/egg-core/lib/egg.js:118:19)",
        "at EggApplication (/code/node_modules/@midwayjs/egg-layer/node_modules/egg/lib/egg.js:46:5)",
        "at Agent (/code/node_modules/@midwayjs/egg-layer/node_modules/egg/lib/agent.js:22:5)",
        "at LayerWrapper (/code/node_modules/@midwayjs/egg-layer/framework/index.js:8:12)",
        "at module.exports (/code/node_modules/@midwayjs/egg-layer/node_modules/egg/lib/start.js:31:17)"
    ]
}
```

猜测原因：

- 1、初始化超时（报错），导致在 invoke 时并发又进行初始化
- 2、fc 并发调用 initializer，比如配置了单实例多并发（概率小，因为默认是单实例，每次也只会有一个流量进来）
- 3、框架运行时未调用 initializer 方法初始化，而是从 invoke 初始化（测试了下排除）

Action：

- 1、发现 egg 启动，如果默认开了 static 插件，导致会往目录结构里写文件（app/public)，导致报错，默认禁用 static
- 2、加入初始化方法锁
- 3、延长初始化时间（3s -> 10s），只对支持 initTimeout 的有效