### PR TITLE
fix: definition for getAsync and get

### DIFF
--- a/packages/core/src/context/applicationContext.ts
+++ b/packages/core/src/context/applicationContext.ts
@@ -179,7 +179,9 @@ export class BaseApplicationContext
     return false;
   }
 
-  get<T>(identifier: ObjectIdentifier, args?: any): T {
+  get<T>(identifier: { new (): T }, args?: any): T;
+  get<T>(identifier: ObjectIdentifier, args?: any): T;
+  get(identifier: any, args?: any): any {
     // 因为在这里拿不到类名, NotFoundError 类的错误信息在 ManagedResolverFactory.ts createAsync 方法中增加错误类名
     identifier = parsePrefix(identifier);
 
@@ -197,7 +199,7 @@ export class BaseApplicationContext
         throw new Error(`${identifier} must use getAsync`);
       }
 
-      return this.parent.get<T>(identifier, args);
+      return this.parent.get(identifier, args);
     }
     if (!definition) {
       throw new NotFoundError(identifier);
@@ -205,7 +207,9 @@ export class BaseApplicationContext
     return this.getManagedResolverFactory().create({ definition, args });
   }
 
-  async getAsync<T>(identifier: ObjectIdentifier, args?: any): Promise<T> {
+  async getAsync<T>(identifier: { new (): T }, args?: any): Promise<T>;
+  async getAsync<T>(identifier: ObjectIdentifier, args?: any): Promise<T>;
+  async getAsync(identifier: any, args?: any): Promise<any> {
     // 因为在这里拿不到类名, NotFoundError 类的错误信息在 ManagedResolverFactory.ts createAsync 方法中增加错误类名
     identifier = parsePrefix(identifier);
 
@@ -215,7 +219,7 @@ export class BaseApplicationContext
 
     const definition = this.registry.getDefinition(identifier);
     if (!definition && this.parent) {
-      return this.parent.getAsync<T>(identifier, args);
+      return this.parent.getAsync(identifier, args);
     }
 
     if (!definition) {

--- a/packages/core/src/interface.ts
+++ b/packages/core/src/interface.ts
@@ -34,7 +34,9 @@ export interface IMessageSource {
 export interface IObjectFactory {
   registry: IObjectDefinitionRegistry;
   isAsync(identifier: ObjectIdentifier): boolean;
+  get<T>(identifier: new () => T, args?: any): T;
   get<T>(identifier: ObjectIdentifier, args?: any): T;
+  getAsync<T>(identifier: new () => T, args?: any): Promise<T>;
   getAsync<T>(identifier: ObjectIdentifier, args?: any): Promise<T>;
 }
 /**

--- a/packages/core/test/fixtures/fun_sample.ts
+++ b/packages/core/test/fixtures/fun_sample.ts
@@ -45,13 +45,13 @@ export class AliSingleton {
 }
 
 export async function singletonFactory(context: IApplicationContext) {
-  const inst = await context.getAsync('aliSingleton');
-  return (inst as AliSingleton).getInstance();
+  const inst = await context.getAsync(AliSingleton);
+  return inst.getInstance();
 }
 
 export async function singletonFactory2(context: IApplicationContext) {
   return async () => {
-    const inst = await context.getAsync('aliSingleton');
-    return (inst as AliSingleton).getInstance();
+    const inst = await context.getAsync<AliSingleton>('aliSingleton');
+    return inst.getInstance();
   };
 }

--- a/packages/midway/src/index.ts
+++ b/packages/midway/src/index.ts
@@ -13,7 +13,6 @@ export const VERSION = require('../package.json').version;
  */
 export const RELEASE = 'WANDA';
 
-
 /**
  * @deprecated Please use IWebMiddleware instead
  */


### PR DESCRIPTION
增加 get 和 getAsync 的类参数定义支持。现在参数为 class 拿到的返回值，可以被正确推导出类型。