### PR TITLE
feat: add midway cache

### DIFF
--- a/packages/cache/.gitignore
+++ b/packages/cache/.gitignore
@@ -1,0 +1,15 @@
+logs/
+npm-debug.log
+yarn-error.log
+node_modules/
+package-lock.json
+yarn.lock
+coverage/
+dist/
+.idea/
+run/
+.DS_Store
+*.sw*
+*.un~
+.tsbuildinfo
+.tsbuildinfo.*

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@midwayjs/cli": "^1.2.38",
-    "@midwayjs/core": "^2.3.0",
+    "@midwayjs/core": "^2.8.11",
     "@midwayjs/decorator": "^2.3.0",
     "@types/jest": "^26.0.10",
     "@types/node": "14",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -8,7 +8,8 @@
     "build": "midway-bin build -c",
     "test": "midway-bin test --ts",
     "cov": "midway-bin cov --ts",
-    "ci": "npm run cov"
+    "ci": "npm run cov",
+    "lint": "mwts check"
   },
   "author": "",
   "files": [

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -37,7 +37,9 @@
     "jest": "^26.4.0",
     "mwts": "^1.0.5",
     "ts-jest": "^26.2.0",
-    "typescript": "^4.0.0"
+    "typescript": "^4.0.0",
+    "@types/cache-manager": "^3.4.0",
+    "cache-manager": "^3.4.1"
   },
   "peerDependencies": {
     "@types/cache-manager": "^3.4.0",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@midwayjs/cache",
+  "version": "2.8.11",
+  "description": "",
+  "main": "dist/index.js",
+  "typings": "dist/index.d.ts",
+  "scripts": {
+    "build": "midway-bin build -c",
+    "test": "midway-bin test --ts",
+    "cov": "midway-bin cov --ts",
+    "ci": "npm run cov"
+  },
+  "author": "",
+  "files": [
+    "dist/**/*.js",
+    "dist/**/*.d.ts"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:midwayjs/midway.git"
+  },
+  "keywords": [
+    "midway",
+    "cache"
+  ],
+  "engines": {
+    "node": ">= 10"
+  },
+  "devDependencies": {
+    "@midwayjs/cli": "^1.2.38",
+    "@midwayjs/core": "^2.3.0",
+    "@midwayjs/decorator": "^2.3.0",
+    "@types/jest": "^26.0.10",
+    "@types/node": "14",
+    "cross-env": "^6.0.0",
+    "jest": "^26.4.0",
+    "mwts": "^1.0.5",
+    "ts-jest": "^26.2.0",
+    "typescript": "^4.0.0"
+  },
+  "peerDependencies": {
+    "@types/cache-manager": "^3.4.0",
+    "cache-manager": "^3.4.1"
+  }
+}

--- a/packages/cache/src/config/config.default.ts
+++ b/packages/cache/src/config/config.default.ts
@@ -1,8 +1,7 @@
-
 export const cache = {
   store: 'memory',
   options: {
     max: 100,
-    ttl: 10
-  }
-}
+    ttl: 10,
+  },
+};

--- a/packages/cache/src/config/config.default.ts
+++ b/packages/cache/src/config/config.default.ts
@@ -1,0 +1,8 @@
+
+export const cache = {
+  store: 'memory',
+  options: {
+    max: 100,
+    ttl: 10
+  }
+}

--- a/packages/cache/src/configuration.ts
+++ b/packages/cache/src/configuration.ts
@@ -1,0 +1,13 @@
+// src/configuration.ts
+import { Configuration } from '@midwayjs/decorator';
+import { join } from 'path';
+
+@Configuration({
+  namespace: 'cache',
+  importConfigs: [
+    join(__dirname, 'config')
+  ]
+})
+export class AutoConfiguration {
+
+}

--- a/packages/cache/src/configuration.ts
+++ b/packages/cache/src/configuration.ts
@@ -4,10 +4,6 @@ import { join } from 'path';
 
 @Configuration({
   namespace: 'cache',
-  importConfigs: [
-    join(__dirname, 'config')
-  ]
+  importConfigs: [join(__dirname, 'config')],
 })
-export class AutoConfiguration {
-
-}
+export class AutoConfiguration {}

--- a/packages/cache/src/index.ts
+++ b/packages/cache/src/index.ts
@@ -1,0 +1,2 @@
+export { AutoConfiguration as Configuration } from './configuration';
+export * from './service/cache';

--- a/packages/cache/src/service/cache.ts
+++ b/packages/cache/src/service/cache.ts
@@ -3,7 +3,7 @@ import * as cacheManager from 'cache-manager';
 
 @Scope(ScopeEnum.Singleton)
 @Provide()
-export class Cache {
+export class CacheManager {
 
   cache: cacheManager.Cache;
 

--- a/packages/cache/src/service/cache.ts
+++ b/packages/cache/src/service/cache.ts
@@ -4,42 +4,44 @@ import * as cacheManager from 'cache-manager';
 @Scope(ScopeEnum.Singleton)
 @Provide()
 export class CacheManager {
-
   cache: cacheManager.Cache;
 
   @Config('cache')
   cacheConfig;
 
   @Init()
-  async init(){
-    this.cache = cacheManager.caching({store: this.cacheConfig.store, ...this.cacheConfig.options});
+  async init() {
+    this.cache = cacheManager.caching({
+      store: this.cacheConfig.store,
+      ...this.cacheConfig.options,
+    });
   }
 
   // 获取key
   async get(key: string) {
-    return new Promise((resolve, reject)=>{
-      this.cache.get(key, (err, result)=>{
-        if(err){
+    return new Promise((resolve, reject) => {
+      this.cache.get(key, (err, result) => {
+        if (err) {
           reject(err);
           return;
         }
         resolve(result);
-      })
-    })
+      });
+    });
   }
 
   // 设置cache
-  async set(key: string, value: string, options?: cacheManager.CachingConfig){
+  async set(key: string, value: string, options?: cacheManager.CachingConfig) {
     return await this.cache.set(key, value, options);
   }
 
   // 删除key
-  async del(key: string){
+  async del(key: string) {
     return await this.cache.del(key);
   }
 
   // 清空cache
-  async reset(){
+  async reset() {
     return await this.cache.reset();
   }
 }

--- a/packages/cache/src/service/cache.ts
+++ b/packages/cache/src/service/cache.ts
@@ -1,0 +1,45 @@
+import { Config, Init, Provide, Scope, ScopeEnum } from '@midwayjs/decorator';
+import * as cacheManager from 'cache-manager';
+
+@Scope(ScopeEnum.Singleton)
+@Provide()
+export class Cache {
+
+  cache: cacheManager.Cache;
+
+  @Config('cache')
+  cacheConfig;
+
+  @Init()
+  async init(){
+    this.cache = cacheManager.caching({store: this.cacheConfig.store, ...this.cacheConfig.options});
+  }
+
+  // 获取key
+  async get(key: string) {
+    return new Promise((resolve, reject)=>{
+      this.cache.get(key, (err, result)=>{
+        if(err){
+          reject(err);
+          return;
+        }
+        resolve(result);
+      })
+    })
+  }
+
+  // 设置cache
+  async set(key: string, value: string, options?: cacheManager.CachingConfig){
+    return await this.cache.set(key, value, options);
+  }
+
+  // 删除key
+  async del(key: string){
+    return await this.cache.del(key);
+  }
+
+  // 清空cache
+  async reset(){
+    return await this.cache.reset();
+  }
+}

--- a/packages/cache/test/cache.test.ts
+++ b/packages/cache/test/cache.test.ts
@@ -1,0 +1,23 @@
+
+import { LightFramework } from '@midwayjs/core';
+import * as path from 'path';
+import * as assert from 'assert';
+
+describe(`test.cache`, ()=>{
+  it(`test cache`, async ()=>{
+    const framework = new LightFramework();
+    await framework.initialize({
+      baseDir: path.join(__dirname, './fixtures/cache-manager/src'),
+      isTsMode: true,
+    });
+
+    const appCtx = framework.getApplicationContext();
+
+    const userService: any = await appCtx.getAsync('userService');
+    assert((await userService.getUser(`name`)) === undefined)
+    await userService.setUser('name', 'stone-jin')
+    assert((await userService.getUser(`name`)) === 'stone-jin')
+    await userService.reset();
+    assert((await userService.getUser(`name`)) === undefined)
+  })
+})

--- a/packages/cache/test/fixtures/cache-manager/package.json
+++ b/packages/cache/test/fixtures/cache-manager/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "my-midway-project"
+}

--- a/packages/cache/test/fixtures/cache-manager/src/configuration.ts
+++ b/packages/cache/test/fixtures/cache-manager/src/configuration.ts
@@ -1,0 +1,10 @@
+import { Configuration } from '@midwayjs/decorator';
+import * as cacheComponent from '../../../../src/index';
+
+@Configuration({
+  imports: [
+    cacheComponent
+  ]
+})
+export class ContainerLifeCycle {
+}

--- a/packages/cache/test/fixtures/cache-manager/src/service/user.service.ts
+++ b/packages/cache/test/fixtures/cache-manager/src/service/user.service.ts
@@ -1,0 +1,22 @@
+import { Inject, Provide } from '@midwayjs/decorator';
+import { CacheManager } from '../../../../../src/index';
+
+@Provide()
+export class UserService {
+
+  @Inject(`cache:cacheManager`)
+  cache: CacheManager;
+
+  async setUser(name: string, value: string){
+    await this.cache.set(name, value);
+  }
+
+  async getUser(name: string){
+    let result = await this.cache.get(name);
+    return result;
+  }
+
+  async reset(){
+    await this.cache.reset();
+  }
+}

--- a/packages/cache/tsconfig.json
+++ b/packages/cache/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compileOnSave": true,
+  "compilerOptions": {
+    "target": "ES2018",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "inlineSourceMap":false,
+    "noImplicitThis": true,
+    "noUnusedLocals": true,
+    "stripInternal": true,
+    "noImplicitReturns": false,
+    "pretty": true,
+    "declaration": true,
+    "outDir": "dist"
+  },
+  "exclude": [
+    "dist",
+    "node_modules",
+    "test"
+  ]
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -48,6 +48,7 @@ export * from './util/pathFileUtil';
 export * from './features';
 export * from './util/webRouterParam';
 export * from './util/webRouterCollector';
+export * from './util/emptyFramework'
 export { plainToClass, classToPlain } from 'class-transformer';
 export * from './logger';
 export { createConfiguration } from './functional/configuration';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -48,7 +48,7 @@ export * from './util/pathFileUtil';
 export * from './features';
 export * from './util/webRouterParam';
 export * from './util/webRouterCollector';
-export * from './util/emptyFramework'
+export * from './util/emptyFramework';
 export { plainToClass, classToPlain } from 'class-transformer';
 export * from './logger';
 export { createConfiguration } from './functional/configuration';


### PR DESCRIPTION
Midway Cache描述：
Midway为不同的cache存储的provider提供了统一的api。内置的是一个memory方式的缓存模块。同时我们可以方便的切换到更全面的解决方案，例如使用redis等方式。

使用方法：
1、安装依赖: 
```
$ npm install cache-manager -S
$ npm install @types/cache-manager -D 
$ npm install @midwayjs/cache -S
```
2、导入component
在configuration.ts中：
```
import { Configuration, App } from '@midwayjs/decorator';
import { Application } from '@midwayjs/koa';
import * as bodyParser from 'koa-bodyparser';
import * as cacheComponent from '@midwayjs/cache';
import { join } from 'path'

@Configuration({
  imports: [
    cacheComponent
  ],
  importConfigs: [
    join(__dirname, 'config')
  ]
})
export class ContainerLifeCycle {
}
```

3、使用方法：
```
import { Inject, Provide } from '@midwayjs/decorator';
import { IUserOptions } from '../interface';
import { Cache } from '@midwayjs/cache';

@Provide()
export class UserService {

  @Inject(`cache:cache`)
  cache: Cache;     //依赖注入Cache

  async getUser(options: IUserOptions) {
    await this.cache.set(`name`, 'stone-jin'); // 设置缓存内容
    let result = await this.cache.get(`name`);
    return result;
  }

  async getUser2(){
    let result = await this.cache.get(`name`); //获取缓存内容
    return result;
  }

  async reset(){
    await this.cache.reset(); // 清空对应store的内容
  }
}
```

4、功能描述：
- 默认是采用memory的方式。
- 同时也支持各种其他store的方式。

5、配置方式：
在config.ts中添加：
```
export const cache = {
    store: 'memory',
    options: {
        max: 100, 
        ttl: 10/*seconds*/
    }
}
```