### PR TITLE
fix: disable logrotator and avoid file exists error

### DIFF
--- a/packages/web/config/plugin.js
+++ b/packages/web/config/plugin.js
@@ -8,4 +8,5 @@ module.exports = {
     enable: true,
     package: 'midway-schedule',
   },
+  logrotator: false,
 };

--- a/packages/web/src/logger.ts
+++ b/packages/web/src/logger.ts
@@ -137,7 +137,11 @@ class EggLoggers extends BaseEggLoggers {
    */
   constructor(options, app: Application) {
     super(options);
-    this.app = app;
+    // 这么改是为了防止 egg 日志切割时遍历属性，导致报错
+    Object.defineProperty(this, 'app', {
+      value: app,
+      enumerable: false,
+    });
     /**
      * 由于 egg 的日志生成不是软链，每次都会创建，无法覆盖这个行为
      * 1、如果以前存在老的 egg 日志，必然存在非软链文件，则重命名备份


### PR DESCRIPTION
现有 egg 日志切割依旧在启用，会造成下面的错误，由于 midway 日志自带了日志切割处理，为避免问题和 midway 框架统一，禁止 egg 的切割。

```
2021-01-10 01:23:00,012 ERROR 7405 nodejs.Error: [egg-logrotator] rename /Users/harry/project/application/my_midway_app/logs/my_midway_project/midway-web.log, found exception: targetFile /Users/harry/project/application/my_midway_app/logs/my_midway_project/midway-web.log.2021-01-09 exists!!!
    at renameOrDelete (/Users/harry/project/application/my_midway_app/node_modules/egg-logrotator/app/lib/rotator.js:63:17)
    at async DayRotator.rotate (/Users/harry/project/application/my_midway_app/node_modules/egg-logrotator/app/lib/rotator.js:28:9)
    at async Object.task (/Users/harry/project/application/my_midway_app/node_modules/egg-logrotator/app/schedule/rotate_by_file.js:17:7)

```