### PR TITLE
chore: backup orginal yml file

### DIFF
--- a/packages/faas-cli-plugin-package/src/index.ts
+++ b/packages/faas-cli-plugin-package/src/index.ts
@@ -215,7 +215,7 @@ export class PackagePlugin extends BasePlugin {
     const packageObj: any = this.core.service.package || {};
     // backup original yml file
     await copy(
-      resolve(this.core.config.specFile.path),
+      this.core.config.specFile.path,
       resolve(this.midwayBuildPath, './f.origin.yml')
     );
     this.core.cli.log(

--- a/packages/faas-cli-plugin-package/src/index.ts
+++ b/packages/faas-cli-plugin-package/src/index.ts
@@ -214,8 +214,16 @@ export class PackagePlugin extends BasePlugin {
     // copy packages config files
     const packageObj: any = this.core.service.package || {};
     // backup original yml file
-    await copy(resolve(this.core.config.specFile.path), resolve(this.midwayBuildPath, './f.origin.yml') );
-    this.core.cli.log(`   - Copy ${this.core.config.specFile.path.replace(`${this.servicePath}/`, '')} to ${'f.origin.yml'}`);
+    await copy(
+      resolve(this.core.config.specFile.path),
+      resolve(this.midwayBuildPath, './f.origin.yml')
+    );
+    this.core.cli.log(
+      `   - Copy ${this.core.config.specFile.path.replace(
+        `${this.servicePath}/`,
+        ''
+      )} to ${'f.origin.yml'}`
+    );
     await copyFiles({
       sourceDir: this.servicePath,
       targetDir: this.midwayBuildPath,

--- a/packages/faas-cli-plugin-package/src/index.ts
+++ b/packages/faas-cli-plugin-package/src/index.ts
@@ -213,6 +213,9 @@ export class PackagePlugin extends BasePlugin {
     this.core.cli.log('Copy Files to build directory...');
     // copy packages config files
     const packageObj: any = this.core.service.package || {};
+    // backup original yml file
+    await copy(resolve(this.core.config.specFile.path), resolve(this.midwayBuildPath, './f.origin.yml') );
+    this.core.cli.log(`   - Copy ${this.core.config.specFile.path.replace(`${this.servicePath}/`, '')} to ${'f.origin.yml'}`);
     await copyFiles({
       sourceDir: this.servicePath,
       targetDir: this.midwayBuildPath,

--- a/packages/faas-cli-plugin-package/test/package.test.ts
+++ b/packages/faas-cli-plugin-package/test/package.test.ts
@@ -38,6 +38,7 @@ describe('/test/package.test.ts', () => {
       assert(existsSync(join(buildPath, 'copy.js')));
       assert(existsSync(join(buildPath, 'tsconfig.json')));
       assert(existsSync(resolve(baseDir, 'serverless.zip')));
+      assert(existsSync(join(buildPath, 'f.origin.yml')));
     });
     it('build target package', async () => {
       const core = new CommandHookCore({


### PR DESCRIPTION
close #634 
由于发布到 serverless 平台时会根据具体的平台来生成最终的serverless.yml文件与原yml文件格式内容不一致导致一些运行时的具体逻辑判断失效。所以需要额外保留一份原本的yml文件，这里统一命名为 `f.origin.yml`