### PR TITLE
fix: when middleware config options is undefined. options.enable expr…

### DIFF
--- a/packages/web/app.js
+++ b/packages/web/app.js
@@ -39,7 +39,7 @@ class AppBootHook {
       } else {
         // egg
         const options = this.app.config[name];
-        if (options.enable === false) {
+        if (options && options.enable === false) {
           continue;
         }
         // support options.match and options.ignore


### PR DESCRIPTION
When middleware config options is undefined. options.enable expression will be error occurred

@czy88840616 