### PR TITLE
fix: ctx logger overwrite in egg extend

### DIFF
--- a/packages/web/agent.js
+++ b/packages/web/agent.js
@@ -5,6 +5,13 @@ class AgentBootHook {
     this.app = app;
   }
 
+  configDidLoad() {
+    if (this.app.config.midwayFeature['replaceEggLogger']) {
+      // if use midway logger will be use midway custom context logger
+      this.app.ContextLogger = this.app.webFramework.BaseContextLoggerClass;
+    }
+  }
+
   async didLoad() {}
 
   async willReady() {}

--- a/packages/web/app.js
+++ b/packages/web/app.js
@@ -15,6 +15,10 @@ class AppBootHook {
     this.app.loader.config.coreMiddleware = [];
     this.appMiddleware = this.app.loader.config.appMiddleware;
     this.app.loader.config.appMiddleware = [];
+    if (this.app.config.midwayFeature['replaceEggLogger']) {
+      // if use midway logger will be use midway custom context logger
+      this.app.ContextLogger = this.app.webFramework.BaseContextLoggerClass;
+    }
   }
 
   async didLoad() {

--- a/packages/web/app/extend/agent.js
+++ b/packages/web/app/extend/agent.js
@@ -1,0 +1,13 @@
+module.exports = {
+  get baseDir() {
+    return this.loader.baseDir;
+  },
+
+  get appDir() {
+    return this.loader.appDir;
+  },
+
+  get webFramework() {
+    return this.loader.framework;
+  },
+};

--- a/packages/web/src/framework/web.ts
+++ b/packages/web/src/framework/web.ts
@@ -215,4 +215,9 @@ export class MidwayWebFramework extends MidwayKoaBaseFramework<
     }
     return null;
   }
+
+  protected setContextLoggerClass(BaseContextLogger: any) {
+    this.BaseContextLoggerClass = BaseContextLogger;
+    this.app.ContextLogger = BaseContextLogger;
+  }
 }

--- a/packages/web/test/feature.test.ts
+++ b/packages/web/test/feature.test.ts
@@ -1,5 +1,5 @@
 import { closeApp, creatApp, createHttpRequest, matchContentTimes, sleep } from './utils';
-import { IMidwayWebApplication } from '../src/interface';
+import { IMidwayWebApplication } from '../src';
 import { join } from 'path';
 
 describe('/test/feature.test.ts', () => {
@@ -76,7 +76,8 @@ describe('/test/feature.test.ts', () => {
     expect(result.status).toEqual(200);
     expect(result.text).toEqual('hello world,harry');
     await sleep();
-    expect(matchContentTimes(join(app.getAppDir(), 'logs', 'ali-demo', 'midway-web.log'), 'custom label')).toEqual(1);
+    expect(matchContentTimes(join(app.getAppDir(), 'logs', 'ali-demo', 'midway-web.log'), 'GET /] aaaaa')).toEqual(3);
+    expect(matchContentTimes(join(app.getAppDir(), 'logs', 'ali-demo', 'midway-web.log'), 'abcde] custom label')).toEqual(1);
     await closeApp(app);
   });
 

--- a/packages/web/test/fixtures/feature/base-app-set-ctx-logger/src/agent.ts
+++ b/packages/web/test/fixtures/feature/base-app-set-ctx-logger/src/agent.ts
@@ -1,0 +1,10 @@
+import { Application } from 'egg';
+import * as assert from 'assert';
+import { join } from 'path';
+
+module.exports = (app: Application) => {
+  assert(app.baseDir === __dirname);
+  assert((app as any).appDir === join(__dirname, '..'));
+  assert((app as any).applicationContext);
+  app.createAnonymousContext().logger.warn('aaaaa');
+}

--- a/packages/web/test/fixtures/feature/base-app-set-ctx-logger/src/app.ts
+++ b/packages/web/test/fixtures/feature/base-app-set-ctx-logger/src/app.ts
@@ -1,0 +1,10 @@
+import * as assert from 'assert';
+import { join } from 'path';
+import { Application } from 'egg';
+
+module.exports = (app: Application) => {
+  assert(app.baseDir === __dirname);
+  assert((app as any).appDir === join(__dirname, '..'));
+  assert((app as any).applicationContext);
+  app.createAnonymousContext().logger.warn('aaaaa');
+}

--- a/packages/web/test/fixtures/feature/base-app-set-ctx-logger/src/configuration.ts
+++ b/packages/web/test/fixtures/feature/base-app-set-ctx-logger/src/configuration.ts
@@ -11,6 +11,8 @@ export class ContainerConfiguration {
   app: any;
 
   async onReady() {
+    this.app.createAnonymousContext().logger.warn('aaaaa');
     this.app.setContextLoggerClass(MidwayCustomContextLogger);
+    this.app.createAnonymousContext().logger.warn('ccccc');
   }
 }

--- a/packages/web/test/fixtures/feature/base-app-set-ctx-logger/src/logger.ts
+++ b/packages/web/test/fixtures/feature/base-app-set-ctx-logger/src/logger.ts
@@ -4,6 +4,6 @@ import { Context } from 'egg';
 export class MidwayCustomContextLogger extends MidwayContextLogger<Context> {
   formatContextLabel() {
     const ctx = this.ctx;
-    return `${Date.now() - ctx.startTime}ms ${ctx.method}`;
+    return `${Date.now() - ctx.startTime}ms ${ctx.method} abcde`;
   }
 }

--- a/packages/web/test/utils.ts
+++ b/packages/web/test/utils.ts
@@ -47,7 +47,7 @@ export const matchContentTimes = (p: string, matchString: string | RegExp) => {
   }
 
   if (typeof matchString === 'string') {
-    matchString = new RegExp(matchString);
+    matchString = new RegExp(matchString, 'g');
   }
 
   const result = content.match(matchString) || [];


### PR DESCRIPTION
修复egg 框架继承的情况下，提前使用 ctx.logger 输出报错 "[winston] Unknown logger level: INFO" 的情况。错误如截图。

![image](https://user-images.githubusercontent.com/418820/107148297-68884b80-698d-11eb-83f3-615d634306dc.png)
