### PR TITLE
feat: compatible read config.prod and config.unittest

### DIFF
--- a/packages/core/src/service/configService.ts
+++ b/packages/core/src/service/configService.ts
@@ -14,6 +14,10 @@ export class MidwayConfigService implements IConfigService {
   isReady = false;
   container: IMidwayContainer;
   externalObject: Record<string, unknown>[] = [];
+  aliasMap = {
+    prod: 'production',
+    unittest: 'test',
+  };
 
   constructor(container) {
     this.container = container;
@@ -27,6 +31,9 @@ export class MidwayConfigService implements IConfigService {
         const env = this.getConfigEnv(dir);
         const envSet = this.getEnvSet(env);
         envSet.add(dir);
+        if (this.aliasMap[env]) {
+          this.getEnvSet(this.aliasMap[env]).add(dir);
+        }
       } else {
         // directory
         const fileStat = statSync(dir);

--- a/packages/core/test/services/fixtures/compatible_production/config.default.ts
+++ b/packages/core/test/services/fixtures/compatible_production/config.default.ts
@@ -1,0 +1,3 @@
+export const key = {
+  data: 123,
+}

--- a/packages/core/test/services/fixtures/compatible_production/config.prod.ts
+++ b/packages/core/test/services/fixtures/compatible_production/config.prod.ts
@@ -1,0 +1,3 @@
+export const bbb = {
+  data: 123,
+}

--- a/packages/core/test/services/fixtures/compatible_production/config.unittest.ts
+++ b/packages/core/test/services/fixtures/compatible_production/config.unittest.ts
@@ -1,0 +1,3 @@
+export const bbb = {
+  data: 321,
+}

--- a/packages/core/test/services/fixtures/default_case/config.default.ts
+++ b/packages/core/test/services/fixtures/default_case/config.default.ts
@@ -1,0 +1,6 @@
+export default {
+  parent: {
+    a: 1,
+    b: 2
+  }
+};

--- a/packages/core/test/services/fixtures/default_case/config.local.ts
+++ b/packages/core/test/services/fixtures/default_case/config.local.ts
@@ -1,0 +1,5 @@
+export default {
+  parent: {
+    a: 1
+  }
+};


### PR DESCRIPTION
兼容原来 egg 的用户习惯：

- config.prod 在 production 依旧会读取
- config.unittest 在 test 下依旧会读取