### PR TITLE
fix: missing originContext property  in http trigger

### DIFF
--- a/packages-serverless/serverless-fc-starter/src/runtime.ts
+++ b/packages-serverless/serverless-fc-starter/src/runtime.ts
@@ -60,6 +60,9 @@ export class FCRuntime extends ServerlessLightRuntime {
     const newRes = new HTTPResponse();
 
     if (isHTTPMode) {
+      req.getOriginContext = () => {
+        return context;
+      }
       // http
       // const rawBody = 'test';
       // req.rawBody = rawBody;

--- a/packages-serverless/serverless-fc-starter/test/fixtures/http/index.ts
+++ b/packages-serverless/serverless-fc-starter/test/fixtures/http/index.ts
@@ -9,6 +9,6 @@ exports.handler = asyncWrapper(async (...args) => {
     runtime = await start();
   }
   return runtime.asyncEvent(async function (ctx) {
-    ctx.body = 'Alan';
+    ctx.body = 'Alan|' + ctx.originContext.requestId;
   })(...args);
 });

--- a/packages-serverless/serverless-fc-starter/test/index.test.ts
+++ b/packages-serverless/serverless-fc-starter/test/index.test.ts
@@ -420,7 +420,7 @@ describe('/test/index.test.ts', () => {
           method: 'GET',
         })
       );
-      assert.equal(result.body, 'Alan');
+      assert.equal(result.body, 'Alan|b1c5100f-819d-c421-3a5e-7782a27d8a33');
       await runtime.close();
     });
 


### PR DESCRIPTION
修复在 fc http 触发器下，ctx.originContext 属性为空的问题。