### PR TITLE
fix: definition fix for getLogger and getCoreLogger

### DIFF
--- a/packages-serverless/egg-layer/index.js
+++ b/packages-serverless/egg-layer/index.js
@@ -13,7 +13,7 @@ module.exports = engine => {
     async beforeRuntimeStart(runtime) {
       let framework = '';
       const baseDir = runtime.getPropertyParser().getEntryDir();
-      // 从 packagejson 中获取 egg 框架
+      // 从 package.json 中获取 egg 框架
       const packageJSON = require(resolve(baseDir, 'package.json'));
       framework = packageJSON.egg && packageJSON.egg.framework;
       const localFrameWorkPath = resolve(__dirname, 'framework');

--- a/packages/core/src/baseFramework.ts
+++ b/packages/core/src/baseFramework.ts
@@ -265,7 +265,7 @@ export abstract class BaseFramework<
         return this.getCoreLogger();
       },
 
-      getLogger: (name: string) => {
+      getLogger: (name?: string) => {
         return this.getLogger(name);
       },
 

--- a/packages/core/src/baseFramework.ts
+++ b/packages/core/src/baseFramework.ts
@@ -261,6 +261,10 @@ export abstract class BaseFramework<
         return MidwayProcessTypeEnum.APPLICATION;
       },
 
+      getCoreLogger: () => {
+        return this.getCoreLogger();
+      },
+
       getLogger: (name: string) => {
         return this.getLogger(name);
       },

--- a/packages/core/src/interface.ts
+++ b/packages/core/src/interface.ts
@@ -300,7 +300,8 @@ export interface IMidwayApplication {
   getProcessType(): MidwayProcessTypeEnum;
   getApplicationContext(): IMidwayContainer;
   getConfig(key?: string): any;
-  getLogger(key?: string): ILogger;
+  getLogger(name?: string): ILogger;
+  getCoreLogger(): ILogger;
   createLogger(name: string, options: LoggerOptions): ILogger;
   getProjectName(): string;
 }
@@ -346,7 +347,7 @@ export interface IMidwayFramework<APP extends IMidwayApplication, T extends ICon
   getFrameworkType(): MidwayFrameworkType;
   getAppDir(): string;
   getBaseDir(): string;
-  getLogger(): ILogger;
+  getLogger(name?: string): ILogger;
   getCoreLogger(): ILogger;
   createLogger(name: string, options: LoggerOptions): ILogger;
   getProjectName(): string;

--- a/packages/core/test/baseFramework.test.ts
+++ b/packages/core/test/baseFramework.test.ts
@@ -581,6 +581,8 @@ describe('/test/baseFramework.test.ts', () => {
     });
     expect(framework.getApplication().getLogger()).toEqual(framework.getLogger());
     expect(framework.getApplication().getLogger('coreLogger')).toEqual(framework.getLogger('coreLogger'));
+    expect(framework.getApplication().getCoreLogger()).toEqual(framework.getLogger('coreLogger'));
+    expect(framework.getApplication().getCoreLogger()).toEqual(framework.getCoreLogger());
     expect(framework.getApplication().getLogger('logger')).toEqual(framework.getLogger('logger'));
     expect(framework.getApplication().getLogger('otherLogger')).not.toBeNull();
     expect(framework.getApplication().getLogger('otherLogger')).toEqual(framework.getLogger('otherLogger'));

--- a/packages/faas/src/framework.ts
+++ b/packages/faas/src/framework.ts
@@ -7,6 +7,7 @@ import {
 } from './interface';
 import {
   BaseFramework,
+  createMidwayLogger,
   getClassMetadata,
   IMiddleware,
   IMidwayBootstrapOptions,
@@ -22,7 +23,7 @@ import { FUNC_KEY, LOGGER_KEY, PLUGIN_KEY } from '@midwayjs/decorator';
 import SimpleLock from '@midwayjs/simple-lock';
 import * as compose from 'koa-compose';
 import { MidwayHooks } from './hooks';
-import { loggers } from '@midwayjs/logger';
+import { LoggerOptions, loggers } from '@midwayjs/logger';
 
 const LOCK_KEY = '_faas_starter_start_key';
 
@@ -328,6 +329,14 @@ export class MidwayFaaSFramework extends BaseFramework<
   }
 
   async applicationInitialize(options: IMidwayBootstrapOptions) {}
+
+  public createLogger(name: string, option: LoggerOptions = {}) {
+    // 覆盖基类的创建日志对象，函数场景下的日志，即使自定义，也只启用控制台输出
+    return createMidwayLogger(this, name, Object.assign(option, {
+      disableFile: true,
+      disableError: true,
+    }));
+  }
 }
 
 function covertId(cls, method) {

--- a/packages/logger/src/container.ts
+++ b/packages/logger/src/container.ts
@@ -64,4 +64,9 @@ export class MidwayLoggerContainer extends Map<string, ILogger> {
   updateContainerOption(options: LoggerOptions) {
     this.containerOptions = Object.assign(this.containerOptions, options);
   }
+
+  reset() {
+    this.close();
+    this.containerOptions = {};
+  }
 }

--- a/packages/logger/src/container.ts
+++ b/packages/logger/src/container.ts
@@ -2,9 +2,17 @@ import { ILogger, LoggerOptions } from './interface';
 import { MidwayBaseLogger } from './logger';
 
 export class MidwayLoggerContainer extends Map<string, ILogger> {
+
+  private containerOptions: LoggerOptions;
+
+  constructor(options: LoggerOptions = {}) {
+    super();
+    this.containerOptions = options;
+  }
+
   createLogger(name: string, options: LoggerOptions): ILogger {
     if (!this.has(name)) {
-      const logger = new MidwayBaseLogger(options);
+      const logger = new MidwayBaseLogger(Object.assign(options, this.containerOptions));
       this.addLogger(name, logger);
       this.set(name, logger);
       return logger;
@@ -51,5 +59,9 @@ export class MidwayLoggerContainer extends Map<string, ILogger> {
     }
 
     Array.from(this.keys()).forEach(key => this.removeLogger(key));
+  }
+
+  updateContainerOption(options: LoggerOptions) {
+    this.containerOptions = Object.assign(this.containerOptions, options);
   }
 }

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -28,5 +28,5 @@ export const createConsoleLogger = (
 };
 
 export const clearAllLoggers = () => {
-  loggers.close();
+  loggers.reset();
 };

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -1,7 +1,7 @@
 import { ILogger, LoggerOptions } from './interface';
 import { MidwayLoggerContainer } from './container';
 
-export { format } from 'winston';
+export { format, transports } from 'winston';
 export { displayCommonMessage, displayLabels } from './format';
 export * from './interface';
 export * from './transport';

--- a/packages/logger/test/index.test.ts
+++ b/packages/logger/test/index.test.ts
@@ -17,7 +17,8 @@ import {
   sleep,
   createChildProcess,
   finishLogger,
-  matchContentTimes
+  matchContentTimes,
+  getCurrentDateString
 } from './util';
 import { EggLogger } from 'egg-logger';
 import { readFileSync } from "fs";
@@ -295,7 +296,7 @@ describe('/test/index.test.ts', () => {
     clearAllLoggers();
     const logsDir = join(__dirname, 'logs');
     await removeFileOrDir(logsDir);
-    const timeFormat = [new Date().getFullYear(), new Date().getMonth() + 1, new Date().getDate()].join('-');
+    const timeFormat = getCurrentDateString();
     const logger = createLogger<IMidwayLogger>('testLogger', {
       dir: logsDir,
       fileLogName: 'test-logger.log',
@@ -367,6 +368,24 @@ describe('/test/index.test.ts', () => {
     expect(originLogger).toBe(consoleLogger);
     loggers.close('consoleLogger');
     expect(loggers.size).toBe(0);
+  });
+
+  it('should create container with options and add logger', async () => {
+    clearAllLoggers();
+    loggers.updateContainerOption({
+      level: 'warn',
+      disableFile: true,
+      disableError: true,
+    })
+    const customLogger: any = loggers.createLogger('customLogger', {
+      level: 'info',
+      dir: __dirname,
+      fileLogName: 'custom.log',
+    });
+    customLogger.info('11111');
+    customLogger.warn('222');
+    await sleep();
+    expect(!fileExists(join(__dirname, 'custom.log'))).toBeTruthy();
   });
 
   it('should create logger update level', async () => {

--- a/packages/logger/test/util.ts
+++ b/packages/logger/test/util.ts
@@ -70,3 +70,7 @@ export const finishLogger = async (logger) => {
     logger.close();
   })
 }
+
+export const getCurrentDateString = () => {
+  return new Date().toISOString().split('T')[0];
+};

--- a/packages/mock/src/utils.ts
+++ b/packages/mock/src/utils.ts
@@ -4,6 +4,7 @@ import {
   IMidwayApplication,
   IMidwayFramework,
   MidwayFrameworkType,
+  safeRequire,
 } from '@midwayjs/core';
 import { isAbsolute, join } from 'path';
 import { remove } from 'fs-extra';
@@ -41,6 +42,8 @@ export async function create<
   clearAllModule();
   clearContainerCache();
   clearAllLoggers();
+  safeRequire(`${baseDir}/src/interface`);
+
   let framework: T = null;
   let DefaultFramework = null;
 

--- a/packages/mock/src/utils.ts
+++ b/packages/mock/src/utils.ts
@@ -74,17 +74,6 @@ export async function create<
   if (DefaultFramework) {
     framework = new DefaultFramework();
     if (framework.getFrameworkType() === MidwayFrameworkType.WEB) {
-      if (isTestEnvironment()) {
-        options.cleanLogsDir = true;
-        options.cleanTempDir = true;
-      }
-      // clean first
-      if (options.cleanLogsDir) {
-        await remove(join(baseDir, 'logs'));
-      }
-      if (options.cleanTempDir) {
-        await remove(join(baseDir, 'run'));
-      }
       // add egg-mock plugin for @midwayjs/web test, provide mock method
       options = Object.assign(options || {}, {
         plugins: {
@@ -144,9 +133,11 @@ export async function createApp<
 }
 
 export async function close(
-  app: IMidwayApplication | IMidwayFramework<any, any>
+  app: IMidwayApplication | IMidwayFramework<any, any>,
+  options?: any
 ) {
   if (!app) return;
+  options = options || {};
   let newApp: IMidwayApplication;
   if ((app as IMidwayFramework<any, any>).getApplication) {
     newApp = (app as IMidwayFramework<any, any>).getApplication();
@@ -159,8 +150,15 @@ export async function close(
     appMap.delete(starter);
   }
 
-  if (MidwayFrameworkType.WEB === newApp.getFrameworkType()) {
-    await remove(join(newApp.getAppDir(), 'logs'));
-    await remove(join(newApp.getAppDir(), 'run'));
+  if (isTestEnvironment()) {
+    if (MidwayFrameworkType.WEB === newApp.getFrameworkType()) {
+      // clean first
+      if (options.cleanLogsDir !== false) {
+        await remove(join(newApp.getAppDir(), 'logs'));
+      }
+      if (options.cleanTempDir !== false) {
+        await remove(join(newApp.getAppDir(), 'run'));
+      }
+    }
   }
 }

--- a/packages/mock/src/utils.ts
+++ b/packages/mock/src/utils.ts
@@ -14,6 +14,13 @@ import { clearAllLoggers } from '@midwayjs/logger';
 
 process.setMaxListeners(0);
 
+function isTestEnvironment() {
+  const testEnv = ['test', 'unittest'];
+  return testEnv.includes(process.env.MIDWAY_SERVER_ENV)
+    || testEnv.includes(process.env.EGG_SERVER_ENV)
+    || testEnv.includes(process.env.NODE_ENV);
+}
+
 const appMap = new WeakMap();
 
 function getIncludeFramework(dependencies): string {
@@ -67,11 +74,15 @@ export async function create<
   if (DefaultFramework) {
     framework = new DefaultFramework();
     if (framework.getFrameworkType() === MidwayFrameworkType.WEB) {
+      if (isTestEnvironment()) {
+        options.cleanLogsDir = true;
+        options.cleanTempDir = true;
+      }
       // clean first
-      if (options.cleanLogsDir !== false) {
+      if (options.cleanLogsDir) {
         await remove(join(baseDir, 'logs'));
       }
-      if (options.cleanTempDir !== false) {
+      if (options.cleanTempDir) {
         await remove(join(baseDir, 'run'));
       }
       // add egg-mock plugin for @midwayjs/web test, provide mock method

--- a/packages/web/src/interface.ts
+++ b/packages/web/src/interface.ts
@@ -6,7 +6,7 @@ import {
 } from '@midwayjs/core';
 import { IMidwayKoaConfigurationOptions, IMidwayKoaContext, IMidwayKoaNext } from '@midwayjs/koa';
 import { DefaultState, Middleware } from 'koa';
-import { LoggerOptions } from '@midwayjs/logger';
+import { ILogger, LoggerOptions } from '@midwayjs/logger';
 
 declare module 'egg' {
   interface EggAppInfo {
@@ -22,6 +22,8 @@ declare module 'egg' {
     getProcessType(): MidwayProcessTypeEnum;
     getApplicationContext(): IMidwayContainer;
     getConfig(key?: string): any;
+    getLogger(name?: string): EggLogger | ILogger;
+    getCoreLogger(): EggLogger;
     generateController?(controllerMapping: string);
     generateMiddleware?(middlewareId: string): Promise<Middleware<DefaultState, IMidwayKoaContext>>;
     createLogger(name: string, options: LoggerOptions);

--- a/packages/web/src/logger.ts
+++ b/packages/web/src/logger.ts
@@ -1,10 +1,26 @@
 import { EggLoggers as BaseEggLoggers, EggLogger, Transport } from 'egg-logger';
-import { loggers, ILogger } from '@midwayjs/logger';
+import { loggers, MidwayBaseLogger, transports } from '@midwayjs/logger';
 import { relative, join, isAbsolute, dirname, basename } from 'path';
 import { existsSync, lstatSync, readFileSync, renameSync, unlinkSync } from 'fs';
 import { Application } from 'egg';
-import { MidwayProcessTypeEnum } from '@midwayjs/core';
+import { MidwayFrameworkType, MidwayProcessTypeEnum } from '@midwayjs/core';
 import { getCurrentDateString } from './utils';
+
+export class WebConsoleTransport extends transports.Console {
+
+  app: Application;
+  constructor(app: Application) {
+    super();
+    this.app = app;
+  }
+
+  log(info, callback) {
+    if (this.app.getFrameworkType() === MidwayFrameworkType.WEB) {
+      return;
+    }
+    return super.log(info, callback);
+  }
+}
 
 const levelTransform = (level) => {
   switch (level) {
@@ -35,7 +51,7 @@ const levelTransform = (level) => {
  * output log into file {@link Transport}。
  */
 class WinstonTransport extends Transport {
-  transportLogger: ILogger;
+  transportLogger: MidwayBaseLogger;
 
   constructor(options) {
     super(options);
@@ -46,7 +62,10 @@ class WinstonTransport extends Transport {
         disableError: true,   // EggJS 的默认转发到错误日志是通过设置重复的 logger 实现的，在这种情况下代理会造成 midway 写入多个 error 日志，默认需要移除掉
         level: levelTransform(options.level),
       })
-    );
+    ) as MidwayBaseLogger;
+    // 由于现在的日志是个大池子，其他框架也会和 egg 复用日志对象，在这种场景下，如果和 egg 复用（socket）Logger，那么池子里存在的，可能只有 fileLogger，不会输出控制台日志。
+    // 解决的方法是，添加一个 transport，其中判断如果 app 是非 egg 的时候则输出
+    this.transportLogger.add(new WebConsoleTransport(options.app));
   }
 
   /**
@@ -182,6 +201,7 @@ class EggLoggers extends BaseEggLoggers {
         fileLogName,
         level: (logger as any).options.level,
         transportName: name,
+        app: this.app,
       })
     );
   }

--- a/packages/web/src/logger.ts
+++ b/packages/web/src/logger.ts
@@ -4,6 +4,7 @@ import { relative, join, isAbsolute, dirname, basename } from 'path';
 import { existsSync, lstatSync, readFileSync, renameSync, unlinkSync } from 'fs';
 import { Application } from 'egg';
 import { MidwayProcessTypeEnum } from '@midwayjs/core';
+import { getCurrentDateString } from './utils';
 
 const levelTransform = (level) => {
   switch (level) {
@@ -162,11 +163,7 @@ class EggLoggers extends BaseEggLoggers {
       existsSync(eggLogFile) &&
       eggLoggerFiles.includes(eggLogFile)
     ) {
-      const timeFormat = [
-        new Date().getFullYear(),
-        new Date().getMonth() + 1,
-        new Date().getDate(),
-      ].join('-');
+      const timeFormat = getCurrentDateString();
       renameSync(eggLogFile, eggLogFile + '.' + timeFormat + '_eggjs_bak');
     }
 

--- a/packages/web/src/utils.ts
+++ b/packages/web/src/utils.ts
@@ -44,3 +44,7 @@ export const findLernaRoot = (findRoot = process.cwd()) => {
     { cwd: findRoot, type: 'directory' }
   );
 };
+
+export const getCurrentDateString = () => {
+  return new Date().toISOString().split('T')[0];
+};

--- a/packages/web/test/logger.test.ts
+++ b/packages/web/test/logger.test.ts
@@ -4,6 +4,7 @@ import { levels } from 'egg-logger';
 import { join } from 'path';
 import { existsSync, readFileSync, writeFileSync, ensureDir } from 'fs-extra';
 import { lstatSync } from 'fs';
+import { getCurrentDateString } from '../src/utils';
 
 describe('test/logger.test.js', () => {
 
@@ -25,7 +26,7 @@ describe('test/logger.test.js', () => {
     writeFileSync(join(logsDir, 'midway-web.log'), 'hello world');
     const app = await creatApp('apps/mock-dev-app', { cleanLogsDir: false});
     app.coreLogger.error('aaaaa');
-    const timeFormat = [new Date().getFullYear(), new Date().getMonth() + 1, new Date().getDate()].join('-');
+    const timeFormat = getCurrentDateString();
     // 备份文件存在
     expect(existsSync(join(logsDir, 'common-error.log.' + timeFormat + '_eggjs_bak'))).toBeTruthy();
     expect(existsSync(join(logsDir, 'egg-schedule.log.' + timeFormat + '_eggjs_bak'))).toBeTruthy();

--- a/packages/web/test/logger.test.ts
+++ b/packages/web/test/logger.test.ts
@@ -2,7 +2,7 @@ import { creatApp, closeApp, getFilepath, sleep, matchContentTimes } from './uti
 import * as mm from 'mm';
 import { levels } from 'egg-logger';
 import { join } from 'path';
-import { existsSync, readFileSync, writeFileSync, ensureDir } from 'fs-extra';
+import { existsSync, readFileSync, writeFileSync, ensureDir, remove } from 'fs-extra';
 import { lstatSync } from 'fs';
 import { getCurrentDateString } from '../src/utils';
 
@@ -62,6 +62,7 @@ describe('test/logger.test.js', () => {
     mm(process.env, 'EGG_SERVER_ENV', 'prod');
     mm(process.env, 'EGG_LOG', '');
     mm(process.env, 'EGG_HOME', getFilepath('apps/mock-production-app/src/config'));
+    await remove(join(getFilepath('apps/mock-production-app/src/config'), 'logs'));
     const app = await creatApp('apps/mock-production-app');
 
     // 生产环境默认 _level = info
@@ -97,6 +98,7 @@ describe('test/logger.test.js', () => {
     mm(process.env, 'EGG_SERVER_ENV', 'prod');
     mm(process.env, 'EGG_LOG', '');
     mm(process.env, 'EGG_HOME', getFilepath('apps/mock-production-app-do-not-force/src/config'));
+    await remove(join(getFilepath('apps/mock-production-app-do-not-force/src/config'), 'logs'));
     const app = await creatApp('apps/mock-production-app-do-not-force');
 
     expect(app.config.logger.allowDebugAtProd).toBeTruthy();
@@ -115,6 +117,7 @@ describe('test/logger.test.js', () => {
     mm(process.env, 'MIDWAY_SERVER_ENV', '');
     mm(process.env, 'EGG_SERVER_ENV', 'local');
     mm(process.env, 'EGG_LOG', '');
+    await remove(join(getFilepath('apps/mock-dev-app'), 'logs'));
     const app = await creatApp('apps/mock-dev-app');
 
     expect((app.logger.get('file') as any).options.level === levels.INFO);
@@ -129,6 +132,7 @@ describe('test/logger.test.js', () => {
     mm(process.env, 'MIDWAY_SERVER_ENV', '');
     mm(process.env, 'EGG_SERVER_ENV', 'local');
     mm(process.env, 'EGG_LOG', 'ERROR');
+    await remove(join(getFilepath('apps/mock-dev-app'), 'logs'));
     const app = await creatApp('apps/mock-dev-app');
 
     expect((app.logger.get('file') as any).options.level === levels.INFO);
@@ -143,6 +147,7 @@ describe('test/logger.test.js', () => {
     mm(process.env, 'MIDWAY_SERVER_ENV', '');
     mm(process.env, 'EGG_SERVER_ENV', 'unittest');
     mm(process.env, 'EGG_LOG', '');
+    await remove(join(getFilepath('apps/mock-dev-app'), 'logs'));
     const app = await creatApp('apps/mock-dev-app');
 
     expect((app.logger.get('file') as any).options.level === levels.INFO);
@@ -155,6 +160,7 @@ describe('test/logger.test.js', () => {
 
   it('should set log.consoleLevel to env.EGG_LOG', async () => {
     mm(process.env, 'EGG_LOG', 'ERROR');
+    await remove(join(getFilepath('apps/mock-dev-app'), 'logs'));
     const app = await creatApp('apps/mock-dev-app');
 
     expect((app.logger.get('file') as any).options.level === levels.INFO);
@@ -164,6 +170,7 @@ describe('test/logger.test.js', () => {
 
   xit('log buffer disable cache on local and unittest env', async () => {
     mm(process.env, 'EGG_LOG', 'NONE');
+    await remove(join(getFilepath('apps/nobuffer-logger'), 'logs'));
     const app = await creatApp('apps/nobuffer-logger');
 
     expect(app.config.logger.disableConsoleAfterReady === false);

--- a/packages/web/test/utils.ts
+++ b/packages/web/test/utils.ts
@@ -16,6 +16,10 @@ export async function closeApp(app) {
   if (process.env.EGG_HOME) {
     await remove(join(process.env.EGG_HOME, 'logs'));
   }
+  if(app?.getAppDir()) {
+    await remove(join(app?.getAppDir(), 'logs'));
+    await remove(join(app?.getAppDir(), 'run'));
+  }
 }
 
 export { createHttpRequest } from '@midwayjs/mock';


### PR DESCRIPTION
处理几个问题

- 1、给 app 和 framework 都增加 getCoreLogger 方法
- 2、在本地开发的时候，ts-node 会出现扩展 egg 定义找不到的情况，原因是 ts-node 不认 tsconfig 中的 tsRoot，而编辑器和 tsc 则认识，导致只会在 run dev 的时候报错，但是如果提前 require 了对应的定义文件，则不会出现此问题，由于 midway 在文档里中推荐将定义放到 interface.ts 中，那么，在本地 dev 启动的时候，我们提前去 require 该文件即可。
- 3、由于现在的日志是个大池子，其他框架也会和 egg 复用日志对象，在这种场景下，如果和 egg 复用（socket）Logger，那么池子里存在的，可能只有 fileLogger，不会输出控制台日志。
- 4、~新版本在使用 egg-layer 时，需要处理日志的问题，比如把 file transport 删除。~ 没有问题，因为 egg-layer 写到临时目录里去了