### PR TITLE
fix: stack missing in context logger

### DIFF
--- a/packages/logger/src/format.ts
+++ b/packages/logger/src/format.ts
@@ -43,6 +43,18 @@ export const displayCommonMessage = format(
       );
     }
 
+    // error(new Error(''), {label: 1}) 的情况
+    if (info.message['stack'] && info.message['message']) {
+      // info.message = info.message.replace(err.message, '') + err.stack;
+      const err = new Error(info.message['message']);
+      err.name = info.message['name'];
+      err.stack = info.message['stack'];
+      info.originError = err;
+      info.stack = info.message['stack'];
+      info.message = err.stack;
+      info[MESSAGE] = info[MESSAGE] || info.message;
+    }
+
     // 处理数组，Map，Set 的 message
     if (
       Array.isArray(info.message) ||

--- a/packages/logger/src/format.ts
+++ b/packages/logger/src/format.ts
@@ -45,7 +45,6 @@ export const displayCommonMessage = format(
 
     // error(new Error(''), {label: 1}) 的情况
     if (info.message['stack'] && info.message['message']) {
-      // info.message = info.message.replace(err.message, '') + err.stack;
       const err = new Error(info.message['message']);
       err.name = info.message['name'];
       err.stack = info.message['stack'];

--- a/packages/logger/test/index.test.ts
+++ b/packages/logger/test/index.test.ts
@@ -213,10 +213,13 @@ describe('/test/index.test.ts', () => {
     await removeFileOrDir(join(process.cwd(), 'common-error.log'));
     const consoleLogger = createConsoleLogger('consoleLogger');
     consoleLogger.error('test console error');
+    console.log('---');
     const err = new Error('custom error');
     err.name = 'MyCustomError';
     consoleLogger.error(err);
+    consoleLogger.error(err, { label: 123});
     consoleLogger.error('before:', err);
+    console.log('---');
     consoleLogger.info('启动耗时 %d ms', 111);
     consoleLogger.info('%j', {a: 1});
     consoleLogger.debug('1', '2', '3');


### PR DESCRIPTION
原来 

```
  async home() {
    throw new Error('bbb');
  }
```
修复前
![image](https://user-images.githubusercontent.com/418820/106927579-46a08600-674d-11eb-9ead-80d0be9234d6.png)

修复后

![image](https://user-images.githubusercontent.com/418820/106927713-689a0880-674d-11eb-95be-48a02a67f193.png)


