### PR TITLE
refactor: modify the implementation of aspect

### DIFF
--- a/packages/core/src/baseFramework.ts
+++ b/packages/core/src/baseFramework.ts
@@ -14,7 +14,6 @@ import {
   CONFIGURATION_KEY,
   getProviderId,
   listModule,
-  listPreloadModule,
 } from '@midwayjs/decorator';
 import { isAbsolute, join } from 'path';
 
@@ -136,8 +135,6 @@ export abstract class BaseFramework<
     await this.applicationContext.ready();
     // lifecycle 支持
     await this.loadLifeCycles();
-    // 预加载模块支持
-    await this.loadPreloadModule();
   }
 
   protected async containerStop() {
@@ -263,19 +260,6 @@ export abstract class BaseFramework<
           })
         );
       }
-    }
-  }
-
-  /**
-   * load preload module for container
-   * @private
-   */
-  private async loadPreloadModule() {
-    // some common decorator implementation
-    const modules = listPreloadModule();
-    for (const module of modules) {
-      // preload init context
-      await this.getApplicationContext().getAsync(module);
     }
   }
 }

--- a/packages/core/src/context/midwayContainer.ts
+++ b/packages/core/src/context/midwayContainer.ts
@@ -24,6 +24,7 @@ import {
   getClassMetadata,
   ASPECT_KEY,
   listPreloadModule,
+  isProxy,
 } from '@midwayjs/decorator';
 import { ContainerConfiguration } from './configuration';
 import { FUNCTION_INJECT_KEY } from '../common/constants';
@@ -844,7 +845,7 @@ export class MidwayContainer
    */
   protected wrapperAspectToInstance(ins) {
     let proxy = null;
-    if (ins?.constructor) {
+    if (!isProxy(ins) && ins?.constructor) {
       // 动态处理拦截器
       let methodAspectCollection;
       if (this.aspectMappingMap?.has(ins.constructor)) {

--- a/packages/core/src/context/midwayContainer.ts
+++ b/packages/core/src/context/midwayContainer.ts
@@ -21,6 +21,8 @@ import {
   getConstructorInject,
   TAGGED_PROP,
   getObjectDefProps,
+  getClassMetadata,
+  ASPECT_KEY,
 } from '@midwayjs/decorator';
 import { ContainerConfiguration } from './configuration';
 import { FUNCTION_INJECT_KEY } from '../common/constants';
@@ -75,12 +77,13 @@ export class MidwayContainer
   private likeMainConfiguration: IContainerConfiguration[] = [];
   public configService: IConfigService;
   public environmentService: IEnvironmentService;
+  private aspectMappingMap: WeakMap<object, Map<string, any[]>>;
+  private aspectModuleSet: Set<any>;
 
   /**
    * 单个进程中上一次的 applicationContext 的 registry
    */
   static parentDefinitionMetadata: Map<string, IObjectDefinitionMetadata[]>;
-  static wrapperAspect = false;
 
   constructor(baseDir: string = process.cwd(), parent?: IApplicationContext) {
     super(baseDir, parent);
@@ -92,6 +95,9 @@ export class MidwayContainer
   }
 
   init(): void {
+    this.aspectMappingMap = new WeakMap();
+    this.aspectModuleSet = new Set();
+
     this.initService();
 
     this.resolverHandler = new ResolverHandler(
@@ -500,103 +506,6 @@ export class MidwayContainer
     return '';
   }
 
-  public async addAspect(aspectIns: IMethodAspect, aspectData: AspectMetadata) {
-    const module = aspectData.aspectTarget;
-    const names = Object.getOwnPropertyNames(module.prototype);
-    const isMatch = aspectData.match ? pm(aspectData.match) : () => true;
-
-    for (const name of names) {
-      if (name === 'constructor' || !isMatch(name)) {
-        continue;
-      }
-      const descriptor = Object.getOwnPropertyDescriptor(
-        module.prototype,
-        name
-      );
-      if (!descriptor || descriptor.writable === false) {
-        continue;
-      }
-      let originMethod = descriptor.value;
-      if (isAsyncFunction(originMethod)) {
-        this.debugLogger(
-          `aspect [#${module.name}:${name}], isAsync=true, aspect class=[${aspectIns.constructor.name}]`
-        );
-        descriptor.value = async function (...args) {
-          let error, result;
-          const newProceed = (...args) => {
-            return originMethod.apply(this, args);
-          }
-          const joinPoint = {
-            methodName: name,
-            target: this,
-            args: args,
-            proceed: newProceed,
-          };
-          try {
-            await aspectIns.before?.(joinPoint);
-            if (aspectIns.around) {
-              result = await aspectIns.around(joinPoint);
-            } else {
-              result = await originMethod.apply(this, joinPoint.args);
-            }
-            joinPoint.proceed = undefined;
-            const resultTemp = await aspectIns.afterReturn?.(joinPoint, result);
-            result = typeof resultTemp === 'undefined' ? result : resultTemp;
-            return result;
-          } catch (err) {
-            joinPoint.proceed = undefined;
-            error = err;
-            if (aspectIns.afterThrow) {
-              await aspectIns.afterThrow(joinPoint, error);
-            } else {
-              throw err;
-            }
-          } finally {
-            await aspectIns.after?.(joinPoint, result, error);
-          }
-        };
-      } else {
-        this.debugLogger(
-          `aspect [#${module.name}:${name}], isAsync=false, aspect class=[${aspectIns.constructor.name}]`
-        );
-        descriptor.value = function (...args) {
-          let error, result;
-          const newProceed = (...args) => {
-            return originMethod.apply(this, args);
-          }
-          const joinPoint = {
-            methodName: name,
-            target: this,
-            args: args,
-            proceed: newProceed,
-          };
-          try {
-            aspectIns.before?.(joinPoint);
-            if (aspectIns.around) {
-              result = aspectIns.around(joinPoint);
-            } else {
-              result = originMethod.apply(this, joinPoint.args);
-            }
-            const resultTemp = aspectIns.afterReturn?.(joinPoint, result);
-            result = typeof resultTemp === 'undefined' ? result : resultTemp;
-            return result;
-          } catch (err) {
-            error = err;
-            if (aspectIns.afterThrow) {
-              aspectIns.afterThrow(joinPoint, error);
-            } else {
-              throw err;
-            }
-          } finally {
-            aspectIns.after?.(joinPoint, result, error);
-          }
-        };
-      }
-
-      Object.defineProperty(module.prototype, name, descriptor);
-    }
-  }
-
   resolve<T>(target: T): T {
     const tempContainer = new MidwayContainer();
     tempContainer.bind<T>(target);
@@ -615,7 +524,25 @@ export class MidwayContainer
     if (typeof identifier !== 'string') {
       identifier = this.getIdentifier(identifier);
     }
-    return super.getAsync<T>(identifier, args);
+    const ins: any = await super.getAsync<T>(identifier, args);
+    if (this.aspectMappingMap.has(ins.__proto__.constructor)) {
+      // 动态处理拦截器
+      const methodAspectCollection = this.aspectMappingMap.get(ins.__proto__.constructor);
+      for (let [method, aspectFn] of methodAspectCollection) {
+        const descriptor = Object.getOwnPropertyDescriptor(
+          ins,
+          method
+        );
+
+        // 拦截器方法已经合并过了
+        if (aspectFn.length === 1) {
+          descriptor.value = aspectFn[0](descriptor.value);
+        } else {
+          throw new Error('Aspect length error, length = ' + aspectFn.length);
+        }
+      }
+    }
+    return ins;
   }
 
   protected getIdentifier(target: any) {
@@ -628,6 +555,8 @@ export class MidwayContainer
       // 加载配置
       await this.configService.load();
     }
+
+    await this.loadAspect();
   }
 
   async stop(): Promise<void> {
@@ -740,5 +669,187 @@ export class MidwayContainer
 
   public getResolverHandler() {
     return this.resolverHandler;
+  }
+
+
+  /**
+   * load aspect method for container
+   * @private
+   */
+  private async loadAspect() {
+    // for aop implementation
+    const aspectModules = listModule(ASPECT_KEY);
+    // sort for aspect target
+    let aspectDataList = [];
+    for (const module of aspectModules) {
+      const data = getClassMetadata(ASPECT_KEY, module);
+      aspectDataList = aspectDataList.concat(
+        data.map(el => {
+          el.aspectModule = module;
+          return el;
+        })
+      );
+    }
+
+    // sort priority
+    aspectDataList.sort((pre, next) => {
+      return (next.priority || 0) - (pre.priority || 0);
+    });
+
+    for (const aspectData of aspectDataList) {
+      const aspectIns = await this.getAsync<
+        IMethodAspect
+        >(aspectData.aspectModule);
+      await this.addAspect(aspectIns, aspectData);
+    }
+
+    // 合并拦截器方法，提升性能
+    for (let module of this.aspectModuleSet) {
+      const aspectMapping = this.aspectMappingMap.get(module);
+      for (let [method, aspectFn] of aspectMapping) {
+        let result = (originMethod) => {
+          if (isAsyncFunction(originMethod)) {
+            return async (...args) => {
+              return originMethod.call(this, args);
+            }
+          } else {
+            return (...args) => {
+              return originMethod.call(this, args);
+            }
+          }
+        };
+        for (const fn of aspectFn) {
+          result = fn(result);
+        }
+        aspectMapping.set(method, [result]);
+      }
+    }
+  }
+
+
+  public async addAspect(aspectIns: IMethodAspect, aspectData: AspectMetadata) {
+    const module = aspectData.aspectTarget;
+    const names = Object.getOwnPropertyNames(module.prototype);
+    const isMatch = aspectData.match ? pm(aspectData.match) : () => true;
+
+    // 存到 set 里用来做循环
+    this.aspectModuleSet.add(module);
+
+    /**
+     * 拦截器流程
+     * 1、在每个被拦截的 class 上做拦截标记，记录哪些方法需要被拦截
+     * 2、Container 保存每个 class 的方法对应的拦截器数组
+     * 3、创建完实例后，在返回前执行包裹逻辑，把需要拦截的方法都执行一遍拦截（不对原型做修改）
+     */
+
+    for (const name of names) {
+      if (name === 'constructor' || !isMatch(name)) {
+        continue;
+      }
+      const descriptor = Object.getOwnPropertyDescriptor(
+        module.prototype,
+        name
+      );
+      if (!descriptor || descriptor.writable === false) {
+        continue;
+      }
+
+      // 把拦截器和当前容器绑定
+      if (!this.aspectMappingMap.has(module)) {
+        this.aspectMappingMap.set(module, new Map());
+      }
+
+      const mappingMap = this.aspectMappingMap.get(module);
+      if (!mappingMap.has(name)) {
+        mappingMap.set(name, []);
+      }
+      // 把拦截器本身加到数组中
+      const methodAspectCollection = mappingMap.get(name);
+
+      if (isAsyncFunction(descriptor.value)) {
+        this.debugLogger(
+          `aspect [#${module.name}:${name}], isAsync=true, aspect class=[${aspectIns.constructor.name}]`
+        );
+
+        const fn = (originMethod) => {
+          return async (...args) => {
+            let error, result;
+            const newProceed = (...args) => {
+              return originMethod.apply(this, args);
+            }
+            const joinPoint = {
+              methodName: name,
+              target: this,
+              args: args,
+              proceed: newProceed,
+            };
+            try {
+              await aspectIns.before?.(joinPoint);
+              if (aspectIns.around) {
+                result = await aspectIns.around(joinPoint);
+              } else {
+                result = await originMethod.apply(this, joinPoint.args);
+              }
+              joinPoint.proceed = undefined;
+              const resultTemp = await aspectIns.afterReturn?.(joinPoint, result);
+              result = typeof resultTemp === 'undefined' ? result : resultTemp;
+              return result;
+            } catch (err) {
+              joinPoint.proceed = undefined;
+              error = err;
+              if (aspectIns.afterThrow) {
+                await aspectIns.afterThrow(joinPoint, error);
+              } else {
+                throw err;
+              }
+            } finally {
+              await aspectIns.after?.(joinPoint, result, error);
+            }
+          };
+        }
+
+        methodAspectCollection.push(fn);
+      } else {
+        this.debugLogger(
+          `aspect [#${module.name}:${name}], isAsync=false, aspect class=[${aspectIns.constructor.name}]`
+        );
+        const fn = (originMethod) => {
+          return (...args) => {
+            let error, result;
+            const newProceed = (...args) => {
+              return originMethod.apply(this, args);
+            }
+            const joinPoint = {
+              methodName: name,
+              target: this,
+              args: args,
+              proceed: newProceed,
+            };
+            try {
+              aspectIns.before?.(joinPoint);
+              if (aspectIns.around) {
+                result = aspectIns.around(joinPoint);
+              } else {
+                result = originMethod.apply(this, joinPoint.args);
+              }
+              const resultTemp = aspectIns.afterReturn?.(joinPoint, result);
+              result = typeof resultTemp === 'undefined' ? result : resultTemp;
+              return result;
+            } catch (err) {
+              error = err;
+              if (aspectIns.afterThrow) {
+                aspectIns.afterThrow(joinPoint, error);
+              } else {
+                throw err;
+              }
+            } finally {
+              aspectIns.after?.(joinPoint, result, error);
+            }
+          };
+        }
+
+        methodAspectCollection.push(fn);
+      }
+    }
   }
 }

--- a/packages/core/src/context/requestContainer.ts
+++ b/packages/core/src/context/requestContainer.ts
@@ -50,10 +50,11 @@ export class MidwayRequestContainer extends MidwayContainer {
         definition.id === PIPELINE_IDENTIFIER
       ) {
         // create object from applicationContext definition for requestScope
-        return this.getManagedResolverFactory().create({
+        const ins = this.getManagedResolverFactory().create({
           definition,
           args,
         });
+        return this.wrapperAspectToInstance(ins);
       }
     }
 
@@ -86,31 +87,7 @@ export class MidwayRequestContainer extends MidwayContainer {
           definition,
           args,
         });
-
-        let proxy = null;
-        if (
-          ins?.constructor &&
-          (this.parent as IMidwayContainer).aspectMappingMap.has(
-            ins.constructor
-          )
-        ) {
-          // 动态处理拦截器
-          const methodAspectCollection = (this
-            .parent as IMidwayContainer).aspectMappingMap.get(ins.constructor);
-          proxy = new Proxy(ins, {
-            get: (obj, prop) => {
-              if (
-                typeof prop === 'string' &&
-                methodAspectCollection.has(prop)
-              ) {
-                const aspectFn = methodAspectCollection.get(prop);
-                return aspectFn[0](ins, obj[prop]);
-              }
-              return obj[prop];
-            },
-          });
-        }
-        return proxy || ins;
+        return this.wrapperAspectToInstance(ins);
       }
     }
 

--- a/packages/core/src/interface.ts
+++ b/packages/core/src/interface.ts
@@ -231,7 +231,6 @@ export interface IResolverHandler {
 }
 
 export interface IMidwayContainer extends IApplicationContext {
-  aspectMappingMap;
   load(opts: {
     loadDir: string | string[];
     pattern?: string | string[];

--- a/packages/core/src/interface.ts
+++ b/packages/core/src/interface.ts
@@ -231,6 +231,7 @@ export interface IResolverHandler {
 }
 
 export interface IMidwayContainer extends IApplicationContext {
+  aspectMappingMap;
   load(opts: {
     loadDir: string | string[];
     pattern?: string | string[];

--- a/packages/core/src/loader.ts
+++ b/packages/core/src/loader.ts
@@ -1,13 +1,9 @@
 import * as path from 'path';
 import { MidwayContainer } from './context/midwayContainer';
 import {
-  ASPECT_KEY,
   CONFIGURATION_KEY,
-  getClassMetadata,
   getProviderId,
-  IMethodAspect,
   listModule,
-  listPreloadModule,
 } from '@midwayjs/decorator';
 import { ILifeCycle, IMidwayContainer } from './interface';
 
@@ -92,39 +88,6 @@ export class ContainerLoader {
   async refresh() {
     await this.applicationContext.ready();
     await this.loadLifeCycles();
-
-    // some common decorator implementation
-    const modules = listPreloadModule();
-    for (const module of modules) {
-      // preload init context
-      await this.getApplicationContext().getAsync(module);
-    }
-
-    // for aop implementation
-    const aspectModules = listModule(ASPECT_KEY);
-    // sort for aspect target
-    let aspectDataList = [];
-    for (const module of aspectModules) {
-      const data = getClassMetadata(ASPECT_KEY, module);
-      aspectDataList = aspectDataList.concat(
-        data.map(el => {
-          el.aspectModule = module;
-          return el;
-        })
-      );
-    }
-
-    // sort priority
-    aspectDataList.sort((pre, next) => {
-      return (next.priority || 0) - (pre.priority || 0);
-    });
-
-    for (const aspectData of aspectDataList) {
-      const aspectIns = await this.getApplicationContext().getAsync<
-        IMethodAspect
-      >(aspectData.aspectModule);
-      await this.getApplicationContext().addAspect(aspectIns, aspectData);
-    }
   }
 
   async stop() {

--- a/packages/core/src/loader.ts
+++ b/packages/core/src/loader.ts
@@ -1,8 +1,10 @@
 import * as path from 'path';
 import { MidwayContainer } from './context/midwayContainer';
 import {
-  ASPECT_KEY, CONFIGURATION_KEY,
-  getClassMetadata, getProviderId,
+  ASPECT_KEY,
+  CONFIGURATION_KEY,
+  getClassMetadata,
+  getProviderId,
   IMethodAspect,
   listModule,
   listPreloadModule,

--- a/packages/core/test/baseFramework.test.ts
+++ b/packages/core/test/baseFramework.test.ts
@@ -52,7 +52,6 @@ describe('/test/baseFramework.test.ts', () => {
   beforeEach(() => {
     clearAllModule();
     MidwayContainer.parentDefinitionMetadata = null;
-    MidwayContainer.wrapperAspect = false;
   });
 
   it.skip('should load js directory and auto disable', async () => {

--- a/packages/core/test/fixtures/base-app-aspect/src/aspect/a.ts
+++ b/packages/core/test/fixtures/base-app-aspect/src/aspect/a.ts
@@ -1,10 +1,12 @@
 import { Aspect, IMethodAspect, JoinPoint, Provide } from '@midwayjs/decorator';
 import { Home } from '../home';
+import * as assert from 'assert';
 
 @Provide()
 @Aspect([Home])
 export class MyAspect1 implements IMethodAspect {
   before(point: JoinPoint): any {
+    assert.ok(this instanceof MyAspect1);
     console.log('change args in aspect1');
     point.args = ['ddd', 'cccc'];
   }

--- a/packages/core/test/fixtures/base-app-aspect/src/aspect/b.ts
+++ b/packages/core/test/fixtures/base-app-aspect/src/aspect/b.ts
@@ -1,16 +1,19 @@
 import { Aspect, IMethodAspect, JoinPoint, Provide } from '@midwayjs/decorator';
-import { Home } from "../home";
+import { Home } from '../home';
+import * as assert from 'assert';
 
 @Provide()
 @Aspect([Home], '*2', 1)
 export class MyAspect2 implements IMethodAspect {
 
   async before(point: JoinPoint) {
+    assert.ok(this instanceof MyAspect2);
     console.log('change args in aspect2');
     point.args = ['ccc', 'ppp']
   }
 
   async around(point: JoinPoint) {
+    assert.ok(this instanceof MyAspect2);
     console.log('before around in aspect2');
     const data = await point.proceed(...point.args);
     console.log('after around in aspect2');

--- a/packages/core/test/fixtures/base-app-aspect/src/aspect/c.ts
+++ b/packages/core/test/fixtures/base-app-aspect/src/aspect/c.ts
@@ -1,10 +1,12 @@
 import { Aspect, IMethodAspect, JoinPoint, Provide } from '@midwayjs/decorator';
 import { UserController } from '../home';
+import * as assert from 'assert';
 
 @Provide()
 @Aspect([UserController])
 export class MyAspect3 implements IMethodAspect {
   afterThrow(point: JoinPoint, err): any {
+    assert.ok(this instanceof MyAspect3);
     if (err.message === 'bbb') {
       throw new Error('ccc');
     }

--- a/packages/core/test/loader.test.ts
+++ b/packages/core/test/loader.test.ts
@@ -21,7 +21,6 @@ describe('/test/loader.test.ts', () => {
   beforeEach(() => {
     clearAllModule();
     MidwayContainer.parentDefinitionMetadata = null;
-    MidwayContainer.wrapperAspect = false;
   });
   it('should create new loader', async () => {
     const loader = new ContainerLoader({

--- a/packages/decorator/src/util/index.ts
+++ b/packages/decorator/src/util/index.ts
@@ -50,6 +50,22 @@ export function isNumber(value) {
   return typeof value === 'number';
 }
 
+export function isProxy(value) {
+  return util.types.isProxy(value);
+}
+
+export function isMap(value) {
+  return util.types.isMap(value);
+}
+
+export function isSet(value) {
+  return util.types.isSet(value);
+}
+
+export function isRegExp(value) {
+  return util.types.isRegExp(value);
+}
+
 export function sleep(sleepTime = 1000) {
   return new Promise(resolve => {
     setTimeout(() => {

--- a/packages/decorator/src/web/requestMapping.ts
+++ b/packages/decorator/src/web/requestMapping.ts
@@ -75,10 +75,12 @@ const createMappingDecorator = (method: string) => (
     description?: string;
   } = { middleware: [] }
 ): MethodDecorator => {
-  return RequestMapping(Object.assign(routerOptions, {
-    requestMethod: method,
-    path,
-  }));
+  return RequestMapping(
+    Object.assign(routerOptions, {
+      requestMethod: method,
+      path,
+    })
+  );
 };
 
 /**

--- a/packages/mock/src/utils.ts
+++ b/packages/mock/src/utils.ts
@@ -34,7 +34,6 @@ export async function create<
   process.env.MIDWAY_TS_MODE = 'true';
   clearAllModule();
   MidwayContainer.parentDefinitionMetadata = null;
-  MidwayContainer.wrapperAspect = false;
   let framework: T = null;
   let DefaultFramework = null;
 

--- a/packages/web/jest.config.js
+++ b/packages/web/jest.config.js
@@ -6,4 +6,5 @@ module.exports = {
   testPathIgnorePatterns: ['<rootDir>/test/fixtures'],
   coveragePathIgnorePatterns: ['<rootDir>/test/'],
   setupFilesAfterEnv: [path.join(__dirname, 'test/.setup.js')],
+  forceExit: true,
 };

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -6,8 +6,8 @@
   "typings": "dist/index.d.ts",
   "scripts": {
     "build": "midway-bin build -c",
-    "test": "midway-bin test --ts --forceExit",
-    "cov": "midway-bin cov --ts --forceExit",
+    "test": "midway-bin test --ts",
+    "cov": "midway-bin cov --ts",
     "link": "npm link"
   },
   "keywords": [

--- a/packages/web/test/fixtures/issue/base-app-aspect-throw/src/aspect/testThrow.ts
+++ b/packages/web/test/fixtures/issue/base-app-aspect-throw/src/aspect/testThrow.ts
@@ -1,10 +1,12 @@
 import { Aspect, IMethodAspect, JoinPoint, Provide } from '@midwayjs/decorator';
 import { UserController } from '../controller/User';
+import * as assert from 'assert';
 
 @Provide()
 @Aspect(UserController, 'api')
 export class ReportInfo implements IMethodAspect {
   async afterThrow(point: JoinPoint, err) {
+    assert.ok(this instanceof ReportInfo);
     point.target.ctx.status = 200;
     point.target.ctx.body = 'hello';
   }
@@ -14,6 +16,7 @@ export class ReportInfo implements IMethodAspect {
 @Aspect(UserController, 'do*')
 export class ReportInfo1 implements IMethodAspect {
   async around(point: JoinPoint) {
+    assert.ok(this instanceof ReportInfo1);
     const result = await point.proceed(...point.args);  // 执行原方法
     return result + ' world';
   }

--- a/packages/web/test/fixtures/issue/base-app-aspect-throw/src/controller/User.ts
+++ b/packages/web/test/fixtures/issue/base-app-aspect-throw/src/controller/User.ts
@@ -1,4 +1,5 @@
 import { Controller, Get, Provide, Inject } from '@midwayjs/decorator';
+import * as assert from 'assert';
 
 @Provide()
 @Controller('/api/user')
@@ -8,11 +9,13 @@ export class UserController {
 
   @Get('/info')
   async api() {
+    assert.ok(this instanceof UserController);
     throw new Error('bbb');
   }
 
   @Get('/ctx_bind')
   async doTestCtxBind() {
+    assert.ok(this instanceof UserController);
     return this.ctx.query.text;
   }
 }


### PR DESCRIPTION
使用新的方法重构拦截器。老的修改 descriptor.value，直接改到原型上，新的绑定到容器上，每个容器进行了隔离，理论上老的方案对性能影响较小，但是无法做到隔离性，以及注入会有问题，新的方案，虽然对性能有些影响，但是更干净，隔离性和注入也都没问题。

做个benchmark。

- 每个 case 做10次，平均对比
- 前 5 次老的先执行，后 5 次新的先执行

**普通情况下（不拦截）**

<table>
<tr>
	<th>old
	<td>303,837 ops/sec ±1.51%
	<td>301,375 ops/sec ±1.60%
	<td>292,021 ops/sec ±1.35%
	<td>303,102 ops/sec ±0.65%
	<td>296,131 ops/sec ±1.25%
	<td>307,447 ops/sec ±0.95%
	<td>279,391 ops/sec ±0.65%
	<td>284,551 ops/sec ±5.90%
	<td>303,720 ops/sec ±1.19%
	<td>278,311 ops/sec ±1.57% 
<tr>
	<th>new
	<td>287,145 ops/sec ±1.47%
	<td>282,594 ops/sec ±0.61%
	<td>281,689 ops/sec ±2.36% 
	<td>292,187 ops/sec ±0.53%
	<td>288,832 ops/sec ±0.66%
	<td>291,384 ops/sec ±0.66%
	<td>280,037 ops/sec ±11.77%
	<td>276,774 ops/sec ±1.92%
	<td>289,160 ops/sec ±0.99%
	<td>292,276 ops/sec ±0.74%
</table>

**一个拦截器**

<table>
<tr>
	<th>old
	<td>305,395 ops/sec ±1.96%
	<td>297,242 ops/sec ±0.62%
	<td>305,653 ops/sec ±0.97%
	<td>290,445 ops/sec ±0.90%
	<td>302,247 ops/sec ±0.71%
	<td>296,101 ops/sec ±0.63%
	<td>299,792 ops/sec ±0.72%
	<td>293,836 ops/sec ±1.60%
	<td>288,431 ops/sec ±0.65%
	<td>292,846 ops/sec ±1.84%
<tr>
	<th>new
	<td>284,489 ops/sec ±0.56%
	<td>282,883 ops/sec ±0.73%
	<td>288,193 ops/sec ±0.80%
	<td>281,882 ops/sec ±0.76%
	<td>289,624 ops/sec ±0.66%
	<td>275,419 ops/sec ±0.72%
	<td>293,986 ops/sec ±0.66%
	<td>289,457 ops/sec ±0.63%
	<td>284,601 ops/sec ±0.74%
	<td>286,446 ops/sec ±0.71% 
</table>

**两个拦截器**

<table>
<tr>
	<th>old
	<td>302,846 ops/sec ±0.69%
	<td>293,136 ops/sec ±0.63%
	<td>288,999 ops/sec ±0.63%
	<td>302,102 ops/sec ±0.74%
	<td>306,716 ops/sec ±0.60%
	<td>292,082 ops/sec ±0.60%
	<td>296,496 ops/sec ±0.85%
	<td>269,102 ops/sec ±5.35%
	<td>292,933 ops/sec ±1.19%
	<td>304,441 ops/sec ±0.85%
<tr>
	<th>new
	<td>288,645 ops/sec ±0.66%
	<td>282,980 ops/sec ±0.66%
	<td>287,829 ops/sec ±0.91%
	<td>292,715 ops/sec ±0.87%
	<td>287,143 ops/sec ±1.63%
	<td>284,371 ops/sec ±1.05%
	<td>277,521 ops/sec ±0.74%
	<td>248,870 ops/sec ±7.06%
	<td>276,878 ops/sec ±1.27%
	<td>267,813 ops/sec ±12.18%
</table>


结论，新版拦截器实现性能在创建时影响约在 3% 左右，拦截器的数量增长对创建时的性能损耗不是很明显。
