### PR TITLE
feat(consul): register to consul server and lookup service with balancer

### DIFF
--- a/packages/consul/README.md
+++ b/packages/consul/README.md
@@ -1,0 +1,12 @@
+# midway-consul
+
+[![Package Quality](http://npm.packagequality.com/shield/midway-core.svg)](http://packagequality.com/#?package=midway-core)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/midwayjs/midway/pulls)
+
+this is a sub package for midway.
+
+Document: [https://midwayjs.org/midway](https://midwayjs.org/midway)
+
+## License
+
+[MIT]((http://github.com/midwayjs/midway/blob/master/LICENSE))

--- a/packages/consul/jest.config.js
+++ b/packages/consul/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  preset: 'ts-jest',
+  testPathIgnorePatterns: ['<rootDir>/test/fixtures'],
+  coveragePathIgnorePatterns: ['<rootDir>/test/'],
+  setupFilesAfterEnv: ['./jest.setup.js']
+};

--- a/packages/consul/jest.setup.js
+++ b/packages/consul/jest.setup.js
@@ -1,0 +1,1 @@
+jest.setTimeout(30000);

--- a/packages/consul/package.json
+++ b/packages/consul/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@midwayjs/consul",
+  "description": "midway consul",
+  "version": "1.0.0",
+  "main": "dist/index",
+  "typings": "dist/index.d.ts",
+  "files": [
+    "dist/**/*.js",
+    "dist/**/*.d.ts"
+  ],
+  "devDependencies": {
+    "@midwayjs/cli": "^1.2.36",
+    "@midwayjs/core": "^2.9.1",
+    "@midwayjs/decorator": "^2.9.1",
+    "@midwayjs/koa": "^2.9.1",
+    "@midwayjs/mock": "^2.9.1",
+    "@types/consul": "^0.23.34",
+    "@types/sinon": "^9.0.11",
+    "nock": "^13.0.11"
+  },
+  "dependencies": {
+    "consul": "^0.40.0"
+  },
+  "keywords": [
+    "consul"
+  ],
+  "author": "Wang Bo <1982wb@gmail.com>",
+  "license": "MIT",
+  "scripts": {
+    "build": "midway-bin build -c",
+    "test": "midway-bin test --ts",
+    "cov": "midway-bin cov --ts",
+    "ci": "npm run test",
+    "lint": "mwts check"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/midwayjs/midway.git"
+  }
+}

--- a/packages/consul/src/config/config.default.ts
+++ b/packages/consul/src/config/config.default.ts
@@ -1,0 +1,17 @@
+export default {
+  consul: {
+    provider: {
+      register: false,
+      host: '127.0.0.1',
+      port: 8500,
+      strategy: 'random',
+    },
+    service: {
+      id: null,
+      name: null,
+      tags: [],
+      address: null,
+      port: 7001,
+    },
+  },
+};

--- a/packages/consul/src/configuration.ts
+++ b/packages/consul/src/configuration.ts
@@ -1,0 +1,106 @@
+import {
+  Config,
+  Configuration,
+  MidwayFrameworkType,
+} from '@midwayjs/decorator';
+import { join } from 'path';
+import {
+  ILifeCycle,
+  IMidwayApplication,
+  IMidwayContainer,
+} from '@midwayjs/core';
+import {
+  IConsulProviderInfoOptions,
+  IConsulRegisterInfoOptions,
+} from './interface';
+import { ConsulProvider } from './lib/provider';
+
+@Configuration({
+  namespace: 'consul',
+  importConfigs: [join(__dirname, 'config')],
+})
+export class AutoConfiguration implements ILifeCycle {
+  /**
+   * 有关 consul server 的配置
+   */
+  @Config('consul.provider')
+  consulProviderConfig: IConsulProviderInfoOptions;
+
+  /**
+   * 有关 service registry 注册的信息
+   */
+  @Config('consul.service')
+  consulRegisterConfig: IConsulRegisterInfoOptions;
+
+  get consulProvider(): ConsulProvider {
+    const symbol = Symbol('consulProvider');
+    this[symbol] =
+      this[symbol] || new ConsulProvider(this.consulProviderConfig);
+    return this[symbol];
+  }
+
+  /**
+   * 注册自己的条件
+   * 由于环境的复杂性(多网卡、自动端口冲突) address 和 port 必须提供
+   */
+  get shouldBeRegisterMe(): boolean {
+    const { address, port } = this.consulRegisterConfig;
+    return this.consulProviderConfig.register && address.length > 0 && port > 0;
+  }
+
+  /**
+   * 注册 consul 服务
+   * @param container 容器 IoC
+   * @param app 应用 App
+   */
+  async registerConsul(
+    container: IMidwayContainer,
+    app: IMidwayApplication
+  ): Promise<void> {
+    const config = this.consulRegisterConfig;
+    const { address, port } = this.consulRegisterConfig;
+
+    if (this.shouldBeRegisterMe) {
+      config.name = config.name || app.getProjectName();
+      config.id = config.id || `${config.name}:${address}:${port}`;
+
+      config.check =
+        config.check ||
+        (app.getFrameworkType() === MidwayFrameworkType.WEB
+          ? {
+              http: `http://${address}:${port}/consul/health/self/check`,
+              interval: '3s',
+            }
+          : {
+              tcp: `${address}:${port}`,
+              interval: '3s',
+            });
+
+      Object.assign(this.consulRegisterConfig, config);
+
+      // 把原始的 consul 对象注入到容器
+      container.registerObject('consul', this.consulProvider.getConsul());
+      await this.consulProvider.registerService(this.consulRegisterConfig);
+    }
+  }
+
+  async onReady(
+    container: IMidwayContainer,
+    app?: IMidwayApplication
+  ): Promise<void> {
+    await this.registerConsul(container, app);
+  }
+
+  async onStop(
+    container: IMidwayContainer,
+    app?: IMidwayApplication
+  ): Promise<void> {
+    if (
+      this.consulProviderConfig.register &&
+      this.consulProviderConfig.deregister
+    ) {
+      const { id } = this.consulRegisterConfig;
+      await this.consulProvider.deregisterService({ id });
+    }
+  }
+}

--- a/packages/consul/src/controller/consul.ts
+++ b/packages/consul/src/controller/consul.ts
@@ -1,0 +1,12 @@
+import { Controller, Get, Provide } from '@midwayjs/decorator';
+
+@Provide()
+@Controller('/consul')
+export class ConsulController {
+  @Get('/health/self/check')
+  async healthCheck(): Promise<any> {
+    return {
+      status: 'success',
+    };
+  }
+}

--- a/packages/consul/src/index.ts
+++ b/packages/consul/src/index.ts
@@ -1,0 +1,4 @@
+export { AutoConfiguration as Configuration } from './configuration';
+export * from './controller/consul';
+export * from './service/balancer';
+export * from './interface';

--- a/packages/consul/src/interface.ts
+++ b/packages/consul/src/interface.ts
@@ -1,0 +1,78 @@
+import * as Consul from "consul";
+import { ConsulOptions } from "consul";
+import RegisterOptions = Consul.Agent.Service.RegisterOptions;
+
+export interface IBalancer {
+  /**
+   * 根据服务名称选择实例
+   * @param serviceName 注册的服务名称
+   * @param passingOnly 只返回通过健康检查的实例，默认为 true
+   */
+  select(serviceName: string, passingOnly?: boolean): any | never;
+}
+
+export interface IConsulBalancer {
+  /**
+   * 根绝策略返回负载均衡器
+   * @param strategy
+   */
+  getBalancer(strategy?: string): IBalancer;
+}
+
+export interface IConsulProviderInfoOptions extends ConsulOptions {
+  /**
+   * 本服务是否注册到 consul 服务器，默认是 NO 不会执行注册
+   */
+  register?: boolean;
+
+  /**
+   * 应用正常关闭的额时候自动反注册，默认是 YES 会执行反注册
+   * 如果 register=false 改参数无效
+   */
+  deregister?: boolean;
+
+  /**
+   * 调用服务负载均衡的策略(default、random)，默认是 random 随机
+   */
+  strategy?: string
+}
+
+export interface IConsulRegisterInfoOptions extends RegisterOptions {
+  /**
+   * 注册 id 标识，默认是 name:address:port 的组合
+   */
+  id?: string;
+
+  /**
+   * 服务名称
+   */
+  name: string;
+
+  /**
+   * 服务地址
+   */
+  address: string;
+
+  /**
+   * 服务端口
+   */
+  port: number;
+
+  /**
+   * 服务标签
+   */
+  tags?: string[];
+
+  /**
+   * 健康检查配置，组件默认会配置一个(检查间隔是3秒)
+   */
+  check?: {
+    tcp?: string;
+    http?: string;
+    script?: string;
+    interval?: string;
+    ttl?: string;
+    notes?: string;
+    status?: string;
+  }
+}

--- a/packages/consul/src/interface.ts
+++ b/packages/consul/src/interface.ts
@@ -2,7 +2,7 @@ import * as Consul from "consul";
 import { ConsulOptions } from "consul";
 import RegisterOptions = Consul.Agent.Service.RegisterOptions;
 
-export interface IBalancer {
+export interface IServiceBalancer {
   /**
    * 根据服务名称选择实例
    * @param serviceName 注册的服务名称
@@ -14,9 +14,9 @@ export interface IBalancer {
 export interface IConsulBalancer {
   /**
    * 根绝策略返回负载均衡器
-   * @param strategy
+   * @param strategy 负载均衡策略
    */
-  getBalancer(strategy?: string): IBalancer;
+  getServiceBalancer(strategy?: string): IServiceBalancer;
 }
 
 export interface IConsulProviderInfoOptions extends ConsulOptions {

--- a/packages/consul/src/lib/balancer.ts
+++ b/packages/consul/src/lib/balancer.ts
@@ -1,0 +1,101 @@
+import * as Consul from 'consul';
+import { IBalancer, IConsulBalancer } from '../interface';
+
+abstract class Balancer implements IBalancer {
+  protected constructor(protected consul: Consul.Consul) {
+    //
+  }
+
+  async select(serviceName: string, passingOnly = true): Promise<any | never> {
+    throw new Error('not implemented');
+  }
+
+  async loadServices(serviceName: string, passingOnly = true) {
+    if (passingOnly) return this.loadPassing(serviceName);
+    return this.loadAll(serviceName);
+  }
+
+  private async loadAll(serviceName: string) {
+    return (await this.consul.catalog.service.nodes(serviceName)) as Array<any>;
+  }
+
+  private async loadPassing(serviceName: string) {
+    const passingIds = [];
+    const checks = (await this.consul.health.checks(serviceName)) as any[];
+
+    // 健康检查通过的
+    checks.forEach(check => {
+      if (check.Status === 'passing') {
+        passingIds.push(check.ServiceID);
+      }
+    });
+
+    const instances = await this.loadAll(serviceName);
+    return instances.filter(item => passingIds.includes(item.ServiceID));
+  }
+}
+
+class DefaultBalancer extends Balancer {
+  constructor(consul: Consul.Consul) {
+    super(consul);
+  }
+
+  async select(serviceName: string, passingOnly = true): Promise<any | never> {
+    const instances = await this.loadServices(serviceName, passingOnly);
+    if (instances.length > 0) {
+      return instances[0];
+    }
+
+    throw new Error('no avaiable instance named ' + serviceName);
+  }
+}
+
+class RandomBalancer extends Balancer {
+  constructor(consul: Consul.Consul) {
+    super(consul);
+  }
+
+  async select(serviceName: string, passingOnly = true): Promise<any | never> {
+    let instances = await this.loadServices(serviceName, passingOnly);
+    if (instances.length > 0) {
+      instances = this.shuffle(instances);
+      return instances[Math.floor(Math.random() * instances.length)];
+    }
+
+    throw new Error('no avaiable instance named ' + serviceName);
+  }
+
+  /**
+   * shuff by fisher-yates
+   */
+  shuffle(instances: Array<any>): Array<any> {
+    const result = [];
+
+    for (let i = 0; i < instances.length; i++) {
+      const j = Math.floor(Math.random() * (i + 1));
+      if (j !== i) {
+        result[i] = result[j];
+      }
+      result[j] = instances[i];
+    }
+
+    return result;
+  }
+}
+
+export class ConsulBalancer implements IConsulBalancer {
+  constructor(private consul: Consul.Consul) {
+    //
+  }
+
+  getBalancer(strategy?: string): IBalancer {
+    switch (strategy) {
+      case 'default':
+        return new DefaultBalancer(this.consul);
+      case 'random':
+        return new RandomBalancer(this.consul);
+    }
+
+    throw new Error('invalid strategy balancer');
+  }
+}

--- a/packages/consul/src/lib/provider.ts
+++ b/packages/consul/src/lib/provider.ts
@@ -1,0 +1,29 @@
+import {
+  IConsulProviderInfoOptions,
+  IConsulRegisterInfoOptions,
+} from '../interface';
+import * as Consul from 'consul';
+
+export class ConsulProvider {
+  private readonly consul: Consul.Consul;
+
+  constructor(providerOptions: IConsulProviderInfoOptions) {
+    // should be, ignore config
+    providerOptions.promisify = true;
+    this.consul = Consul(providerOptions);
+  }
+
+  getConsul(): Consul.Consul {
+    return this.consul;
+  }
+
+  async registerService(
+    registerOptions: IConsulRegisterInfoOptions
+  ): Promise<void> {
+    await this.consul.agent.service.register(registerOptions);
+  }
+
+  async deregisterService(deregisterOptions: { id: string }): Promise<void> {
+    await this.consul.agent.service.deregister(deregisterOptions);
+  }
+}

--- a/packages/consul/src/service/balancer.ts
+++ b/packages/consul/src/service/balancer.ts
@@ -1,7 +1,7 @@
 import { Init, Inject, Provide, Scope, ScopeEnum } from '@midwayjs/decorator';
 import { ConsulBalancer } from '../lib/balancer';
 import * as Consul from 'consul';
-import { IBalancer, IConsulBalancer } from '../interface';
+import { IServiceBalancer, IConsulBalancer } from '../interface';
 
 @Provide()
 @Scope(ScopeEnum.Singleton)
@@ -16,7 +16,7 @@ export class BalancerService implements IConsulBalancer {
     this.consulBalancer = new ConsulBalancer(this.consul);
   }
 
-  getBalancer(strategy = 'random'): IBalancer {
-    return this.consulBalancer.getBalancer(strategy);
+  getServiceBalancer(strategy = 'random'): IServiceBalancer {
+    return this.consulBalancer.getServiceBalancer(strategy);
   }
 }

--- a/packages/consul/src/service/balancer.ts
+++ b/packages/consul/src/service/balancer.ts
@@ -1,0 +1,22 @@
+import { Init, Inject, Provide, Scope, ScopeEnum } from '@midwayjs/decorator';
+import { ConsulBalancer } from '../lib/balancer';
+import * as Consul from 'consul';
+import { IBalancer, IConsulBalancer } from '../interface';
+
+@Provide()
+@Scope(ScopeEnum.Singleton)
+export class BalancerService implements IConsulBalancer {
+  @Inject()
+  consul: Consul.Consul;
+
+  private consulBalancer: ConsulBalancer;
+
+  @Init()
+  init(): void {
+    this.consulBalancer = new ConsulBalancer(this.consul);
+  }
+
+  getBalancer(strategy = 'random'): IBalancer {
+    return this.consulBalancer.getBalancer(strategy);
+  }
+}

--- a/packages/consul/test/consul.framework.ts
+++ b/packages/consul/test/consul.framework.ts
@@ -1,0 +1,47 @@
+import {Framework} from '@midwayjs/koa';
+import * as nock from 'nock';
+import {checks, services} from './fixtures/mock.data';
+
+/**
+ * 自定义实现 mock consul 相关的 http API
+ */
+export class ConsulKoaFramework extends Framework {
+  async applicationInitialize(options) {
+    await super.applicationInitialize(options);
+
+    // 断开外部 http 地址访问
+    nock.disableNetConnect();
+    // 允许 app#superTest 的路由访问
+    nock.enableNetConnect('127.0.0.1');
+
+    this.mockConsulApi(this);
+    this.mockConsulApi(this.app);
+  }
+
+  async beforeStop() {
+    await super.beforeStop();
+    nock.cleanAll();
+  }
+
+  mockConsulApi(object) {
+    Object.defineProperty(object, 'nock', {
+      configurable: true,
+      enumerable: true,
+      get: function () {
+        return nock('http://mock.consul.server:8500');
+      },
+    });
+
+    // 注册服务
+    object['nock'].put('/v1/agent/service/register').reply(200);
+
+    // 反注册服务
+    object['nock'].put('/v1/agent/service/deregister/ali-demo:127.0.0.1:7001').reply(200);
+
+    // 查询服务
+    object['nock'].get('/v1/catalog/service/ali-demo').reply(200, services);
+
+    // 健康检查
+    object['nock'].get('/v1/health/checks/ali-demo').reply(200, checks);
+  }
+}

--- a/packages/consul/test/consul.framework.ts
+++ b/packages/consul/test/consul.framework.ts
@@ -33,15 +33,17 @@ export class ConsulKoaFramework extends Framework {
     });
 
     // 注册服务
-    object['nock'].put('/v1/agent/service/register').reply(200);
+    object['nock'].persist().put('/v1/agent/service/register').reply(200);
 
     // 反注册服务
-    object['nock'].put('/v1/agent/service/deregister/ali-demo:127.0.0.1:7001').reply(200);
+    object['nock'].persist().put('/v1/agent/service/deregister/ali-demo:127.0.0.1:7001').reply(200);
 
     // 查询服务
-    object['nock'].get('/v1/catalog/service/ali-demo').reply(200, services);
+    object['nock'].persist().get('/v1/catalog/service/ali-demo').reply(200, services);
+    object['nock'].persist().get('/v1/catalog/service/noexists').reply(200, []);
 
     // 健康检查
-    object['nock'].get('/v1/health/checks/ali-demo').reply(200, checks);
+    object['nock'].persist().get('/v1/health/checks/ali-demo').reply(200, checks);
+    object['nock'].persist().get('/v1/health/checks/noexists').reply(200, []);
   }
 }

--- a/packages/consul/test/fixtures/base-app/package.json
+++ b/packages/consul/test/fixtures/base-app/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "ali-demo",
+  "dependencies": {
+    "@midwayjs/koa": "^2.3.0"
+  }
+}

--- a/packages/consul/test/fixtures/base-app/src/config/config.default.ts
+++ b/packages/consul/test/fixtures/base-app/src/config/config.default.ts
@@ -1,0 +1,20 @@
+export default {
+  keys: 'midwayjs-consul-test',
+
+  consul: {
+    provider: {
+      register: true,
+      deregister: true,
+      // see consul.framework.ts plz
+      host: 'mock.consul.server',
+      // host: '127.0.0.1',
+      port: 8500,
+      strategy: 'random',
+    },
+    service: {
+      address: '127.0.0.1',
+      port: 7001,
+      tags: ["midwayjs-consul-test"],
+    }
+  }
+}

--- a/packages/consul/test/fixtures/base-app/src/configuration.ts
+++ b/packages/consul/test/fixtures/base-app/src/configuration.ts
@@ -1,0 +1,22 @@
+import { Configuration } from '@midwayjs/decorator';
+import * as consul from '../../../../src';
+import {
+  ILifeCycle,
+  IMidwayApplication,
+  IMidwayContainer,
+} from '@midwayjs/core';
+import {join} from 'path';
+
+@Configuration({
+  imports: [
+    consul
+  ],
+  importConfigs: [join(__dirname, 'config')]
+})
+export class ContainerConfiguration implements ILifeCycle {
+  async onReady(container: IMidwayContainer, app?: IMidwayApplication) {
+    // console.info(app.getConfig());
+    // const collector = new WebRouterCollector();
+    // console.log(await collector.getFlattenRouterTable());
+  }
+}

--- a/packages/consul/test/fixtures/base-app/src/controller/test.ts
+++ b/packages/consul/test/fixtures/base-app/src/controller/test.ts
@@ -10,8 +10,7 @@ export class TestController {
   // @ts-ignore
   @Get('/balancer/lookup/:serviceName')
   async lookupConsulService(@Param() serviceName: string) {
-    const balancer = this.balancerService.getBalancer();
+    const balancer = this.balancerService.getServiceBalancer();
     return await balancer.select(serviceName);
-    // return await balancer.select(serviceName, false);
   }
 }

--- a/packages/consul/test/fixtures/base-app/src/controller/test.ts
+++ b/packages/consul/test/fixtures/base-app/src/controller/test.ts
@@ -1,0 +1,17 @@
+import {Controller, Get, Inject, Param, Provide} from "@midwayjs/decorator";
+import {IConsulBalancer} from "../../../../../src";
+
+@Provide()
+@Controller('/test')
+export class TestController {
+  @Inject('consul:balancerService')
+  balancerService: IConsulBalancer;
+
+  // @ts-ignore
+  @Get('/balancer/lookup/:serviceName')
+  async lookupConsulService(@Param() serviceName: string) {
+    const balancer = this.balancerService.getBalancer();
+    return await balancer.select(serviceName);
+    // return await balancer.select(serviceName, false);
+  }
+}

--- a/packages/consul/test/fixtures/mock.data.ts
+++ b/packages/consul/test/fixtures/mock.data.ts
@@ -1,0 +1,43 @@
+const services = [
+  {
+    ID: '74c581ef-35e7-4aa6-b26b-ae55e5e05ede',
+    Node: 'macpro.local',
+    Address: '127.0.0.1',
+    Datacenter: 'dc1',
+    TaggedAddresses: {lan: '127.0.0.1', wan: '127.0.0.1'},
+    NodeMeta: {'consul-network-segment': ''},
+    ServiceKind: '',
+    ServiceID: 'ali-demo:127.0.0.1:7001',
+    ServiceName: 'ali-demo',
+    ServiceTags: ['midwayjs-consul-test'],
+    ServiceAddress: '127.0.0.1',
+    ServiceWeights: {Passing: 2, Warning: 0},
+    ServiceMeta: {},
+    ServicePort: 7001,
+    ServiceEnableTagOverride: false,
+    ServiceProxyDestination: '',
+    ServiceProxy: {},
+    ServiceConnect: {},
+    CreateIndex: 53,
+    ModifyIndex: 53
+  }
+];
+
+const checks = [
+  {
+    Node: 'macpro.local',
+    CheckID: 'service:ali-demo:127.0.0.1:7001',
+    Name: "Service 'ali-demo' check",
+    Status: 'passing',
+    Notes: '',
+    Output: '',
+    ServiceID: 'ali-demo:127.0.0.1:7001',
+    ServiceName: 'ali-demo',
+    ServiceTags: ['midwayjs-consul-test'],
+    Definition: {},
+    CreateIndex: 83,
+    ModifyIndex: 83
+  }
+];
+
+export {services, checks};

--- a/packages/consul/test/index.test.ts
+++ b/packages/consul/test/index.test.ts
@@ -1,0 +1,60 @@
+import {close, createApp, createHttpRequest} from '@midwayjs/mock';
+import {IMidwayApplication} from "@midwayjs/core";
+import {IConsulBalancer} from "../src";
+import {ConsulKoaFramework} from "./consul.framework";
+import * as Consul from 'consul';
+
+describe('/test/feature.test.ts', () => {
+
+  describe('test new features', () => {
+
+    let app: IMidwayApplication;
+
+    beforeAll(async () => {
+      // 如果使用真实的 server (consul agent --dev) 测试打开下面一行
+      // 同时记得修改配置中的 consul.provide.host 参数
+      // app = await createApp('base-app', {}, '@midwayjs/koa');
+      app = await createApp('base-app', {}, ConsulKoaFramework);
+    });
+
+    afterAll(async () => {
+      await close(app);
+    });
+
+    it('should provide health check route', async () => {
+      const result = await createHttpRequest(app)
+        .get('/consul/health/self/check');
+      expect(result.status).toBe(200);
+      expect(JSON.parse(result.text).status).toBe('success');
+    });
+
+    it('should get balancer from ioc container', async () => {
+      const balancerService = await app.getApplicationContext().getAsync<IConsulBalancer>('consul:balancerService');
+      const service = await balancerService.getBalancer().select(app.getProjectName());
+      // const service = await balancerService.getBalancer().select(app.getProjectName(),false);
+      expect(service['ServiceAddress']).toBe('127.0.0.1');
+      expect(service['ServicePort']).toBe(7001);
+    });
+
+    it('should lookup consul service by balancer which injected', async () => {
+      const result = await createHttpRequest(app)
+        .get(`/test/balancer/lookup/${app.getProjectName()}`);
+      expect(result.status).toBe(200);
+      const service = JSON.parse(result.text);
+      expect(service['ServiceAddress']).toBe('127.0.0.1');
+      expect(service['ServicePort']).toBe(7001);
+    });
+
+    it('should get the origin consul object', async () => {
+      try {
+        const consul = await app.getApplicationContext().getAsync<Consul.Consul>('consul:consul');
+        expect(consul).toBeDefined();
+        expect(consul).toBeInstanceOf(Consul);
+      } catch (e) {
+        expect(e).not.toBeInstanceOf(Error);
+      }
+    });
+
+  });
+
+});

--- a/packages/consul/test/index.test.ts
+++ b/packages/consul/test/index.test.ts
@@ -30,8 +30,37 @@ describe('/test/feature.test.ts', () => {
 
     it('should get balancer from ioc container', async () => {
       const balancerService = await app.getApplicationContext().getAsync<IConsulBalancer>('consul:balancerService');
-      const service = await balancerService.getBalancer().select(app.getProjectName());
-      // const service = await balancerService.getBalancer().select(app.getProjectName(),false);
+      expect(balancerService).toBeDefined();
+    });
+
+    it('should throw error when not imeplements balancer', async () => {
+      const balancerService = await app.getApplicationContext().getAsync<IConsulBalancer>('consul:balancerService');
+      try {
+        await balancerService.getServiceBalancer('noexists');
+      } catch (e) {
+        expect(e).toBeDefined();
+      }
+    });
+
+    it('should throw error when lookup not exist service', async () => {
+      const balancerService = await app.getApplicationContext().getAsync<IConsulBalancer>('consul:balancerService');
+      try {
+        await balancerService.getServiceBalancer().select('noexists');
+      } catch (e) {
+        expect(e).toBeDefined();
+      }
+    });
+
+    it('should lookup consul service by name', async () => {
+      const balancerService = await app.getApplicationContext().getAsync<IConsulBalancer>('consul:balancerService');
+      const service = await balancerService.getServiceBalancer().select(app.getProjectName(), false);
+      expect(service['ServiceAddress']).toBe('127.0.0.1');
+      expect(service['ServicePort']).toBe(7001);
+    });
+
+    it('should lookup consul service which check-passing', async () => {
+      const balancerService = await app.getApplicationContext().getAsync<IConsulBalancer>('consul:balancerService');
+      const service = await balancerService.getServiceBalancer().select(app.getProjectName());
       expect(service['ServiceAddress']).toBe('127.0.0.1');
       expect(service['ServicePort']).toBe(7001);
     });

--- a/packages/consul/tsconfig.json
+++ b/packages/consul/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compileOnSave": true,
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": [
+    "./src/**/*.ts"
+  ],
+  "noImplicitThis": false
+}

--- a/packages/consul/usage.md
+++ b/packages/consul/usage.md
@@ -1,0 +1,85 @@
+# midway consul
+
+## How to use
+
+```shell
+npm i @midwayjs/consul -S
+# optional
+npm i @types/consul -D
+```
+
+## Support
+
+- [x] register (optional)
+- [x] deregister on the shutdown (optional)
+- [x] service balancer (default random)
+- [x] expose the origin consul object
+
+## Usage age
+
+### 1. import component firstly.
+
+```
+import * as consul from '@midwayjs/consul'
+
+@Configuration({
+  imports: [
+    consul
+  ],
+  importConfigs: [join(__dirname, 'config')]
+})
+export class ContainerConfiguration {}
+```
+
+### 2. config consul server and service definition.
+
+```
+consul: {
+  provider: {
+    // 注册本服务
+    register: true,
+    // 应用正常下线反注册
+    deregister: true,
+    // consul server 主机
+    host: '192.168.0.10',
+    // consul server 端口
+    port: 8500,
+    // 调用服务的策略(default 默认选取，random 具有随机性)
+    strategy: 'random',
+  },
+  service: {
+    address: '127.0.0.1',
+    port: 7001,
+    tags: ['tag1', 'tag2'],
+    // others consul service definition
+  }
+}
+```
+
+### 3. lookup the service instance to call.
+
+```
+// 1. 注入的方式
+@Inject('consul:balancerService')
+balancerService: IConsulBalancer;
+// 2. 编码的方式
+const balancerService = await app.getApplicationContext().getAsync<IConsulBalancer>('consul:balancerService');
+
+// 查询的 service 数据是 consul 返回的原生数据，因为组件并不知道应用层使用了 consul 的哪些元数据信息
+// 注意下 select 在没有服务实例时会抛出 Error
+
+// 1. 查询通过健康检查的服务
+const service = await balancerService.getBalancer().select('the-service-name');
+// 2. 可能取到不健康的服务
+const service = await balancerService.getBalancer().select('the-service-name', false);
+```
+
+### 4. inject the origin consul object.
+
+```
+import * as Consul from 'consul';
+
+// 使用 consul 官方包装的 API 接口
+@Inject('consul:consul')
+consul: Consul.Consul;
+```

--- a/packages/consul/usage.md
+++ b/packages/consul/usage.md
@@ -4,7 +4,6 @@
 
 ```shell
 npm i @midwayjs/consul -S
-# optional
 npm i @types/consul -D
 ```
 
@@ -44,7 +43,7 @@ consul: {
     host: '192.168.0.10',
     // consul server 端口
     port: 8500,
-    // 调用服务的策略(default 默认选取，random 具有随机性)
+    // 调用服务的策略(默认选取 random 具有随机性)
     strategy: 'random',
   },
   service: {


### PR DESCRIPTION
##### commit message

register to consul server and deregister when shutdown, but both are optional, also lookup the services which registered on the consul server, get the service instance with injected balancer, the origin consul object is managed by the IoC container also.

dependency:
- the hashicorp consul server(except unittest)  
- npm consul package  


##### Checklist

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines
- [x] coding style check with mwts check (4 unused var warning )

---

##### How to use

```shell
npm i @midwayjs/consul -S
npm i @types/consul -D
```

###### Support

- [x] register (optional)
- [x] deregister on the shutdown (optional)
- [x] service balancer (default random)
- [x] expose the origin consul object

###### Usage age

###### 1. import component firstly.

```
import * as consul from '@midwayjs/consul'

@Configuration({
  imports: [
    consul
  ],
  importConfigs: [join(__dirname, 'config')]
})
export class ContainerConfiguration {}
```

###### 2. config consul server and service definition.

```
consul: {
  provider: {
    // 注册本服务
    register: true,
    // 应用正常下线反注册
    deregister: true,
    // consul server 主机
    host: '192.168.0.10',
    // consul server 端口
    port: 8500,
    // 调用服务的策略(默认 random 具有随机性)
    strategy: 'random',
  },
  service: {
    address: '127.0.0.1',
    port: 7001,
    tags: ['tag1', 'tag2'],
    // others consul service definition
  }
}
```

###### 3. lookup the service instance to call.

```
// 1. 注入的方式
@Inject('consul:balancerService')
balancerService: IConsulBalancer;
// 2. 编码的方式
const balancerService = await app.getApplicationContext().getAsync<IConsulBalancer>('consul:balancerService');

// 查询的 service 数据是 consul 返回的原生数据，因为组件并不知道应用层使用了 consul 的哪些元数据信息
// 注意下 select 在没有服务实例时会抛出 Error

// 1. 查询通过健康检查的服务
const service = await balancerService.getBalancer().select('the-service-name');
// 2. 第二个参数设定 false 可能取到不健康的服务(不推荐)
const service = await balancerService.getBalancer().select('the-service-name', false);
```

###### 4. inject the origin consul object.

```
import * as Consul from 'consul';

// 使用 consul 官方包装的 API 接口
@Inject('consul:consul')
consul: Consul.Consul;
```