### PR TITLE
fix: disable coreLogger info console output in local env

### DIFF
--- a/packages/web-express/src/framework.ts
+++ b/packages/web-express/src/framework.ts
@@ -279,7 +279,9 @@ export class MidwayExpressFramework extends BaseFramework<
             [];
 
           this.logger.info(
-            `Load Router "${webRouter.requestMethod.toUpperCase()} ${webRouter.path}"`
+            `Load Router "${webRouter.requestMethod.toUpperCase()} ${
+              webRouter.path
+            }"`
           );
           // apply controller from request context
           newRouter[webRouter.requestMethod].call(

--- a/packages/web-express/src/framework.ts
+++ b/packages/web-express/src/framework.ts
@@ -279,7 +279,7 @@ export class MidwayExpressFramework extends BaseFramework<
             [];
 
           this.logger.info(
-            `Load Router "${webRouter.requestMethod} ${webRouter.path}"`
+            `Load Router "${webRouter.requestMethod.toUpperCase()} ${webRouter.path}"`
           );
           // apply controller from request context
           newRouter[webRouter.requestMethod].call(

--- a/packages/web-koa/src/framework.ts
+++ b/packages/web-koa/src/framework.ts
@@ -222,7 +222,7 @@ export abstract class MidwayKoaBaseFramework<
           ];
 
           this.logger.info(
-            `Load Router "${webRouter.requestMethod} ${webRouter.path}"`
+            `Load Router "${webRouter.requestMethod.toUpperCase()} ${webRouter.path}"`
           );
 
           // apply controller from request context
@@ -275,6 +275,10 @@ export abstract class MidwayKoaBaseFramework<
         }
       }
     }
+  }
+
+  public getDefaultContextLoggerClass() {
+    return MidwayKoaContextLogger;
   }
 }
 
@@ -361,9 +365,5 @@ export class MidwayKoaFramework extends MidwayKoaBaseFramework<
 
   public getServer() {
     return this.server;
-  }
-
-  public getDefaultContextLoggerClass() {
-    return MidwayKoaContextLogger;
   }
 }

--- a/packages/web-koa/src/framework.ts
+++ b/packages/web-koa/src/framework.ts
@@ -222,7 +222,9 @@ export abstract class MidwayKoaBaseFramework<
           ];
 
           this.logger.info(
-            `Load Router "${webRouter.requestMethod.toUpperCase()} ${webRouter.path}"`
+            `Load Router "${webRouter.requestMethod.toUpperCase()} ${
+              webRouter.path
+            }"`
           );
 
           // apply controller from request context

--- a/packages/web/config/config.local.js
+++ b/packages/web/config/config.local.js
@@ -1,5 +1,0 @@
-exports.logger = {
-  coreLogger: {
-    consoleLevel: 'INFO',
-  },
-};

--- a/packages/web/src/framework/web.ts
+++ b/packages/web/src/framework/web.ts
@@ -6,7 +6,7 @@ import {
 } from '@midwayjs/core';
 import { ControllerOption, CONFIG_KEY, PLUGIN_KEY } from '@midwayjs/decorator';
 import { IMidwayWebConfigurationOptions } from '../interface';
-import { MidwayKoaBaseFramework, MidwayKoaContextLogger } from '@midwayjs/koa';
+import { MidwayKoaBaseFramework } from '@midwayjs/koa';
 import { EggRouter } from '@eggjs/router';
 import { Application, Context, Router, EggLogger } from 'egg';
 import { loggers } from '@midwayjs/logger';
@@ -66,7 +66,7 @@ export class MidwayWebFramework extends MidwayKoaBaseFramework<
     if (this.app.config.midwayFeature['replaceEggLogger']) {
       Object.defineProperty(this.app, 'ContextLogger', {
         get() {
-          return MidwayKoaContextLogger;
+          return self.BaseContextLoggerClass;
         },
       });
     }

--- a/packages/web/src/framework/web.ts
+++ b/packages/web/src/framework/web.ts
@@ -32,6 +32,10 @@ export class MidwayWebFramework extends MidwayKoaBaseFramework<
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const self = this;
     this.configurationOptions = options;
+    // set default context logger
+    this.BaseContextLoggerClass =
+      options.ContextLoggerClass || this.getDefaultContextLoggerClass();
+
     if (options.typescript === false) {
       this.isTsMode = false;
     }
@@ -64,6 +68,7 @@ export class MidwayWebFramework extends MidwayKoaBaseFramework<
     );
 
     if (this.app.config.midwayFeature['replaceEggLogger']) {
+      // if use midway logger will be use midway custom context logger
       Object.defineProperty(this.app, 'ContextLogger', {
         get() {
           return self.BaseContextLoggerClass;

--- a/packages/web/src/logger.ts
+++ b/packages/web/src/logger.ts
@@ -132,7 +132,11 @@ class MidwayLoggers extends Map<string, ILogger> {
     if (this.app.getProcessType() === MidwayProcessTypeEnum.AGENT) {
       this.createLogger(
         'coreLogger',
-        { file: options.logger.agentLogName },
+        {
+          file: options.logger.agentLogName,
+          level: options.logger?.coreLogger?.level,
+          consoleLevel: options.logger?.coreLogger?.consoleLevel,
+        },
         options.logger,
         'agent:coreLogger'
       );
@@ -145,7 +149,11 @@ class MidwayLoggers extends Map<string, ILogger> {
     } else {
       this.createLogger(
         'coreLogger',
-        { file: options.logger.coreLogName },
+        {
+          file: options.logger.coreLogName,
+          level: options.logger?.coreLogger?.level,
+          consoleLevel: options.logger?.coreLogger?.consoleLevel,
+        },
         options.logger,
         'coreLogger'
       );

--- a/packages/web/test/feature.test.ts
+++ b/packages/web/test/feature.test.ts
@@ -1,4 +1,4 @@
-import { closeApp, creatApp, createHttpRequest, matchContentTimes } from './utils';
+import { closeApp, creatApp, createHttpRequest, matchContentTimes, sleep } from './utils';
 import { IMidwayWebApplication } from '../src/interface';
 import { join } from 'path';
 
@@ -75,6 +75,7 @@ describe('/test/feature.test.ts', () => {
       .query({ name: 'harry' });
     expect(result.status).toEqual(200);
     expect(result.text).toEqual('hello world,harry');
+    await sleep();
     expect(matchContentTimes(join(app.getAppDir(), 'logs', 'ali-demo', 'midway-web.log'), 'custom label')).toEqual(1);
     await closeApp(app);
   });

--- a/packages/web/test/feature.test.ts
+++ b/packages/web/test/feature.test.ts
@@ -1,5 +1,6 @@
-import { closeApp, creatApp, createHttpRequest } from './utils';
+import { closeApp, creatApp, createHttpRequest, matchContentTimes } from './utils';
 import { IMidwayWebApplication } from '../src/interface';
+import { join } from 'path';
 
 describe('/test/feature.test.ts', () => {
   describe('test new decorator', () => {
@@ -64,6 +65,17 @@ describe('/test/feature.test.ts', () => {
     const app = await creatApp('feature/base-app-plugin-inject');
     const result = await createHttpRequest(app).get('/');
     expect(result.text).toEqual('hello worldaaaa1aaaa');
+    await closeApp(app);
+  });
+
+  it('should test set custom logger in egg by midway logger', async () => {
+    const app = await creatApp('feature/base-app-set-ctx-logger');
+    const result = await createHttpRequest(app)
+      .get('/')
+      .query({ name: 'harry' });
+    expect(result.status).toEqual(200);
+    expect(result.text).toEqual('hello world,harry');
+    expect(matchContentTimes(join(app.getAppDir(), 'logs', 'ali-demo', 'midway-web.log'), 'custom label')).toEqual(1);
     await closeApp(app);
   });
 

--- a/packages/web/test/fixtures/feature/base-app-set-ctx-logger/package.json
+++ b/packages/web/test/fixtures/feature/base-app-set-ctx-logger/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "ali-demo"
+}

--- a/packages/web/test/fixtures/feature/base-app-set-ctx-logger/src/config/config.default.ts
+++ b/packages/web/test/fixtures/feature/base-app-set-ctx-logger/src/config/config.default.ts
@@ -1,0 +1,13 @@
+'use strict';
+
+export const keys = 'key';
+
+export const hello = {
+  a: 1,
+  b: 2,
+  d: [1, 2, 3],
+};
+
+export const midwayFeature = {
+  replaceEggLogger: true,
+}

--- a/packages/web/test/fixtures/feature/base-app-set-ctx-logger/src/config/config.unittest.ts
+++ b/packages/web/test/fixtures/feature/base-app-set-ctx-logger/src/config/config.unittest.ts
@@ -1,0 +1,5 @@
+
+exports.hello = {
+  b: 4,
+  c: 3,
+};

--- a/packages/web/test/fixtures/feature/base-app-set-ctx-logger/src/configuration.ts
+++ b/packages/web/test/fixtures/feature/base-app-set-ctx-logger/src/configuration.ts
@@ -1,0 +1,16 @@
+import { Configuration, App } from '@midwayjs/decorator';
+import { MidwayCustomContextLogger } from './logger';
+
+@Configuration({
+  importConfigs: [
+    './config'
+  ]
+})
+export class ContainerConfiguration {
+  @App()
+  app: any;
+
+  async onReady() {
+    this.app.setContextLoggerClass(MidwayCustomContextLogger);
+  }
+}

--- a/packages/web/test/fixtures/feature/base-app-set-ctx-logger/src/controller/api.ts
+++ b/packages/web/test/fixtures/feature/base-app-set-ctx-logger/src/controller/api.ts
@@ -1,0 +1,20 @@
+import {
+  Controller,
+  Get,
+  Provide,
+  Inject,
+  Query,
+} from '@midwayjs/decorator';
+
+@Provide()
+@Controller('/')
+export class APIController {
+  @Inject()
+  ctx: any;
+
+  @Get('/')
+  async home(@Query('name') name: string) {
+    this.ctx.logger.info('custom label');
+    return 'hello world,' + name;
+  }
+}

--- a/packages/web/test/fixtures/feature/base-app-set-ctx-logger/src/logger.ts
+++ b/packages/web/test/fixtures/feature/base-app-set-ctx-logger/src/logger.ts
@@ -1,0 +1,9 @@
+import { MidwayContextLogger } from '@midwayjs/core';
+import { Context } from 'egg';
+
+export class MidwayCustomContextLogger extends MidwayContextLogger<Context> {
+  formatContextLabel() {
+    const ctx = this.ctx;
+    return `${Date.now() - ctx.startTime}ms ${ctx.method}`;
+  }
+}


### PR DESCRIPTION
- 1、本地日志还是输出太多，和默认 egg 启动保持一致，不再输出 core logger 的日志。如有需求，可以使用 app.logger 或者调整日志解决
- 2、midway logger 之前未适配 egg 部分配置
- 3、修复 contextLogger 未覆盖成功的错误