### PR TITLE
 fix: midway logger and mixin egg logger will be missing log

### DIFF
--- a/packages/logger/src/interface.ts
+++ b/packages/logger/src/interface.ts
@@ -15,6 +15,8 @@ export interface IMidwayLogger extends ILogger {
   disableError();
   enableError();
   updateLevel(level: LoggerLevel);
+  updateFileLevel(level: LoggerLevel);
+  updateConsoleLevel(level: LoggerLevel);
   updateDefaultLabel(defaultLabel: string);
   updateDefaultMeta(defaultMeta: object);
   getDefaultLabel(): string;
@@ -25,10 +27,11 @@ export type LoggerLevel = 'silly' | 'debug' | 'info' | 'warn' | 'error';
 
 export interface LoggerOptions {
   format?: logform.Format;
-  level?: string;
+  level?: LoggerLevel;
   defaultMeta?: object;
   printFormat?: (info: any) => string;
   dir?: string;
+  errorDir?: string;
   fileLogName?: string;
   errorLogName?: string;
   defaultLabel?: string;

--- a/packages/logger/test/index.test.ts
+++ b/packages/logger/test/index.test.ts
@@ -36,6 +36,17 @@ describe('/test/index.test.ts', () => {
     coreLogger.info('hello world3');
     coreLogger.warn('hello world4');
     coreLogger.error('hello world5');
+    // 调整完之后控制台应该看不见了，但是文件还写入
+    coreLogger.updateConsoleLevel('warn');
+    coreLogger.info('hello world6');
+    coreLogger.info('hello world7');
+    coreLogger.info('hello world8');
+
+    // 文件也不会写入了
+    coreLogger.updateFileLevel('warn');
+    coreLogger.info('hello world9');
+    coreLogger.info('hello world10');
+    coreLogger.info('hello world11');
 
     await sleep();
     // test logger file exist
@@ -48,6 +59,14 @@ describe('/test/index.test.ts', () => {
     expect(includeContent(join(logsDir, 'midway-core.log'), 'hello world3')).toBeTruthy();
     expect(includeContent(join(logsDir, 'midway-core.log'), 'hello world4')).toBeTruthy();
     expect(includeContent(join(logsDir, 'midway-core.log'), 'hello world5')).toBeTruthy();
+
+    expect(includeContent(join(logsDir, 'midway-core.log'), 'hello world6')).toBeTruthy();
+    expect(includeContent(join(logsDir, 'midway-core.log'), 'hello world7')).toBeTruthy();
+    expect(includeContent(join(logsDir, 'midway-core.log'), 'hello world8')).toBeTruthy();
+
+    expect(includeContent(join(logsDir, 'midway-core.log'), 'hello world9')).toBeFalsy();
+    expect(includeContent(join(logsDir, 'midway-core.log'), 'hello world10')).toBeFalsy();
+    expect(includeContent(join(logsDir, 'midway-core.log'), 'hello world11')).toBeFalsy();
 
     // test error logger  file include content
     expect(includeContent(join(logsDir, 'common-error.log'), 'hello world1')).toBeFalsy();

--- a/packages/logger/test/index.test.ts
+++ b/packages/logger/test/index.test.ts
@@ -34,7 +34,7 @@ describe('/test/index.test.ts', () => {
     coreLogger.info('hello world1');
     coreLogger.info('hello world2');
     coreLogger.info('hello world3');
-    coreLogger.info('hello world4');
+    coreLogger.warn('hello world4');
     coreLogger.error('hello world5');
 
     await sleep();

--- a/packages/web/app/extend/context.js
+++ b/packages/web/app/extend/context.js
@@ -10,4 +10,7 @@ module.exports = {
     }
     return this[rc];
   },
+  get startTime() {
+    return this['starttime'];
+  }
 };

--- a/packages/web/config/config.default.js
+++ b/packages/web/config/config.default.js
@@ -17,6 +17,10 @@ module.exports = appInfo => {
     agentLogName: 'midway-agent.log',
   };
 
+  exports.midwayFeature = {
+    replaceEggLogger: false,
+  };
+
   exports.pluginOverwrite = false;
 
   exports.security = {

--- a/packages/web/config/plugin.js
+++ b/packages/web/config/plugin.js
@@ -8,5 +8,4 @@ module.exports = {
     enable: true,
     package: 'midway-schedule',
   },
-  logrotator: false,
 };

--- a/packages/web/src/framework/web.ts
+++ b/packages/web/src/framework/web.ts
@@ -6,7 +6,7 @@ import {
 } from '@midwayjs/core';
 import { ControllerOption, CONFIG_KEY, PLUGIN_KEY } from '@midwayjs/decorator';
 import { IMidwayWebConfigurationOptions } from '../interface';
-import { MidwayKoaBaseFramework } from '@midwayjs/koa';
+import { MidwayKoaBaseFramework, MidwayKoaContextLogger } from '@midwayjs/koa';
 import { EggRouter } from '@eggjs/router';
 import { Application, Context, Router, EggLogger } from 'egg';
 import { loggers } from '@midwayjs/logger';
@@ -59,6 +59,15 @@ export class MidwayWebFramework extends MidwayKoaBaseFramework<
         return MidwayProcessTypeEnum.APPLICATION;
       },
     }, ['createAnonymousContext']);
+
+    if (this.app.config.logger['midwayMode']) {
+      Object.defineProperty(this.app, 'ContextLogger', {
+        get() {
+          return MidwayKoaContextLogger;
+        },
+      });
+
+    }
 
     Object.defineProperty(this.app, 'applicationContext', {
       get() {

--- a/packages/web/src/framework/web.ts
+++ b/packages/web/src/framework/web.ts
@@ -60,13 +60,12 @@ export class MidwayWebFramework extends MidwayKoaBaseFramework<
       },
     }, ['createAnonymousContext']);
 
-    if (this.app.config.logger['midwayMode']) {
+    if (this.app.config.midwayFeature['replaceEggLogger']) {
       Object.defineProperty(this.app, 'ContextLogger', {
         get() {
           return MidwayKoaContextLogger;
         },
       });
-
     }
 
     Object.defineProperty(this.app, 'applicationContext', {

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -9,4 +9,3 @@ export {
 } from './base';
 export { Application, Agent } from './application';
 export { startCluster } from 'egg';
-export { MidwayWebContextLogger } from './logger';

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -9,3 +9,4 @@ export {
 } from './base';
 export { Application, Agent } from './application';
 export { startCluster } from 'egg';
+export { MidwayWebContextLogger } from './logger';

--- a/packages/web/src/interface.ts
+++ b/packages/web/src/interface.ts
@@ -36,6 +36,12 @@ declare module 'egg' {
     getLogger(name?: string): EggLogger & ILogger;
     startTime: number;
   }
+
+  interface EggAppConfig {
+    midwayFeature: {
+      replaceEggLogger: boolean;
+    }
+  }
 }
 
 export type IMidwayWebApplication = Application;

--- a/packages/web/src/logger.ts
+++ b/packages/web/src/logger.ts
@@ -161,6 +161,10 @@ class MidwayLoggers extends Map<string, ILogger> {
       (value as IMidwayLogger)?.disableConsole();
     }
   }
+
+  reload() {
+    // empty method for egg logrotator
+  }
 }
 
 export const createLoggers = (app: Application) => {

--- a/packages/web/src/logger.ts
+++ b/packages/web/src/logger.ts
@@ -194,7 +194,7 @@ export const createLoggers = (app: Application) => {
 
   let loggers;
 
-  if (app.config.logger['midwayMode'] === true) {
+  if (app.config.midwayFeature['replaceEggLogger']) {
     loggers = new MidwayLoggers(app.config, app);
   } else {
     checkMidwayLoggerSymbolExistsAndRemove(app.config);

--- a/packages/web/src/logger.ts
+++ b/packages/web/src/logger.ts
@@ -151,6 +151,18 @@ class MidwayLoggers extends Map<string, ILogger> {
       disableConsole: consoleLevel === null,
       errorDir: dir,
     });
+
+    // overwrite values for pandora collect
+    (logger as any).values = () => {
+      return [
+        {
+          options: {
+            file: options.file,
+          }
+        }
+      ];
+    }
+
     this[loggerKey] = logger;
     this.set(loggerKey, logger);
     return logger;

--- a/packages/web/src/logger.ts
+++ b/packages/web/src/logger.ts
@@ -1,32 +1,17 @@
-import { EggLoggers as BaseEggLoggers, EggLogger, Transport } from 'egg-logger';
-import { loggers, MidwayBaseLogger, transports } from '@midwayjs/logger';
-import { relative, join, isAbsolute, dirname, basename } from 'path';
+import { EggLoggers } from 'egg-logger';
+import { loggers } from '@midwayjs/logger';
+import { join, isAbsolute } from 'path';
 import { existsSync, lstatSync, readFileSync, renameSync, unlinkSync } from 'fs';
-import { Application } from 'egg';
-import { MidwayFrameworkType, MidwayProcessTypeEnum } from '@midwayjs/core';
+import { Application, Context } from 'egg';
+import { MidwayProcessTypeEnum, MidwayContextLogger } from '@midwayjs/core';
 import { getCurrentDateString } from './utils';
 import * as os from 'os';
 
 const isWindows = os.platform() === 'win32';
 
-export class WebConsoleTransport extends transports.Console {
-
-  app: Application;
-  constructor(app: Application) {
-    super();
-    this.app = app;
-  }
-
-  log(info, callback) {
-    if (this.app.getFrameworkType() === MidwayFrameworkType.WEB) {
-      return;
-    }
-    return super.log(info, callback);
-  }
-}
-
 const levelTransform = (level) => {
   switch (level) {
+    case 'NONE':
     case Infinity:      // egg logger 的 none 是这个等级
       return null;
     case 0:
@@ -50,43 +35,6 @@ const levelTransform = (level) => {
   }
 }
 
-/**
- * output log into file {@link Transport}。
- */
-class WinstonTransport extends Transport {
-  transportLogger: MidwayBaseLogger;
-
-  constructor(options) {
-    super(options);
-    this.transportLogger = loggers.createLogger(
-      options.transportName,
-      Object.assign(options, {
-        disableConsole: true,
-        disableError: true,   // EggJS 的默认转发到错误日志是通过设置重复的 logger 实现的，在这种情况下代理会造成 midway 写入多个 error 日志，默认需要移除掉
-        level: levelTransform(options.level),
-      })
-    ) as MidwayBaseLogger;
-    // 由于现在的日志是个大池子，其他框架也会和 egg 复用日志对象，在这种场景下，如果和 egg 复用（socket）Logger，那么池子里存在的，可能只有 fileLogger，不会输出控制台日志。
-    // 解决的方法是，添加一个 transport，其中判断如果 app 是非 egg 的时候则输出
-    this.transportLogger.add(new WebConsoleTransport(options.app));
-  }
-
-  /**
-   * output log, see {@link Transport#log}
-   * @param  {String} level - log level
-   * @param  {Array} args - all arguments
-   * @param  {Object} meta - meta information
-   */
-  log(level, args, meta) {
-    const msg = (super.log(level, args, meta) as unknown) as string;
-    const winstonLevel = levelTransform(level);
-    if (winstonLevel) {
-      this.transportLogger.log(winstonLevel, msg.replace('\n', ''));
-    }
-  }
-}
-
-
 function isEmptyFile(p: string) {
   let content = readFileSync(p, {
     encoding: 'utf8'
@@ -94,7 +42,7 @@ function isEmptyFile(p: string) {
   return content === null || content === undefined || content === '';
 }
 
-function checkEggLoggerExists(dir, fileName, eggLoggerFiles) {
+export function checkEggLoggerExistsAndBackup(dir, fileName) {
   const file = isAbsolute(fileName) ? fileName : join(dir, fileName);
   if (existsSync(file) && !lstatSync(file).isSymbolicLink()) {
     // 如果是空文件，则直接删了，否则加入备份队列
@@ -104,16 +52,15 @@ function checkEggLoggerExists(dir, fileName, eggLoggerFiles) {
         unlinkSync(file);
       }
     } else {
-      eggLoggerFiles.push(fileName);
-      if (!isAbsolute(fileName)) {
-        eggLoggerFiles.push(join(dir, fileName));
-      }
+      const timeFormat = getCurrentDateString();
+      renameSync(file, file + '.' + timeFormat + '_eggjs_bak');
     }
   }
 }
 
-class EggLoggers extends BaseEggLoggers {
+class MidwayLoggers extends Map {
   app: Application;
+
   /**
    * @constructor
    * - logger
@@ -136,87 +83,58 @@ class EggLoggers extends BaseEggLoggers {
    * @param app
    */
   constructor(options, app: Application) {
-    super(options);
+    super();
     // 这么改是为了防止 egg 日志切割时遍历属性，导致报错
     Object.defineProperty(this, 'app', {
       value: app,
       enumerable: false,
     });
     /**
-     * 由于 egg 的日志生成不是软链，每次都会创建，无法覆盖这个行为
-     * 1、如果以前存在老的 egg 日志，必然存在非软链文件，则重命名备份
-     * 2、如果新项目没有老 egg 日志，必然在 super 时会创建空文件，则情况同 1
-     * 3、如果之前已经是 midway 的日志，则文本为软链，egg 也不会新创文件，则不作处理
+     * 提前备份 egg 日志
      */
-    const eggLoggerFiles = [];
     for (const name of [
       options.logger.appLogName,
       options.logger.coreLogName,
       options.logger.agentLogName,
       options.logger.errorLogName,
     ]) {
-      checkEggLoggerExists(options.logger.dir, name, eggLoggerFiles);
+      checkEggLoggerExistsAndBackup(options.logger.dir, name);
+    }
+    // 创建标准的日志
+    if (this.app.getProcessType() === MidwayProcessTypeEnum.AGENT) {
+      this.createLogger('coreLogger', {file: options.logger.agentLogName}, options.logger, 'agent:coreLogger');
+      this.createLogger('logger', {file: options.logger.appLogName}, options.logger, 'agent:logger');
+    } else {
+      this.createLogger('coreLogger', {file: options.logger.coreLogName}, options.logger, 'coreLogger');
+      this.createLogger('logger', {file: options.logger.appLogName}, options.logger, 'logger');
     }
     if (options.customLogger) {
-      for (const customLogger of Object.values(options.customLogger)) {
-        checkEggLoggerExists(
-          customLogger['dir'] || options.logger.dir,
-          customLogger['file'],
-          eggLoggerFiles
-        );
+      for (const loggerKey in options.customLogger) {
+        const customLogger = options.customLogger[loggerKey];
+        checkEggLoggerExistsAndBackup(customLogger['dir'] || options.logger.dir, customLogger['file']);
+        this.createLogger(loggerKey, customLogger, options.logger);
       }
-    }
-    for (const name of this.keys()) {
-      this.updateTransport(name, eggLoggerFiles);
     }
   }
 
-  updateTransport(name: string, eggLoggerFiles: string[]) {
-    const logger = this.get(name) as EggLogger;
-    const eggLogFile = (logger as any).options.file;
-    let fileLogName;
-    let logDir;
-    if (isAbsolute(eggLogFile)) {
-      logDir = dirname(eggLogFile);
-      fileLogName = basename(eggLogFile);
-    } else {
-      logDir = (logger as any).options.dir;
-      fileLogName = relative(logDir, eggLogFile);
-    }
+  createLogger(loggerKey, options, defaultLoggerOptions, createLoggerKey?: string) {
+    const level = options.level ? levelTransform(options.level) : levelTransform(defaultLoggerOptions.level);
+    const consoleLevel = options.consoleLevel ? levelTransform(options.consoleLevel) : levelTransform(defaultLoggerOptions.consoleLevel);
+    const dir = options['dir'] || defaultLoggerOptions.dir;
 
-    // 关闭日志
-    logger.get('file').close();
-
-    // 备份老 egg 日志
-    if (
-      existsSync(eggLogFile) &&
-      eggLoggerFiles.includes(eggLogFile)
-    ) {
-      const timeFormat = getCurrentDateString();
-      renameSync(eggLogFile, eggLogFile + '.' + timeFormat + '_eggjs_bak');
-    }
-
-    if (this.app.getProcessType() === MidwayProcessTypeEnum.AGENT) {
-      // agent 的日志名做特殊处理，使得和 application 分开
-      if (name === 'logger' || name === 'coreLogger') {
-        name = 'agent:' + name;
-      }
-    }
-
-    logger.set(
-      'file',
-      new WinstonTransport({
-        dir: logDir,
-        file: eggLogFile,     // 原来 egg 的 file
-        fileLogName,
-        level: (logger as any).options.level,
-        transportName: name,
-        app: this.app,
-        contextFormatter(meta) {
-          return meta.paddingMessage + ' ' + meta.message;
-        }
-      })
-    );
+    const logger = loggers.createLogger(createLoggerKey || loggerKey, {
+      dir,
+      fileLogName: options.file,
+      errorLogName: defaultLoggerOptions.errorLogName,
+      level,
+      consoleLevel,
+      disableFile: level === null,
+      disableConsole: consoleLevel === null,
+      errorDir: dir,
+    });
+    this[loggerKey] = logger;
+    this.set(loggerKey, logger);
+    return logger;
   }
 }
 
@@ -233,18 +151,47 @@ export const createLoggers = (app: Application) => {
     loggerConfig.level = 'INFO';
   }
 
-  const loggers = new EggLoggers(app.config, app);
+  let loggers;
 
-  // won't print to console after started, except for local and unittest
-  app.ready(() => {
-    if (loggerConfig.disableConsoleAfterReady) {
-      loggers.disableConsole();
-    }
-  });
-  loggers.coreLogger.info(
-    '[egg:logger] init all loggers with options: %j',
-    loggerConfig
-  );
+  if (app.config.logger['midwayMode'] === true) {
+    loggers = new MidwayLoggers(app.config, app);
+  } else {
+    loggers = new EggLoggers(app.config as any);
+    // won't print to console after started, except for local and unittest
+    app.ready(() => {
+      if (loggerConfig.disableConsoleAfterReady) {
+        loggers.disableConsole();
+      }
+    });
+    loggers.coreLogger.info(
+      '[egg:logger] init all loggers with options: %j',
+      loggerConfig
+    );
+  }
 
   return loggers;
 };
+
+
+export class MidwayWebContextLogger extends MidwayContextLogger<Context> {
+  formatContextLabel() {
+    const ctx = this.ctx;
+    // format: '[$userId/$ip/$traceId/$use_ms $method $url]'
+    const userId = ctx.userId || '-';
+    const traceId = (ctx.tracer && ctx.tracer.traceId) || '-';
+    const use = Date.now() - ctx.startTime;
+    return (
+      userId +
+      '/' +
+      ctx.ip +
+      '/' +
+      traceId +
+      '/' +
+      use +
+      'ms ' +
+      ctx.method +
+      ' ' +
+      ctx.url
+    );
+  }
+}

--- a/packages/web/test/fixtures/apps/mock-dev-app-egg-logger/package.json
+++ b/packages/web/test/fixtures/apps/mock-dev-app-egg-logger/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "ali-demo"
+}

--- a/packages/web/test/fixtures/apps/mock-dev-app-egg-logger/src/config/config.default.ts
+++ b/packages/web/test/fixtures/apps/mock-dev-app-egg-logger/src/config/config.default.ts
@@ -1,0 +1,4 @@
+exports.keys = 'd';
+exports.logger = {
+  midwayMode: false
+}

--- a/packages/web/test/fixtures/apps/mock-dev-app-egg-logger/src/config/config.default.ts
+++ b/packages/web/test/fixtures/apps/mock-dev-app-egg-logger/src/config/config.default.ts
@@ -1,4 +1,4 @@
 exports.keys = 'd';
-exports.logger = {
-  midwayMode: false
+export const midwayFeature = {
+  replaceEggLogger: false,
 }

--- a/packages/web/test/fixtures/apps/mock-dev-app-logger/src/config/config.default.ts
+++ b/packages/web/test/fixtures/apps/mock-dev-app-logger/src/config/config.default.ts
@@ -1,4 +1,4 @@
 exports.keys = 'd';
-exports.logger = {
-  midwayMode: true
+export const midwayFeature = {
+  replaceEggLogger: true,
 }

--- a/packages/web/test/fixtures/apps/mock-dev-app-logger/src/config/config.default.ts
+++ b/packages/web/test/fixtures/apps/mock-dev-app-logger/src/config/config.default.ts
@@ -1,1 +1,4 @@
 exports.keys = 'd';
+exports.logger = {
+  midwayMode: true
+}

--- a/packages/web/test/fixtures/apps/mock-dev-app/src/config/config.default.ts
+++ b/packages/web/test/fixtures/apps/mock-dev-app/src/config/config.default.ts
@@ -1,4 +1,4 @@
 exports.keys = 'd';
-exports.logger = {
-  midwayMode: true
+export const midwayFeature = {
+  replaceEggLogger: true,
 }

--- a/packages/web/test/fixtures/apps/mock-dev-app/src/config/config.default.ts
+++ b/packages/web/test/fixtures/apps/mock-dev-app/src/config/config.default.ts
@@ -1,1 +1,4 @@
 exports.keys = 'd';
+exports.logger = {
+  midwayMode: true
+}

--- a/packages/web/test/fixtures/apps/mock-production-app-do-not-force/src/config/config.default.ts
+++ b/packages/web/test/fixtures/apps/mock-production-app-do-not-force/src/config/config.default.ts
@@ -6,7 +6,10 @@ exports.watcher = {
 exports.logger = {
   level: 'DEBUG',
   allowDebugAtProd: true,
-  midwayMode: true,
 };
+
+export const midwayFeature = {
+  replaceEggLogger: true,
+}
 
 exports.keys = 'foo';

--- a/packages/web/test/fixtures/apps/mock-production-app-do-not-force/src/config/config.default.ts
+++ b/packages/web/test/fixtures/apps/mock-production-app-do-not-force/src/config/config.default.ts
@@ -6,6 +6,7 @@ exports.watcher = {
 exports.logger = {
   level: 'DEBUG',
   allowDebugAtProd: true,
+  midwayMode: true,
 };
 
 exports.keys = 'foo';

--- a/packages/web/test/fixtures/apps/mock-production-app/src/config/config.default.ts
+++ b/packages/web/test/fixtures/apps/mock-production-app/src/config/config.default.ts
@@ -7,8 +7,11 @@ exports.watcher = {
 
 exports.logger = {
   level: 'DEBUG',
-  midwayMode: true
 };
+
+export const midwayFeature = {
+  replaceEggLogger: true,
+}
 
 exports.customLogger = {
   middlewareLogger: {

--- a/packages/web/test/fixtures/apps/mock-production-app/src/config/config.default.ts
+++ b/packages/web/test/fixtures/apps/mock-production-app/src/config/config.default.ts
@@ -7,6 +7,7 @@ exports.watcher = {
 
 exports.logger = {
   level: 'DEBUG',
+  midwayMode: true
 };
 
 exports.customLogger = {

--- a/packages/web/test/fixtures/feature/base-app-component-config/src/config/config.default.ts
+++ b/packages/web/test/fixtures/feature/base-app-component-config/src/config/config.default.ts
@@ -7,3 +7,7 @@ export const hello = {
   b: 2,
   d: [1, 2, 3],
 };
+
+export const logger = {
+  midwayMode: true,
+}

--- a/packages/web/test/fixtures/feature/base-app-component-config/src/config/config.default.ts
+++ b/packages/web/test/fixtures/feature/base-app-component-config/src/config/config.default.ts
@@ -8,6 +8,6 @@ export const hello = {
   d: [1, 2, 3],
 };
 
-export const logger = {
-  midwayMode: true,
+export const midwayFeature = {
+  replaceEggLogger: true,
 }

--- a/packages/web/test/fixtures/feature/base-app-middleware/src/config/config.default.ts
+++ b/packages/web/test/fixtures/feature/base-app-middleware/src/config/config.default.ts
@@ -8,6 +8,6 @@ export const hello = {
 
 export const middleware = ['auth', 'globalMiddleware2'];
 
-export const logger = {
-  midwayMode: true,
+export const midwayFeature = {
+  replaceEggLogger: true,
 }

--- a/packages/web/test/fixtures/feature/base-app-middleware/src/config/config.default.ts
+++ b/packages/web/test/fixtures/feature/base-app-middleware/src/config/config.default.ts
@@ -7,3 +7,7 @@ export const hello = {
 };
 
 export const middleware = ['auth', 'globalMiddleware2'];
+
+export const logger = {
+  midwayMode: true,
+}

--- a/packages/web/test/fixtures/feature/base-app-plugin-inject/src/config/config.default.ts
+++ b/packages/web/test/fixtures/feature/base-app-plugin-inject/src/config/config.default.ts
@@ -9,3 +9,7 @@ export const hello = {
 };
 
 export const middleware = ['report'];
+
+export const logger = {
+  midwayMode: true,
+}

--- a/packages/web/test/fixtures/feature/base-app-plugin-inject/src/config/config.default.ts
+++ b/packages/web/test/fixtures/feature/base-app-plugin-inject/src/config/config.default.ts
@@ -10,6 +10,6 @@ export const hello = {
 
 export const middleware = ['report'];
 
-export const logger = {
-  midwayMode: true,
+export const midwayFeature = {
+  replaceEggLogger: true,
 }

--- a/packages/web/test/fixtures/feature/base-app-use-custom-egg/src/config/config.default.ts
+++ b/packages/web/test/fixtures/feature/base-app-use-custom-egg/src/config/config.default.ts
@@ -10,8 +10,8 @@ export = (appInfo) => {
       d: [1, 2, 3],
     },
     rundir: join(appInfo.appDir, 'run'),
-    logger: {
-      midwayMode: true,
+    midwayFeature: {
+      replaceEggLogger: true,
     }
   }
 }

--- a/packages/web/test/fixtures/feature/base-app-use-custom-egg/src/config/config.default.ts
+++ b/packages/web/test/fixtures/feature/base-app-use-custom-egg/src/config/config.default.ts
@@ -9,6 +9,9 @@ export = (appInfo) => {
       b: 2,
       d: [1, 2, 3],
     },
-    rundir: join(appInfo.appDir, 'run')
+    rundir: join(appInfo.appDir, 'run'),
+    logger: {
+      midwayMode: true,
+    }
   }
 }

--- a/packages/web/test/fixtures/feature/base-app/src/config/config.default.ts
+++ b/packages/web/test/fixtures/feature/base-app/src/config/config.default.ts
@@ -7,3 +7,7 @@ export const hello = {
   b: 2,
   d: [1, 2, 3],
 };
+
+export const logger = {
+  midwayMode: true,
+}

--- a/packages/web/test/fixtures/feature/base-app/src/config/config.default.ts
+++ b/packages/web/test/fixtures/feature/base-app/src/config/config.default.ts
@@ -8,6 +8,6 @@ export const hello = {
   d: [1, 2, 3],
 };
 
-export const logger = {
-  midwayMode: true,
+export const midwayFeature = {
+  replaceEggLogger: true,
 }

--- a/packages/web/test/logger.test.ts
+++ b/packages/web/test/logger.test.ts
@@ -70,7 +70,7 @@ describe('test/logger.test.js', () => {
     // 先创建一些文件
     writeFileSync(join(logsDir, 'common-error.log'), 'hello world');
     writeFileSync(join(logsDir, 'egg-schedule.log'), 'hello world');
-    writeFileSync(join(logsDir, 'midway-agent.log'), 'hello world');
+    writeFileSync(join(logsDir, 'midway-agent.log'), '');
     writeFileSync(join(logsDir, 'midway-core.log'), 'hello world');
     writeFileSync(join(logsDir, 'midway-web.log'), 'hello world');
     const app = await creatApp('apps/mock-dev-app', { cleanLogsDir: false});
@@ -79,7 +79,8 @@ describe('test/logger.test.js', () => {
     // 备份文件存在
     expect(existsSync(join(logsDir, 'common-error.log.' + timeFormat + '_eggjs_bak'))).toBeTruthy();
     expect(existsSync(join(logsDir, 'egg-schedule.log.' + timeFormat + '_eggjs_bak'))).toBeTruthy();
-    expect(existsSync(join(logsDir, 'midway-agent.log.' + timeFormat + '_eggjs_bak'))).toBeTruthy();
+    // 这个文件被删了，不需要备份
+    // expect(existsSync(join(logsDir, 'midway-agent.log.' + timeFormat + '_eggjs_bak'))).toBeTruthy();
     expect(existsSync(join(logsDir, 'midway-core.log.' + timeFormat + '_eggjs_bak'))).toBeTruthy();
     expect(existsSync(join(logsDir, 'midway-web.log.' + timeFormat + '_eggjs_bak'))).toBeTruthy();
 

--- a/packages/web/test/logger.test.ts
+++ b/packages/web/test/logger.test.ts
@@ -19,6 +19,15 @@ describe('test/logger.test.js', () => {
     await ensureDir(logsDir);
     const app = await creatApp('apps/mock-dev-app-logger', { cleanLogsDir: false});
     app.coreLogger.warn('custom content');
+
+    // for test pandora collect
+    for(const name of app.loggers.keys()) {
+      const logger = app.loggers.get(name);
+      for (const transport of logger.values()) {
+        console.log((transport as any).options.file);
+      }
+    }
+
     app.createAnonymousContext().logger.warn('custom content in context');
     await sleep();
     const timeFormat = getCurrentDateString();

--- a/packages/web/test/logger.test.ts
+++ b/packages/web/test/logger.test.ts
@@ -53,7 +53,7 @@ describe('test/logger.test.js', () => {
 
   it('should backup egg logger file when start', async () => {
     mm(process.env, 'MIDWAY_SERVER_ENV', '');
-    mm(process.env, 'EGG_SERVER_ENV', 'local'                                                          );
+    mm(process.env, 'EGG_SERVER_ENV', 'local');
     mm(process.env, 'EGG_LOG', 'ERROR');
     const logsDir = join(__dirname, 'fixtures/apps/mock-dev-app/logs/ali-demo');
     await remove(logsDir);


### PR DESCRIPTION
- 1、将 egg logger 和 midway logger 分离，增加开关 fix: #822 
- 2、给 logger 增加动态修改文件 level 和控制台输出 level
- 3、去除默认 info 输出的绿色字体
- 4、原来是 midway 日志，改为使用 egg logger 之后，预先删除软链