### PR TITLE
fix: remove error and symbol link in windows

### DIFF
--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -3,6 +3,11 @@ import * as DailyRotateFileTransport from 'winston-daily-rotate-file';
 import { DelegateLoggerOptions, LoggerLevel, LoggerOptions } from './interface';
 import { DelegateTransport, EmptyTransport } from './transport';
 import { displayLabels, displayCommonMessage } from './format';
+import * as os from 'os';
+
+function isWin32() {
+  return os.platform() === 'win32';
+}
 
 export const EmptyLogger: Logger = createLogger().constructor as Logger;
 
@@ -19,6 +24,10 @@ export class MidwayBaseLogger extends EmptyLogger {
   constructor(options: LoggerOptions = {}) {
     super(options);
     this.exitOnError = false;
+    if (isWin32()) {
+      options.disableErrorSymlink = true;
+      options.disableFileSymlink = true;
+    }
     this.loggerOptions = options;
     if (this.loggerOptions.defaultLabel) {
       this.labels.push(this.loggerOptions.defaultLabel);

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -5,9 +5,7 @@ import { DelegateTransport, EmptyTransport } from './transport';
 import { displayLabels, displayCommonMessage } from './format';
 import * as os from 'os';
 
-function isWin32() {
-  return os.platform() === 'win32';
-}
+const isWindows = os.platform() === 'win32';
 
 export const EmptyLogger: Logger = createLogger().constructor as Logger;
 
@@ -24,7 +22,7 @@ export class MidwayBaseLogger extends EmptyLogger {
   constructor(options: LoggerOptions = {}) {
     super(options);
     this.exitOnError = false;
-    if (isWin32()) {
+    if (isWindows) {
       options.disableErrorSymlink = true;
       options.disableFileSymlink = true;
     }

--- a/packages/mock/src/utils.ts
+++ b/packages/mock/src/utils.ts
@@ -154,10 +154,14 @@ export async function close(
     if (MidwayFrameworkType.WEB === newApp.getFrameworkType()) {
       // clean first
       if (options.cleanLogsDir !== false) {
-        await remove(join(newApp.getAppDir(), 'logs'));
+        try {
+          await remove(join(newApp.getAppDir(), 'logs'));
+        } catch (e) {}
       }
       if (options.cleanTempDir !== false) {
-        await remove(join(newApp.getAppDir(), 'run'));
+        try {
+          await remove(join(newApp.getAppDir(), 'run'));
+        } catch (e) {}
       }
     }
   }

--- a/packages/mock/src/utils.ts
+++ b/packages/mock/src/utils.ts
@@ -11,6 +11,7 @@ import { remove } from 'fs-extra';
 import { clearAllModule } from '@midwayjs/decorator';
 import { existsSync } from 'fs';
 import { clearAllLoggers } from '@midwayjs/logger';
+import * as os from 'os';
 
 process.setMaxListeners(0);
 
@@ -19,6 +20,10 @@ function isTestEnvironment() {
   return testEnv.includes(process.env.MIDWAY_SERVER_ENV)
     || testEnv.includes(process.env.EGG_SERVER_ENV)
     || testEnv.includes(process.env.NODE_ENV);
+}
+
+function isWin32() {
+  return os.platform() === 'win32';
 }
 
 const appMap = new WeakMap();
@@ -153,15 +158,11 @@ export async function close(
   if (isTestEnvironment()) {
     if (MidwayFrameworkType.WEB === newApp.getFrameworkType()) {
       // clean first
-      if (options.cleanLogsDir !== false) {
-        try {
-          await remove(join(newApp.getAppDir(), 'logs'));
-        } catch (e) {}
+      if (options.cleanLogsDir !== false && !isWin32()) {
+        await remove(join(newApp.getAppDir(), 'logs'));
       }
-      if (options.cleanTempDir !== false) {
-        try {
-          await remove(join(newApp.getAppDir(), 'run'));
-        } catch (e) {}
+      if (options.cleanTempDir !== false && !isWin32()) {
+        await remove(join(newApp.getAppDir(), 'run'));
       }
     }
   }

--- a/packages/web/src/logger.ts
+++ b/packages/web/src/logger.ts
@@ -7,6 +7,8 @@ import { MidwayFrameworkType, MidwayProcessTypeEnum } from '@midwayjs/core';
 import { getCurrentDateString } from './utils';
 import * as os from 'os';
 
+const isWindows = os.platform() === 'win32';
+
 export class WebConsoleTransport extends transports.Console {
 
   app: Application;
@@ -92,17 +94,13 @@ function isEmptyFile(p: string) {
   return content === null || content === undefined || content === '';
 }
 
-function isWin32() {
-  return os.platform() === 'win32';
-}
-
 function checkEggLoggerExists(dir, fileName, eggLoggerFiles) {
   const file = isAbsolute(fileName) ? fileName : join(dir, fileName);
   if (existsSync(file) && !lstatSync(file).isSymbolicLink()) {
     // 如果是空文件，则直接删了，否则加入备份队列
     if (isEmptyFile(file)) {
       // midway 的软链在 windows 底下也不会创建出来，在 windows 底下就不做文件删除了
-      if (!isWin32()) {
+      if (!isWindows) {
         unlinkSync(file);
       }
     } else {

--- a/packages/web/src/logger.ts
+++ b/packages/web/src/logger.ts
@@ -5,6 +5,7 @@ import { existsSync, lstatSync, readFileSync, renameSync, unlinkSync } from 'fs'
 import { Application } from 'egg';
 import { MidwayFrameworkType, MidwayProcessTypeEnum } from '@midwayjs/core';
 import { getCurrentDateString } from './utils';
+import * as os from 'os';
 
 export class WebConsoleTransport extends transports.Console {
 
@@ -91,12 +92,19 @@ function isEmptyFile(p: string) {
   return content === null || content === undefined || content === '';
 }
 
+function isWin32() {
+  return os.platform() === 'win32';
+}
+
 function checkEggLoggerExists(dir, fileName, eggLoggerFiles) {
   const file = isAbsolute(fileName) ? fileName : join(dir, fileName);
   if (existsSync(file) && !lstatSync(file).isSymbolicLink()) {
     // 如果是空文件，则直接删了，否则加入备份队列
     if (isEmptyFile(file)) {
-      unlinkSync(file);
+      // midway 的软链在 windows 底下也不会创建出来，在 windows 底下就不做文件删除了
+      if (!isWin32()) {
+        unlinkSync(file);
+      }
     } else {
       eggLoggerFiles.push(fileName);
       if (!isAbsolute(fileName)) {


### PR DESCRIPTION
处理 windows 下日志的问题

- 1、软链在windows 底下无法生成
- 2、egg 日志备份有问题，在 windows 底下一般只会用于开发，且不会生成软链，就不备份了
- 3、本地测试的时候删除日志的功能，在 windows 底下就不删了（fs-extra 也有问题，管理员模式是好的，try是不行的，所以跳过了）