### PR TITLE
feat: add component mongoose

### DIFF
--- a/packages/c-mongoose/.gitignore
+++ b/packages/c-mongoose/.gitignore
@@ -1,0 +1,15 @@
+logs/
+npm-debug.log
+yarn-error.log
+node_modules/
+package-lock.json
+yarn.lock
+coverage/
+dist/
+.idea/
+run/
+.DS_Store
+*.sw*
+*.un~
+.tsbuildinfo
+.tsbuildinfo.*

--- a/packages/c-mongoose/.npmignore
+++ b/packages/c-mongoose/.npmignore
@@ -1,0 +1,16 @@
+logs/
+npm-debug.log
+yarn-error.log
+node_modules/
+package-lock.json
+yarn.lock
+coverage/
+dist/
+.idea/
+run/
+.DS_Store
+*.sw*
+*.un~
+.tsbuildinfo
+.tsbuildinfo.*
+src

--- a/packages/c-mongoose/jest.config.js
+++ b/packages/c-mongoose/jest.config.js
@@ -1,0 +1,9 @@
+const path = require('path');
+
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testPathIgnorePatterns: ['<rootDir>/test/fixtures'],
+  coveragePathIgnorePatterns: ['<rootDir>/test/'],
+  setupFilesAfterEnv: [path.join(__dirname, 'test/.setup.js')], // 预先读取 test/.setup.js
+};

--- a/packages/c-mongoose/package.json
+++ b/packages/c-mongoose/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@midwayjs/mongoose",
+  "version": "2.6.10",
+  "description": "",
+  "main": "dist/index.js",
+  "typings": "dist/index.d.ts",
+  "scripts": {
+    "build": "midway-bin build -c",
+    "test": "midway-bin test --ts --forceExit",
+    "cov": "midway-bin cov --ts --forceExit",
+    "ci": "npm run test"
+  },
+  "keywords": [],
+  "author": "",
+  "files": [
+    "dist/**/*.js",
+    "dist/**/*.d.ts"
+  ],
+  "license": "ISC",
+  "devDependencies": {
+    "@midwayjs/cli": "^1.2.38",
+    "@midwayjs/core": "^2.3.0",
+    "@midwayjs/decorator": "^2.3.0",
+    "@midwayjs/koa": "^2.6.10",
+    "@types/mongoose": "~5.10.3"
+  },
+  "dependencies": {
+    "@typegoose/typegoose": "^7.4.7",
+    "mongoose": "5.10.18"
+  }
+}

--- a/packages/c-mongoose/package.json
+++ b/packages/c-mongoose/package.json
@@ -20,12 +20,13 @@
   "devDependencies": {
     "@midwayjs/cli": "^1.2.38",
     "@midwayjs/koa": "^2.6.10",
-    "@types/mongoose": "~5.10.3"
+    "@midwayjs/mock": "^2.6.10",
+    "@types/mongoose": "~5.10.3",
+    "@typegoose/typegoose": "^7.4.7",
+    "mongoose": "5.10.18"
   },
   "dependencies": {
     "@midwayjs/core": "^2.6.10",
-    "@midwayjs/decorator": "^2.6.8",
-    "@typegoose/typegoose": "^7.4.7",
-    "mongoose": "5.10.18"
+    "@midwayjs/decorator": "^2.6.8"
   }
 }

--- a/packages/c-mongoose/package.json
+++ b/packages/c-mongoose/package.json
@@ -19,12 +19,12 @@
   "license": "ISC",
   "devDependencies": {
     "@midwayjs/cli": "^1.2.38",
-    "@midwayjs/core": "^2.3.0",
-    "@midwayjs/decorator": "^2.3.0",
     "@midwayjs/koa": "^2.6.10",
     "@types/mongoose": "~5.10.3"
   },
   "dependencies": {
+    "@midwayjs/core": "^2.6.10",
+    "@midwayjs/decorator": "^2.6.8",
     "@typegoose/typegoose": "^7.4.7",
     "mongoose": "5.10.18"
   }

--- a/packages/c-mongoose/src/config/config.default.ts
+++ b/packages/c-mongoose/src/config/config.default.ts
@@ -1,0 +1,4 @@
+export const mongoose = {
+  uri: 'mongodb://localhost:27017/',
+  options: { useNewUrlParser: true, useUnifiedTopology: true, dbName: "test" }
+}

--- a/packages/c-mongoose/src/configuration.ts
+++ b/packages/c-mongoose/src/configuration.ts
@@ -1,0 +1,13 @@
+import { Configuration } from '@midwayjs/decorator';
+import * as path from 'path'
+
+@Configuration({
+  namespace: 'mongoose',
+  importConfigs: [path.join(__dirname, "config")]
+})
+export class AutoConfiguration {
+
+  async onReady(app){
+    await app.getAsync('mongoose:mongooseService')
+  }
+}

--- a/packages/c-mongoose/src/index.ts
+++ b/packages/c-mongoose/src/index.ts
@@ -1,0 +1,3 @@
+export { AutoConfiguration as Configuration } from './configuration';
+export * from './service/mongoose'
+export * from '@typegoose/typegoose'

--- a/packages/c-mongoose/src/index.ts
+++ b/packages/c-mongoose/src/index.ts
@@ -1,3 +1,4 @@
 export { AutoConfiguration as Configuration } from './configuration';
 export * from './service/mongoose'
 export * from '@typegoose/typegoose'
+export * from './interface/config.type'

--- a/packages/c-mongoose/src/interface/config.type.ts
+++ b/packages/c-mongoose/src/interface/config.type.ts
@@ -1,0 +1,6 @@
+import * as mongoose from 'mongoose';
+
+export type ConfigType = {
+  uri: string,
+  options: mongoose.ConnectionOptions;
+}

--- a/packages/c-mongoose/src/service/mongoose.ts
+++ b/packages/c-mongoose/src/service/mongoose.ts
@@ -1,0 +1,15 @@
+import { Config, Init, Provide, Scope, ScopeEnum } from '@midwayjs/decorator';
+import * as mongoose from 'mongoose';
+
+@Provide('mongooseService')
+@Scope(ScopeEnum.Singleton)
+export class MongooseService {
+
+  @Config('mongoose')
+  config;
+
+  @Init()
+  async init() {
+    await mongoose.connect(this.config.uri, this.config.options);
+  }
+}

--- a/packages/c-mongoose/test/.setup.js
+++ b/packages/c-mongoose/test/.setup.js
@@ -1,0 +1,1 @@
+jest.setTimeout(30000)

--- a/packages/c-mongoose/test/fixtures/base-app/package.json
+++ b/packages/c-mongoose/test/fixtures/base-app/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "ali-demo"
+}

--- a/packages/c-mongoose/test/fixtures/base-app/src/config/config.default.ts
+++ b/packages/c-mongoose/test/fixtures/base-app/src/config/config.default.ts
@@ -1,0 +1,7 @@
+import { ConfigType } from '../../../../../src';
+
+// 此处是用的一个免费的mongodb，可能不是很稳定
+export const mongoose: ConfigType = {
+  uri: 'mongodb+srv://cluster0.hy9wo.mongodb.net/',
+  options: { useNewUrlParser: true, useUnifiedTopology: true, dbName: "midway_test_db", user: "midway_test", pass: '@7XsLUg.F7ga3DMrzqWU' }
+}

--- a/packages/c-mongoose/test/fixtures/base-app/src/configuration.ts
+++ b/packages/c-mongoose/test/fixtures/base-app/src/configuration.ts
@@ -1,0 +1,13 @@
+import { Configuration } from '@midwayjs/decorator';
+import * as mongoose from '../../../../src';
+
+@Configuration({
+  imports: [mongoose]
+})
+export class AutoConfiguration {
+
+  async onReady(app){
+    let res = await app.getAsync('testService');
+    await res.getTest();
+  }
+}

--- a/packages/c-mongoose/test/fixtures/base-app/src/configuration.ts
+++ b/packages/c-mongoose/test/fixtures/base-app/src/configuration.ts
@@ -1,8 +1,10 @@
 import { Configuration } from '@midwayjs/decorator';
 import * as mongoose from '../../../../src';
+import path from 'path'
 
 @Configuration({
-  imports: [mongoose]
+  imports: [mongoose],
+  importConfigs: [path.join(__dirname, 'config')]
 })
 export class AutoConfiguration {
 

--- a/packages/c-mongoose/test/fixtures/base-app/src/service/test.ts
+++ b/packages/c-mongoose/test/fixtures/base-app/src/service/test.ts
@@ -1,0 +1,21 @@
+import { Provide, Scope, ScopeEnum } from "@midwayjs/decorator";
+import { getModelForClass, prop } from "../../../../../src";
+
+class User {
+  @prop()
+  public name?: string;
+
+  @prop({ type: () => [String] })
+  public jobs?: string[];
+}
+
+@Provide()
+@Scope(ScopeEnum.Singleton)
+export class TestService{
+  async getTest(){
+    const UserModel = getModelForClass(User);
+    const { _id: id } = await UserModel.create({ name: 'JohnDoe', jobs: ['Cleaner'] } as User); // an "as" assertion, to have types for all properties
+    const user = await UserModel.findById(id).exec();
+    console.log(user)
+  }
+}

--- a/packages/c-mongoose/test/index.test.ts
+++ b/packages/c-mongoose/test/index.test.ts
@@ -1,0 +1,11 @@
+import { createApp, close } from '@midwayjs/mock';
+import { Framework } from '@midwayjs/koa'
+import { join } from 'path';
+
+describe('/test/index.test.ts', () => {
+  it('should connnect mongodb', async () => {
+    let app = await createApp(join(__dirname, 'fixtures', 'base-app'), {}, Framework);
+    await close(app);
+  });
+});
+

--- a/packages/c-mongoose/tsconfig.json
+++ b/packages/c-mongoose/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compileOnSave": true,
+  "compilerOptions": {
+    "target": "ES2018",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "inlineSourceMap":false,
+    "noImplicitThis": true,
+    "noUnusedLocals": true,
+    "stripInternal": true,
+    "noImplicitReturns": false,
+    "pretty": true,
+    "declaration": true,
+    "outDir": "dist"
+  },
+  "exclude": [
+    "dist",
+    "node_modules",
+    "test"
+  ]
+}


### PR DESCRIPTION
使用方法：
1、安装npm install @midwayjs/mongoose --save
2、导入模块：
**src/configuration.ts**
```
import { Configuration } from '@midwayjs/decorator';
import * as mongoose from '@midwayjs/mongoose';

@Configuration({
  imports: [mongoose]
})
export class AutoConfiguration {
}
```
3、业务代码中定义对象类型
定义mongodb数据的对象类型：
```
import { prop, getModelForClass } from "@midwayjs/mongoose";
export class User {
  @prop()
  public name?: string;

  @prop({ type: () => [String] })
  public jobs?: string[];
}
export const UserModel = getModelForClass(User);
```

4、业务代码中的增删改查：
```
@Provide()
export class TestService{
  async getTest(){
    const { _id: id } = await UserModel.create({ name: 'JohnDoe', jobs: ['Cleaner'] } as User); //此处增加数据
    const user = await UserModel.findById(id).exec();//查询数据
    console.log(user)
  }
}
```
