### PR TITLE
fix: add info level for core logger in local env

### DIFF
--- a/packages/web/config/config.local.js
+++ b/packages/web/config/config.local.js
@@ -1,0 +1,5 @@
+exports.logger = {
+  coreLogger: {
+    consoleLevel: 'INFO'
+  }
+}


### PR DESCRIPTION
控制台本地输出，默认隐藏了 info。