### PR TITLE
fix: return ctx.body and set header after send

### DIFF
--- a/packages/web-express/src/framework.ts
+++ b/packages/web-express/src/framework.ts
@@ -132,6 +132,12 @@ export class MidwayExpressFramework extends BaseFramework<
       const controller = await req.requestContext.getAsync(controllerId);
       // eslint-disable-next-line prefer-spread
       const result = await controller[methodName].apply(controller, args);
+
+      if (res.headersSent) {
+        // return when response send
+        return;
+      }
+
       if (res.statusCode === 200 && (result === null || result === undefined)) {
         res.status(204);
       }

--- a/packages/web-express/test/fixtures/base-app/src/controller/api.ts
+++ b/packages/web-express/test/fixtures/base-app/src/controller/api.ts
@@ -55,4 +55,9 @@ export class APIController {
   async redirect() {
   }
 
+  @Get('/ctx-body')
+  async getCtxBody() {
+    this.ctx.res.send('ctx-body');
+  }
+
 }

--- a/packages/web-express/test/index.test.ts
+++ b/packages/web-express/test/index.test.ts
@@ -39,6 +39,11 @@ describe('/test/feature.test.ts', () => {
       console.log('result.status', result.status);
       expect(result.status).toBe(204);
     });
+
+    it('test get data with ctx.body', async () => {
+      const result = await createHttpRequest(app).get('/ctx-body');
+      expect(result.text).toEqual('ctx-body');
+    });
   });
 
 });

--- a/packages/web-koa/src/framework.ts
+++ b/packages/web-koa/src/framework.ts
@@ -80,7 +80,14 @@ export abstract class MidwayKoaBaseFramework<
       }
       const controller = await ctx.requestContext.getAsync(controllerId);
       // eslint-disable-next-line prefer-spread
-      ctx.body = await controller[methodName].apply(controller, args);
+      const result = await controller[methodName].apply(controller, args);
+      if (result) {
+        ctx.body = result;
+      }
+
+      if (!ctx.body) {
+        ctx.body = undefined;
+      }
 
       // implement response decorator
       if (Array.isArray(routerResponseData) && routerResponseData.length) {

--- a/packages/web-koa/test/fixtures/base-app/src/controller/api.ts
+++ b/packages/web-koa/test/fixtures/base-app/src/controller/api.ts
@@ -49,4 +49,9 @@ export class APIController {
   @Get('/login')
   @Redirect('/')
   async redirect() {}
+
+  @Get('/ctx-body')
+  async getCtxBody() {
+    this.ctx.body = 'ctx-body';
+  }
 }

--- a/packages/web-koa/test/index.test.ts
+++ b/packages/web-koa/test/index.test.ts
@@ -38,6 +38,11 @@ describe('/test/feature.test.ts', () => {
       const result = await createHttpRequest(app).get('/204');
       expect(result.status).toBe(204);
     });
+
+    it('test get data with ctx.body', async () => {
+      const result = await createHttpRequest(app).get('/ctx-body');
+      expect(result.text).toEqual('ctx-body');
+    });
   });
 
 });

--- a/packages/web/test/feature.test.ts
+++ b/packages/web/test/feature.test.ts
@@ -39,6 +39,11 @@ describe('/test/feature.test.ts', () => {
       const result = await createHttpRequest(app).get('/login');
       expect(result.status).toEqual(302);
     });
+
+    it('test get data with ctx.body', async () => {
+      const result = await createHttpRequest(app).get('/ctx-body');
+      expect(result.text).toEqual('ctx-body');
+    });
   });
 
   it('should test global use midway middleware id in egg', async () => {

--- a/packages/web/test/fixtures/feature/base-app/src/controller/api.ts
+++ b/packages/web/test/fixtures/feature/base-app/src/controller/api.ts
@@ -51,4 +51,8 @@ export class APIController {
     //
   }
 
+  @Get('/ctx-body')
+  async getCtxBody() {
+    this.ctx.body = 'ctx-body';
+  }
 }


### PR DESCRIPTION
fix: #736  @wang-ran

- koa 当手动设置了 body，返回为空的时候，必须显示调用 set body
- express 提前调用 send 之后 不能设置任何头或者再次 send 了