### PR TITLE
fix: date string error in ISO pattern

### DIFF
--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -11,7 +11,6 @@
   },
   "devDependencies": {
     "@midwayjs/cli": "^1.2.36",
-    "dayjs": "^1.10.4",
     "egg-logger": "^2.4.2",
     "fs-extra": "^8.0.1"
   },

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -11,6 +11,7 @@
   },
   "devDependencies": {
     "@midwayjs/cli": "^1.2.36",
+    "dayjs": "^1.10.4",
     "egg-logger": "^2.4.2",
     "fs-extra": "^8.0.1"
   },

--- a/packages/logger/test/util.ts
+++ b/packages/logger/test/util.ts
@@ -1,7 +1,6 @@
 import { existsSync, readFileSync } from 'fs';
 import { remove } from 'fs-extra';
 import { fork, execSync } from 'child_process';
-import * as dayjs from 'dayjs';
 
 export const fileExists = (filePath) => {
   return existsSync(filePath);
@@ -73,5 +72,6 @@ export const finishLogger = async (logger) => {
 }
 
 export const getCurrentDateString = () => {
-  return dayjs().format('YYYY-MM-DD');
+  const d = new Date();
+  return `${d.getFullYear()}-${(d.getMonth() + 1).toString().padStart(2, '0')}-${(d.getDate()).toString().padStart(2, '0')}`
 };

--- a/packages/logger/test/util.ts
+++ b/packages/logger/test/util.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from 'fs';
 import { remove } from 'fs-extra';
 import { fork, execSync } from 'child_process';
+import * as dayjs from 'dayjs';
 
 export const fileExists = (filePath) => {
   return existsSync(filePath);
@@ -72,7 +73,5 @@ export const finishLogger = async (logger) => {
 }
 
 export const getCurrentDateString = () => {
-  // example: 01/23/2021
-  const d = new Date();
-  return `${d.getFullYear()}-${(d.getMonth() + 1).toString().padStart(2, '0')}-${(d.getDate()).toString().padStart(2, '0')}`
+  return dayjs().format('YYYY-MM-DD');
 };

--- a/packages/logger/test/util.ts
+++ b/packages/logger/test/util.ts
@@ -72,5 +72,8 @@ export const finishLogger = async (logger) => {
 }
 
 export const getCurrentDateString = () => {
-  return new Date().toISOString().split('T')[0];
+  // example: 01/23/2021
+  const dateString = new Date().toLocaleString('en-us', { year: 'numeric', month: '2-digit', day: '2-digit' });
+  const arr = dateString.split('/');
+  return `${arr[2]}-${arr[0]}-${arr[1]}`;
 };

--- a/packages/logger/test/util.ts
+++ b/packages/logger/test/util.ts
@@ -73,7 +73,6 @@ export const finishLogger = async (logger) => {
 
 export const getCurrentDateString = () => {
   // example: 01/23/2021
-  const dateString = new Date().toLocaleString('en-us', { year: 'numeric', month: '2-digit', day: '2-digit' });
-  const arr = dateString.split('/');
-  return `${arr[2]}-${arr[0]}-${arr[1]}`;
+  const d = new Date();
+  return `${d.getFullYear()}-${(d.getMonth() + 1).toString().padStart(2, '0')}-${(d.getDate()).toString().padStart(2, '0')}`
 };

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "@midwayjs/cli": "^1.2.36",
     "@midwayjs/mock": "^2.6.13",
+    "dayjs": "^1.10.4",
     "egg-view-nunjucks": "^2.2.0",
     "fake-egg": "1.0.0",
     "fs-extra": "^8.0.1",
@@ -43,7 +44,6 @@
     "@midwayjs/decorator": "^2.6.8",
     "@midwayjs/koa": "^2.6.13",
     "@midwayjs/logger": "^2.6.13",
-    "dayjs": "^1.10.4",
     "debug": "^4.1.1",
     "egg": "^2.28.0",
     "egg-logger": "^2.4.2",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -43,6 +43,7 @@
     "@midwayjs/decorator": "^2.6.8",
     "@midwayjs/koa": "^2.6.13",
     "@midwayjs/logger": "^2.6.13",
+    "dayjs": "^1.10.4",
     "debug": "^4.1.1",
     "egg": "^2.28.0",
     "egg-logger": "^2.4.2",

--- a/packages/web/src/utils.ts
+++ b/packages/web/src/utils.ts
@@ -1,7 +1,6 @@
 import { isTypeScriptEnvironment } from '@midwayjs/bootstrap';
 import { basename, join } from 'path';
 import { sync as findUpSync, stop } from 'find-up';
-import * as dayjs from 'dayjs';
 
 export const parseNormalDir = (baseDir: string, isTypescript = true) => {
   if (isTypescript) {
@@ -47,5 +46,6 @@ export const findLernaRoot = (findRoot = process.cwd()) => {
 };
 
 export const getCurrentDateString = (timestamp: number = Date.now()) => {
-  return dayjs(timestamp).format('YYYY-MM-DD');
+  const d = new Date(timestamp);
+  return `${d.getFullYear()}-${(d.getMonth() + 1).toString().padStart(2, '0')}-${(d.getDate()).toString().padStart(2, '0')}`
 };

--- a/packages/web/src/utils.ts
+++ b/packages/web/src/utils.ts
@@ -45,6 +45,9 @@ export const findLernaRoot = (findRoot = process.cwd()) => {
   );
 };
 
-export const getCurrentDateString = () => {
-  return new Date().toISOString().split('T')[0];
+export const getCurrentDateString = (timestamp?: number) => {
+  // example: 01/23/2021
+  const dateString = new Date(timestamp).toLocaleString('en-us', { year: 'numeric', month: '2-digit', day: '2-digit' });
+  const arr = dateString.split('/');
+  return `${arr[2]}-${arr[0]}-${arr[1]}`;
 };

--- a/packages/web/src/utils.ts
+++ b/packages/web/src/utils.ts
@@ -47,7 +47,6 @@ export const findLernaRoot = (findRoot = process.cwd()) => {
 
 export const getCurrentDateString = (timestamp: number = Date.now()) => {
   // example: 01/23/2021
-  const dateString = new Date(timestamp).toLocaleString('en-us', { year: 'numeric', month: '2-digit', day: '2-digit' });
-  const arr = dateString.split('/');
-  return `${arr[2]}-${arr[0]}-${arr[1]}`;
+  const d = new Date(timestamp);
+  return `${d.getFullYear()}-${(d.getMonth() + 1).toString().padStart(2, '0')}-${(d.getDate()).toString().padStart(2, '0')}`
 };

--- a/packages/web/src/utils.ts
+++ b/packages/web/src/utils.ts
@@ -45,7 +45,7 @@ export const findLernaRoot = (findRoot = process.cwd()) => {
   );
 };
 
-export const getCurrentDateString = (timestamp?: number) => {
+export const getCurrentDateString = (timestamp: number = Date.now()) => {
   // example: 01/23/2021
   const dateString = new Date(timestamp).toLocaleString('en-us', { year: 'numeric', month: '2-digit', day: '2-digit' });
   const arr = dateString.split('/');

--- a/packages/web/src/utils.ts
+++ b/packages/web/src/utils.ts
@@ -1,6 +1,7 @@
 import { isTypeScriptEnvironment } from '@midwayjs/bootstrap';
 import { basename, join } from 'path';
 import { sync as findUpSync, stop } from 'find-up';
+import * as dayjs from 'dayjs';
 
 export const parseNormalDir = (baseDir: string, isTypescript = true) => {
   if (isTypescript) {
@@ -46,7 +47,5 @@ export const findLernaRoot = (findRoot = process.cwd()) => {
 };
 
 export const getCurrentDateString = (timestamp: number = Date.now()) => {
-  // example: 01/23/2021
-  const d = new Date(timestamp);
-  return `${d.getFullYear()}-${(d.getMonth() + 1).toString().padStart(2, '0')}-${(d.getDate()).toString().padStart(2, '0')}`
+  return dayjs(timestamp).format('YYYY-MM-DD');
 };

--- a/packages/web/test/utils.test.ts
+++ b/packages/web/test/utils.test.ts
@@ -5,6 +5,7 @@ describe('test/utils.test.ts', function () {
   it('should test getCurrentDateString', function () {
     //  2021-01-21 00:30:00
     const format = getCurrentDateString(1611160200000);
-    expect(format).toEqual('2021-01-21');
+    const d = new Date(1611160200000);
+    expect(format).toEqual(`${d.getFullYear()}-${(d.getMonth() + 1).toString().padStart(2, '0')}-${(d.getDate()).toString().padStart(2, '0')}`);
   });
 });

--- a/packages/web/test/utils.test.ts
+++ b/packages/web/test/utils.test.ts
@@ -1,0 +1,10 @@
+import { getCurrentDateString } from '../src/utils';
+
+describe('test/utils.test.ts', function () {
+
+  it('should test getCurrentDateString', function () {
+    //  2021-01-21 00:30:00
+    const format = getCurrentDateString(1611160200000);
+    expect(format).toEqual('2021-01-21');
+  });
+});

--- a/packages/web/test/utils.test.ts
+++ b/packages/web/test/utils.test.ts
@@ -1,11 +1,11 @@
 import { getCurrentDateString } from '../src/utils';
+import * as dayjs from 'dayjs';
 
 describe('test/utils.test.ts', function () {
 
   it('should test getCurrentDateString', function () {
     //  2021-01-21 00:30:00
     const format = getCurrentDateString(1611160200000);
-    const d = new Date(1611160200000);
-    expect(format).toEqual(`${d.getFullYear()}-${(d.getMonth() + 1).toString().padStart(2, '0')}-${(d.getDate()).toString().padStart(2, '0')}`);
+    expect(format).toEqual(dayjs(1611160200000).format('YYYY-MM-DD'));
   });
 });


### PR DESCRIPTION
由于时区的问题，获取当前时间会有不对的可能，在第一次做 egg 日志备份的时候，如果正好跨天了，可能会出现去获取前一天的情况。

ps: 部分单测也有影响（这也是为什么凌晨提交有问题，到早上跑就好了的原因）