### PR TITLE
fix: component inject global object and add case

### DIFF
--- a/packages/bootstrap/package.json
+++ b/packages/bootstrap/package.json
@@ -21,9 +21,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@midwayjs/cli": "^1.0.0"
-  },
-  "dependencies": {
+    "@midwayjs/cli": "^1.0.0",
     "@midwayjs/core": "^2.3.9"
   },
   "author": "Harry Chen <czy88840616@gmail.com>",

--- a/packages/core/jest.config.js
+++ b/packages/core/jest.config.js
@@ -1,0 +1,7 @@
+const path = require('path');
+
+module.exports = {
+  preset: 'ts-jest',
+  testPathIgnorePatterns: ['<rootDir>/test/fixtures'],
+  coveragePathIgnorePatterns: ['<rootDir>/test/'],
+};

--- a/packages/core/src/context/applicationContext.ts
+++ b/packages/core/src/context/applicationContext.ts
@@ -104,6 +104,8 @@ export class ObjectDefinitionRegistry
 export class BaseApplicationContext
   implements IApplicationContext, IObjectFactory {
   protected readied = false;
+  // 自己内部实现的，可注入的 feature(见 features)
+  protected midwayIdentifiers: string[] = [];
   private _resolverFactory: ManagedResolverFactory = null;
   private _registry: IObjectDefinitionRegistry = null;
   private _props: ObjectProperties = null;

--- a/packages/core/src/context/configuration.ts
+++ b/packages/core/src/context/configuration.ts
@@ -161,7 +161,7 @@ export class ContainerConfiguration implements IContainerConfiguration {
       debug('   add loadDir => "%s".', loadDir);
       debug('   add namespace => "%s".', this.namespace);
     }
-    debug('   has configuration file => %s.', configuration ? true : false);
+    debug('   has configuration file => %s.', !!configuration);
     this.loadConfiguration(configuration, packageBaseDir, cfgFile);
   }
 
@@ -237,7 +237,10 @@ export class ContainerConfiguration implements IContainerConfiguration {
       namespace: this.namespace,
       srcPath: filePath,
     });
-    saveModule(CONFIGURATION_KEY, clzz);
+    saveModule(CONFIGURATION_KEY, {
+      target: clzz,
+      namespace: this.namespace,
+    });
   }
 
   getImportDirectory() {

--- a/packages/core/src/context/container.ts
+++ b/packages/core/src/context/container.ts
@@ -22,8 +22,6 @@ const globalDebugLogger = util.debuglog('midway:container');
 export class Container extends BaseApplicationContext implements IContainer {
   id = Math.random().toString(10).slice(-5);
   debugLogger = globalDebugLogger;
-  // 自己内部实现的，可注入的 feature(见 features)
-  protected midwayIdentifiers: string[] = [];
   bind<T>(target: T, options?: ObjectDefinitionOptions): void;
   bind<T>(
     identifier: ObjectIdentifier,

--- a/packages/core/src/context/managedResolverFactory.ts
+++ b/packages/core/src/context/managedResolverFactory.ts
@@ -450,7 +450,7 @@ export class ManagedResolverFactory {
 
     // for request scope
     if (definition.isRequestScope() && definition.id) {
-      this.context.registry.registerObject(definition.id, inst);
+      this.context.registerObject(definition.id, inst, false);
     }
     this.removeCreateStatus(definition, true);
 
@@ -567,7 +567,7 @@ export class ManagedResolverFactory {
     // for request scope
     if (definition.isRequestScope() && definition.id) {
       debug('id = %s set to register object', definition.id);
-      this.context.registry.registerObject(definition.id, inst);
+      this.context.registerObject(definition.id, inst, false);
     }
     this.removeCreateStatus(definition, true);
 

--- a/packages/core/src/context/midwayContainer.ts
+++ b/packages/core/src/context/midwayContainer.ts
@@ -93,7 +93,6 @@ export class MidwayContainer extends Container implements IMidwayContainer {
   }) {
     // 添加全局白名单
     this.midwayIdentifiers.push(PIPELINE_IDENTIFIER);
-    this.midwayIdentifiers.push(REQUEST_CTX_KEY);
 
     this.debugLogger('main:create "Main Module" and "Main Configuration"');
     // create main module configuration
@@ -213,6 +212,13 @@ export class MidwayContainer extends Container implements IMidwayContainer {
       this.debugLogger('  @scope => request');
       objectDefinition.scope = ScopeEnum.Request;
     }
+  }
+
+  registerObject(identifier: ObjectIdentifier, target: any, registerByUser = true) {
+    if (registerByUser) {
+      this.midwayIdentifiers.push(identifier);
+    }
+    return super.registerObject(identifier, target);
   }
 
   createConfiguration(): IContainerConfiguration {
@@ -407,7 +413,7 @@ export class MidwayContainer extends Container implements IMidwayContainer {
 
     this.registerImportObjects(
       containerConfiguration.getImportObjects(),
-      containerConfiguration.namespace
+      containerConfiguration.namespace,
     );
   }
 

--- a/packages/core/src/context/midwayContainer.ts
+++ b/packages/core/src/context/midwayContainer.ts
@@ -441,7 +441,7 @@ export class MidwayContainer extends Container implements IMidwayContainer {
          */
         await inst.onReady(new Proxy(this, {
           get: function (target, prop, receiver) {
-            if (prop === 'getCurrentNamespace' && cycle.namespace) {
+            if (prop === 'getCurrentNamespace' && cycle.namespace && cycle.namespace !== MAIN_MODULE_KEY) {
               return () => {
                 return cycle.namespace;
               }

--- a/packages/core/src/context/midwayContainer.ts
+++ b/packages/core/src/context/midwayContainer.ts
@@ -220,7 +220,16 @@ export class MidwayContainer extends Container implements IMidwayContainer {
       this.midwayIdentifiers.push(identifier);
     }
     if (this?.getCurrentNamespace()) {
-      identifier = this.getCurrentNamespace() + ':' + identifier;
+      if (this?.getCurrentNamespace() === MAIN_MODULE_KEY) {
+        // 如果是 main，则同步 alias 到所有的 namespace
+        for (const value of this.configurationMap.values()) {
+          if (value.namespace !== MAIN_MODULE_KEY) {
+            super.registerObject(value.namespace + ':' + identifier, target);
+          }
+        }
+      } else {
+        identifier = this.getCurrentNamespace() + ':' + identifier;
+      }
     }
     return super.registerObject(identifier, target);
   }
@@ -441,7 +450,7 @@ export class MidwayContainer extends Container implements IMidwayContainer {
          */
         await inst.onReady(new Proxy(this, {
           get: function (target, prop, receiver) {
-            if (prop === 'getCurrentNamespace' && cycle.namespace && cycle.namespace !== MAIN_MODULE_KEY) {
+            if (prop === 'getCurrentNamespace' && cycle.namespace) {
               return () => {
                 return cycle.namespace;
               }

--- a/packages/core/src/interface.ts
+++ b/packages/core/src/interface.ts
@@ -148,7 +148,7 @@ export interface IApplicationContext extends IObjectFactory {
   dependencyMap: Map<string, ObjectDependencyTree>;
   ready(): Promise<void>;
   stop(): Promise<void>;
-  registerObject(identifier: ObjectIdentifier, target: any);
+  registerObject(identifier: ObjectIdentifier, target: any, registerByUser?: boolean);
 }
 /**
  * 解析内部管理的属性、json、ref等实例的解析器

--- a/packages/core/test/context/requestContainer.test.ts
+++ b/packages/core/test/context/requestContainer.test.ts
@@ -206,7 +206,7 @@ describe('/test/context/requestContainer.test.ts', () => {
     expect((one.autoScaleService as any).scaleManager.ts).eq('scale');
   });
 
-  it('test getService in requestContainer', () => {
+  it('test getService in requestContainer', async () => {
     const appCtx = new Container();
     // 合并 egg config
     const configService = appCtx.getConfigService();
@@ -214,7 +214,8 @@ describe('/test/context/requestContainer.test.ts', () => {
       name: 'zhangting',
     });
     appCtx.bind(GatewayManager);
-    appCtx.ready();
+    await appCtx.ready();
+
     const ctx1 = { a: 1 };
     const container = new RequestContainer(ctx1, appCtx);
     const defaultConfig = container.getConfigService().getConfiguration();

--- a/packages/core/test/fixtures/app-with-configuration-global-inject/base-app-decorator/package.json
+++ b/packages/core/test/fixtures/app-with-configuration-global-inject/base-app-decorator/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "ali-demo"
+}

--- a/packages/core/test/fixtures/app-with-configuration-global-inject/base-app-decorator/src/configuration.ts
+++ b/packages/core/test/fixtures/app-with-configuration-global-inject/base-app-decorator/src/configuration.ts
@@ -6,6 +6,7 @@ import { Configuration } from '@midwayjs/decorator';
   ],
 })
 export class AutoConfiguration {
-  async onReady() {
+  async onReady(container) {
+    container.registerObject('ccc', 'dddd');
   }
 }

--- a/packages/core/test/fixtures/app-with-configuration-global-inject/base-app-decorator/src/configuration.ts
+++ b/packages/core/test/fixtures/app-with-configuration-global-inject/base-app-decorator/src/configuration.ts
@@ -1,0 +1,11 @@
+import { Configuration } from '@midwayjs/decorator';
+
+@Configuration({
+  imports: [
+    '../../sql/',
+  ],
+})
+export class AutoConfiguration {
+  async onReady() {
+  }
+}

--- a/packages/core/test/fixtures/app-with-configuration-global-inject/sql/package.json
+++ b/packages/core/test/fixtures/app-with-configuration-global-inject/sql/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "bbb",
+  "main": "src/index"
+}

--- a/packages/core/test/fixtures/app-with-configuration-global-inject/sql/src/configuration.ts
+++ b/packages/core/test/fixtures/app-with-configuration-global-inject/sql/src/configuration.ts
@@ -10,7 +10,8 @@ export class ContainerLifeCycle {
   @Inject()
   baseDir;
 
-  async onReady() {
+  async onReady(container) {
     console.log('---', this.baseDir);
+    container.registerObject('aaa', 'bbbb');
   }
 }

--- a/packages/core/test/fixtures/app-with-configuration-global-inject/sql/src/configuration.ts
+++ b/packages/core/test/fixtures/app-with-configuration-global-inject/sql/src/configuration.ts
@@ -1,0 +1,16 @@
+// src/configuration.ts
+import { Configuration, Inject } from '@midwayjs/decorator';
+
+@Configuration({
+  imports: [],
+  namespace: 'SQL',
+})
+export class ContainerLifeCycle {
+
+  @Inject()
+  baseDir;
+
+  async onReady() {
+    console.log('---', this.baseDir);
+  }
+}

--- a/packages/core/test/fixtures/app-with-configuration-global-inject/sql/src/home.ts
+++ b/packages/core/test/fixtures/app-with-configuration-global-inject/sql/src/home.ts
@@ -1,0 +1,11 @@
+import { Inject, Provide } from '@midwayjs/decorator';
+
+@Provide()
+export class Home {
+  @Inject()
+  baseDir: string;
+
+  async getData() {
+    return this.baseDir;
+  }
+}

--- a/packages/core/test/fixtures/app-with-configuration-global-inject/sql/src/home.ts
+++ b/packages/core/test/fixtures/app-with-configuration-global-inject/sql/src/home.ts
@@ -6,9 +6,12 @@ export class Home {
   baseDir: string;
 
   @Inject()
-  aaa;
+  aaa;      // 当前组件注册的属性
+
+  @Inject()
+  ccc;      // 全局注入的属性
 
   async getData() {
-    return this.baseDir + '/' + this.aaa;
+    return this.baseDir + '/' + this.aaa + '/' + this.ccc;
   }
 }

--- a/packages/core/test/fixtures/app-with-configuration-global-inject/sql/src/home.ts
+++ b/packages/core/test/fixtures/app-with-configuration-global-inject/sql/src/home.ts
@@ -5,7 +5,10 @@ export class Home {
   @Inject()
   baseDir: string;
 
+  @Inject()
+  aaa;
+
   async getData() {
-    return this.baseDir;
+    return this.baseDir + '/' + this.aaa;
   }
 }

--- a/packages/core/test/loader.test.ts
+++ b/packages/core/test/loader.test.ts
@@ -629,6 +629,6 @@ describe('/test/loader.test.ts', () => {
     await loader.refresh();
 
     const home: any = await loader.getApplicationContext().getAsync('SQL:home');
-    expect(await home.getData()).toMatch(/base-app-decorator\/src/);
+    expect(await home.getData()).toMatch(/base-app-decorator\/src\/bbbb/);
   });
 });

--- a/packages/core/test/loader.test.ts
+++ b/packages/core/test/loader.test.ts
@@ -352,10 +352,7 @@ describe('/test/loader.test.ts', () => {
     assert((await replaceManager2.getOne()) === 'ok3');
     // 查看覆盖的情况
     const baseService: any = await appCtx.getAsync('baseService');
-    assert(
-      (await baseService.getInformation()) ===
-        'harryone article atmod,one article,ok3'
-    );
+    expect(await baseService.getInformation()).toEqual( 'harryone article atmod,one article,ok3');
 
     assert(baseService.helloworld === 234);
 
@@ -618,5 +615,20 @@ describe('/test/loader.test.ts', () => {
     expect(home.hello()).toEqual('hello worlddddfff');
     expect(await home.hello1()).toEqual('hello world 1');
     expect(await home.hello2()).toEqual('hello worldcccppp');
-  })
+  });
+
+  it('should inject global value in component', async () => {
+    const loader = new ContainerLoader({
+      baseDir: path.join(
+        __dirname,
+        './fixtures/app-with-configuration-global-inject/base-app-decorator/src'
+      )
+    });
+    loader.initialize();
+    loader.loadDirectory();
+    await loader.refresh();
+
+    const home: any = await loader.getApplicationContext().getAsync('SQL:home');
+    expect(await home.getData()).toMatch(/base-app-decorator\/src/);
+  });
 });

--- a/packages/core/test/loader.test.ts
+++ b/packages/core/test/loader.test.ts
@@ -629,6 +629,6 @@ describe('/test/loader.test.ts', () => {
     await loader.refresh();
 
     const home: any = await loader.getApplicationContext().getAsync('SQL:home');
-    expect(await home.getData()).toMatch(/base-app-decorator\/src\/bbbb/);
+    expect(await home.getData()).toMatch(/base-app-decorator\/src\/bbbb\/dddd/);
   });
 });

--- a/packages/faas/jest.config.js
+++ b/packages/faas/jest.config.js
@@ -1,0 +1,7 @@
+const path = require('path');
+
+module.exports = {
+  preset: 'ts-jest',
+  testPathIgnorePatterns: ['<rootDir>/test/fixtures'],
+  coveragePathIgnorePatterns: ['<rootDir>/test/'],
+};

--- a/packages/faas/package.json
+++ b/packages/faas/package.json
@@ -2,7 +2,7 @@
   "name": "@midwayjs/faas",
   "version": "2.3.9",
   "main": "dist/index",
-  "typings": "index.d.ts",
+  "typings": "dist/index.d.ts",
   "dependencies": {
     "@midwayjs/core": "^2.3.9",
     "@midwayjs/decorator": "^2.3.9",

--- a/packages/faas/test/index.test.ts
+++ b/packages/faas/test/index.test.ts
@@ -64,7 +64,7 @@ describe('test/index.test.ts', () => {
     await closeApp(starter);
   });
 
-  it('invoke handler by default name', async () => {
+  it('invoke handler by another name', async () => {
     const starter = await creatStarter('base-app-route');
     const data = await starter.handleInvokeWrapper('deploy.handler9')(
       {

--- a/packages/mock/package.json
+++ b/packages/mock/package.json
@@ -32,12 +32,12 @@
   "license": "MIT",
   "devDependencies": {
     "@midwayjs/cli": "^1.0.0",
+    "@midwayjs/core": "^2.3.9",
     "@types/amqplib": "^0.5.13",
     "amqplib": "^0.6.0"
   },
   "dependencies": {
     "@midwayjs/bootstrap": "^2.3.9",
-    "@midwayjs/core": "^2.3.9",
     "@midwayjs/decorator": "^2.3.9",
     "egg-mock": "^3.21.0",
     "fs-extra": "^8.0.1",

--- a/packages/mock/src/utils.ts
+++ b/packages/mock/src/utils.ts
@@ -30,6 +30,7 @@ export async function create<
   options?: U,
   customFrameworkName?: string | MidwayFrameworkType | object
 ): Promise<T> {
+  process.env.MIDWAY_TS_MODE = 'true';
   clearAllModule();
   let framework: T = null;
   let DefaultFramework = null;

--- a/packages/web/test/.setup.js
+++ b/packages/web/test/.setup.js
@@ -1,5 +1,4 @@
 const path = require('path');
 
-process.env.MIDWAY_TS_MODE = 'true';
 process.env.MIDWAY_EGG_PLUGIN_PATH = path.join(__dirname, '../../../');
 jest.setTimeout(30000);


### PR DESCRIPTION
在手动调用 registerObject 的时候把 key 存起来，bind 的时候判断是否增加前缀。修复在组件中注入baseDir等找不到对象的问题。

- [x] 全局注入 baseDir/appDir
- [x] 全局注入 onReady 中 registerObject 的对象
- [x] 组件注入组件自己 onReady 中 registerObject 的对象
- [x] 组件注入全局的 baseDir/appDir
- [x] 组件注入 Main 中 onReady 中 registerObject 的对象