### PR TITLE
fix: loggers with egg logger instance and invoke disableConsole method

### DIFF
--- a/packages/web/src/logger.ts
+++ b/packages/web/src/logger.ts
@@ -8,7 +8,7 @@ import {
   renameSync,
   unlinkSync,
 } from 'fs';
-import { Application } from 'egg';
+import { Application, EggLogger } from 'egg';
 import { MidwayProcessTypeEnum } from '@midwayjs/core';
 import { getCurrentDateString } from './utils';
 import * as os from 'os';
@@ -219,12 +219,21 @@ class MidwayLoggers extends Map<string, ILogger> {
 
   disableConsole() {
     for (const value of this.values()) {
-      (value as IMidwayLogger)?.disableConsole();
+      if ((value as IMidwayLogger)?.disableConsole) {
+        (value as IMidwayLogger)?.disableConsole();
+      } else if ((value as EggLogger).disable) {
+        (value as EggLogger).disable('console');
+      }
     }
   }
 
   reload() {
-    // empty method for egg logrotator
+    // 忽略 midway logger，只有 egg logger 需要做切割
+    for (const value of this.values()) {
+      if ((value as EggLogger).reload) {
+        (value as EggLogger).reload();
+      }
+    }
   }
 }
 

--- a/packages/web/test/logger.test.ts
+++ b/packages/web/test/logger.test.ts
@@ -4,6 +4,7 @@ import { join } from 'path';
 import { existsSync, readFileSync, writeFileSync, ensureDir, remove, symlinkSync } from 'fs-extra';
 import { lstatSync } from 'fs';
 import { getCurrentDateString } from '../src/utils';
+import { EggLogger } from 'egg-logger';
 
 describe('test/logger.test.js', () => {
 
@@ -248,6 +249,12 @@ describe('test/logger.test.js', () => {
     mm(process.env, 'EGG_HOME', getFilepath('apps/mock-production-app/src/config'));
     const app = await creatApp('apps/mock-production-app');
 
+    app.loggers.set('anotherLogger', new EggLogger({
+      file: join(process.env['EGG_HOME'],'another.log'),
+    }));
+
+    app.loggers.disableConsole();
+
     expect(app.config.logger.disableConsoleAfterReady === true);
     const ctx = app.mockContext();
     const logfile = join(app.config.logger.dir, 'common-error.log');
@@ -258,6 +265,8 @@ describe('test/logger.test.js', () => {
     console.log(logfile)
     expect(existsSync(logfile)).toBeTruthy();
     expect(readFileSync(logfile, 'utf8').includes(''));
+
+    app.loggers.reload();
     await closeApp(app);
   });
 


### PR DESCRIPTION
修复这个问题

```
2021-02-09 14:38:06,377 ERROR 95067 TypeError: _a.disableConsole is not a function
    at Map.disableConsole (/Users/harry/project/gitlab/std-service-market/node_modules/_@midwayjs_web@2.7.3@@midwayjs/web/dist/logger.js:177:66)
    at /Users/harry/project/gitlab/std-service-market/node_modules/_@midwayjs_web@2.7.3@@midwayjs/web/dist/logger.js:203:21
    at /Users/harry/project/gitlab/std-service-market/node_modules/_get-ready@2.0.1@get-ready/index.js:73:53
    at processTicksAndRejections (internal/process/task_queues.js:79:11)
```