### PR TITLE
feat: support inject by class

### DIFF
--- a/packages/decorator/src/common/decoratorManager.ts
+++ b/packages/decorator/src/common/decoratorManager.ts
@@ -23,7 +23,7 @@ import {
   INVALID_DECORATOR_OPERATION,
 } from './errMsg';
 import { Metadata } from './metadata';
-import { getParamNames, classNamed, isNullOrUndefined } from '../util';
+import { getParamNames, classNamed, isNullOrUndefined, isClass } from '../util';
 
 const debug = require('util').debuglog('decorator:manager');
 
@@ -958,7 +958,12 @@ export function getConstructorInject(target: any): TagPropsMetadata[] {
 export function savePropertyInject(opts: InjectOptions) {
   let identifier = opts.identifier;
   if (!identifier) {
-    identifier = opts.targetKey;
+    const type = getPropertyType(opts.target, opts.targetKey);
+    if (!type.isBaseType && isClass(type.originDesign)) {
+      identifier = getProviderId(type.originDesign);
+    } else {
+      identifier = opts.targetKey;
+    }
   }
   if (identifier.includes('@') && !identifier.includes(':')) {
     identifier = `${identifier}:${opts.targetKey}`;

--- a/packages/decorator/src/common/decoratorManager.ts
+++ b/packages/decorator/src/common/decoratorManager.ts
@@ -961,7 +961,8 @@ export function savePropertyInject(opts: InjectOptions) {
     const type = getPropertyType(opts.target, opts.targetKey);
     if (!type.isBaseType && isClass(type.originDesign)) {
       identifier = getProviderId(type.originDesign);
-    } else {
+    }
+    if (!identifier) {
       identifier = opts.targetKey;
     }
   }

--- a/packages/decorator/test/annotation/inject.test.ts
+++ b/packages/decorator/test/annotation/inject.test.ts
@@ -4,6 +4,10 @@ import { Provide, Inject, getConstructorInject, getPropertyInject } from '../../
 class InjectChild {
 }
 
+class InjectChild2 {
+}
+
+
 class Test {
   constructor(@Inject() bb: any, @Inject() cc: any, @Inject() dd: InjectChild) {
     // ignore
@@ -14,6 +18,9 @@ class Test {
 
   @Inject()
   ee: InjectChild;
+
+  @Inject()
+  ff: InjectChild2;
 }
 
 describe('/test/annotation/inject.test.ts', () => {
@@ -51,10 +58,16 @@ describe('/test/annotation/inject.test.ts', () => {
           value: 'aa',
         },
       ],
-      'ee': [
+      ee: [
         {
           'key': 'inject',
           'value': 'injectChild'
+        }
+      ],
+      ff: [
+        {
+          'key': 'inject',
+          'value': 'ff'
         }
       ]
     });

--- a/packages/decorator/test/annotation/inject.test.ts
+++ b/packages/decorator/test/annotation/inject.test.ts
@@ -1,11 +1,19 @@
-import { Inject, getConstructorInject, getPropertyInject } from '../../src';
+import { Provide, Inject, getConstructorInject, getPropertyInject } from '../../src';
+
+@Provide()
+class InjectChild {
+}
 
 class Test {
-  constructor(@Inject() bb: any, @Inject() cc: any) {
+  constructor(@Inject() bb: any, @Inject() cc: any, @Inject() dd: InjectChild) {
     // ignore
   }
+
   @Inject()
   aa: any;
+
+  @Inject()
+  ee: InjectChild;
 }
 
 describe('/test/annotation/inject.test.ts', () => {
@@ -26,6 +34,12 @@ describe('/test/annotation/inject.test.ts', () => {
           value: 'cc',
         },
       ],
+      2: [
+        {
+          key: 'inject',
+          value: 'dd'
+        }
+      ]
     });
 
     meta = getPropertyInject(Test);
@@ -37,6 +51,12 @@ describe('/test/annotation/inject.test.ts', () => {
           value: 'aa',
         },
       ],
+      'ee': [
+        {
+          'key': 'inject',
+          'value': 'injectChild'
+        }
+      ]
     });
   });
 });

--- a/packages/decorator/test/annotation/inject.test.ts
+++ b/packages/decorator/test/annotation/inject.test.ts
@@ -67,7 +67,7 @@ describe('/test/annotation/inject.test.ts', () => {
       ff: [
         {
           'key': 'inject',
-          'value': 'ff'
+          'value': 'injectChild2'
         }
       ]
     });


### PR DESCRIPTION
如果属性明确标识了 class 类型，则取 class 的 provideId 做为 key。比如

```ts
@Provode()
class UserService {}

@Provide()
class UserController {

  @Inject()
  service: UserService;   // 这里因为标识的是class，那么注入的就是这个类型
}

老代码这样写，由于获取的是属性名，所以会报错，但是新代码下可以成功注入。

但是在下面的代码下，是 breaking change。

```ts
@Provide()
class InjectParent {
}

@Provide()
class InjectChild extends InjectParent {
}

class Test {
  @Inject()
  child: InjectParent;

  @Inject()
  InjectChild: InjectParent;
}
```

这里有个 breaking change，如果类型显示是父类，按照新逻辑，注入的实例就会是父类，而不是子类，但是老的场景下就会是子类。
