### PR TITLE
恢复 this.ctx.body = 'body' 用法

### DIFF
--- a/packages/web-express/src/framework.ts
+++ b/packages/web-express/src/framework.ts
@@ -132,9 +132,7 @@ export class MidwayExpressFramework extends BaseFramework<
       const controller = await req.requestContext.getAsync(controllerId);
       // eslint-disable-next-line prefer-spread
       const result = await controller[methodName].apply(controller, args);
-      if (res.statusCode === 200 && (result === null || result === undefined)) {
-        res.status(204);
-      }
+
       // implement response decorator
       if (Array.isArray(routerResponseData) && routerResponseData.length) {
         for (const routerRes of routerResponseData) {
@@ -154,7 +152,10 @@ export class MidwayExpressFramework extends BaseFramework<
           }
         }
       }
-      res.send(result);
+
+      if (result) {
+        res.send(result);
+      }
     };
   }
 

--- a/packages/web-express/test/fixtures/base-app/src/controller/api.ts
+++ b/packages/web-express/test/fixtures/base-app/src/controller/api.ts
@@ -45,11 +45,7 @@ export class APIController {
     return 'hello world,' + name;
   }
 
-  @Get('/204')
-  async status204() {
-    // empty
-  }
-
+  
   @Get('/login')
   @Redirect('/')
   async redirect() {

--- a/packages/web-express/test/index.test.ts
+++ b/packages/web-express/test/index.test.ts
@@ -34,11 +34,6 @@ describe('/test/feature.test.ts', () => {
       expect(result.status).toBe(302);
     });
 
-    it('test get status 204', async () => {
-      const result = await createHttpRequest(app).get('/204');
-      console.log('result.status', result.status);
-      expect(result.status).toBe(204);
-    });
   });
 
 });

--- a/packages/web-koa/src/framework.ts
+++ b/packages/web-koa/src/framework.ts
@@ -80,7 +80,10 @@ export abstract class MidwayKoaBaseFramework<
       }
       const controller = await ctx.requestContext.getAsync(controllerId);
       // eslint-disable-next-line prefer-spread
-      ctx.body = await controller[methodName].apply(controller, args);
+      const result = await controller[methodName].apply(controller, args);
+      if (result) {
+        ctx.body = result;
+      }
 
       // implement response decorator
       if (Array.isArray(routerResponseData) && routerResponseData.length) {

--- a/packages/web-koa/test/fixtures/base-app/src/controller/api.ts
+++ b/packages/web-koa/test/fixtures/base-app/src/controller/api.ts
@@ -41,11 +41,6 @@ export class APIController {
     return 'hello world,' + name + age;
   }
 
-  @Get('/204')
-  async status204() {
-    // empty
-  }
-
   @Get('/login')
   @Redirect('/')
   async redirect() {}

--- a/packages/web-koa/test/index.test.ts
+++ b/packages/web-koa/test/index.test.ts
@@ -34,10 +34,6 @@ describe('/test/feature.test.ts', () => {
       expect(result.status).toBe(302);
     });
 
-    it('test get status 204', async () => {
-      const result = await createHttpRequest(app).get('/204');
-      expect(result.status).toBe(204);
-    });
   });
 
 });

--- a/packages/web/test/feature.test.ts
+++ b/packages/web/test/feature.test.ts
@@ -22,11 +22,6 @@ describe('/test/feature.test.ts', () => {
       expect(result.headers['ccc']).toEqual('ddd');
     });
 
-    it('test get status 204', async () => {
-      const result = await createHttpRequest(app).get('/204');
-      expect(result.status).toEqual(204);
-    });
-
     it('test get method with return value', async () => {
       const result = await createHttpRequest(app)
         .get('/')

--- a/packages/web/test/fixtures/feature/base-app/src/controller/api.ts
+++ b/packages/web/test/fixtures/feature/base-app/src/controller/api.ts
@@ -46,9 +46,4 @@ export class APIController {
   async redirect() {
   }
 
-  @Get('/204')
-  async r204() {
-    //
-  }
-
 }


### PR DESCRIPTION
#736 v2.5.0 的修改导致this.ctx.body = 'body' 这种用法失效。恢复上个版本的写法，支持this.ctx.body = 'body' 。
@czy88840616  