### PR TITLE
fix: support user config code dir

### DIFF
--- a/packages/faas/src/starter.ts
+++ b/packages/faas/src/starter.ts
@@ -49,6 +49,7 @@ export class FaaSStarter implements IFaaSStarter {
   constructor(
     options: {
       baseDir?: string;
+      codeDir?: string;
       config?: object;
       middleware?: string[];
       typescript?: boolean;
@@ -67,7 +68,7 @@ export class FaaSStarter implements IFaaSStarter {
      */
     this.globalMiddleware = options.middleware || [];
     this.logger = options.logger || console;
-    this.baseDir = this.getFaaSBaseDir();
+    this.baseDir = options.codeDir || this.getFaaSBaseDir();
     this.initializeContext = options.initializeContext || {};
     this.webApplication = this.defineApplicationProperties(
       options.applicationAdapter?.getApplication() || {}


### PR DESCRIPTION
用于在一体化环境中指定代码目录为 `/src/apis` 这样的路径。

在原有逻辑中，会根据是否为ts环境来在 `appDir` 后面添加 src 或 dist，但是这在一体化项目中无法满足，导致 configuration.ts 等依赖于 `baseDir` 配置的内容无法被加载。  