### PR TITLE
fix: load config once and support load singleton service before framework start

### DIFF
--- a/packages/bootstrap/test/fixtures/mix-app/bootstrap.js
+++ b/packages/bootstrap/test/fixtures/mix-app/bootstrap.js
@@ -30,8 +30,7 @@ Bootstrap
   })
   .before(async (container) => {
     const configService = await container.getAsync('remoteConfigService');
-    const data = await configService.getRemoteConfig();
-    container.getConfigService().addObject(data);
+    await configService.getRemoteConfig();
   })
   .run();
 

--- a/packages/bootstrap/test/fixtures/mix-app/bootstrap.js
+++ b/packages/bootstrap/test/fixtures/mix-app/bootstrap.js
@@ -1,6 +1,6 @@
 const WebFramemwork = require('../../../../web/').Framework;
 const SocketFramemwork = require('../../../../socketio/').Framework;
-const Bootstrap = require('../../../dist/').Bootstrap;
+const Bootstrap = require('../../../src/').Bootstrap;
 
 const timeoutHandler = setTimeout(() => {
   clearInterval(internalHandler);
@@ -27,6 +27,11 @@ Bootstrap
     const framework = new SocketFramemwork();
     framework.configure();
     return framework;
+  })
+  .before(async (container) => {
+    const configService = await container.getAsync('remoteConfigService');
+    const data = await configService.getRemoteConfig();
+    container.getConfigService().addObject(data);
   })
   .run();
 

--- a/packages/bootstrap/test/fixtures/mix-app/src/configuration.ts
+++ b/packages/bootstrap/test/fixtures/mix-app/src/configuration.ts
@@ -1,6 +1,7 @@
-import { Configuration, Config, ALL } from '@midwayjs/decorator';
+import { Configuration, Config, ALL, Inject } from '@midwayjs/decorator';
 import { join } from 'path';
 import * as assert from 'assert';
+import { RemoteConfigService } from './service/remoteConfigService';
 
 @Configuration({
   importConfigs: [
@@ -11,8 +12,12 @@ export class AutoConfiguration {
   @Config(ALL)
   prepareConfig;
 
+  @Inject()
+  configService: RemoteConfigService;
+
   async onReady() {
     console.log('ready');
     assert(this.prepareConfig['prepare'] === 'remote data');
+    assert(this.prepareConfig['id'] === this.configService.innerData);
   }
 }

--- a/packages/bootstrap/test/fixtures/mix-app/src/configuration.ts
+++ b/packages/bootstrap/test/fixtures/mix-app/src/configuration.ts
@@ -1,5 +1,6 @@
-import { Configuration } from '@midwayjs/decorator';
+import { Configuration, Config, ALL } from '@midwayjs/decorator';
 import { join } from 'path';
+import * as assert from 'assert';
 
 @Configuration({
   importConfigs: [
@@ -7,7 +8,11 @@ import { join } from 'path';
   ],
 })
 export class AutoConfiguration {
+  @Config(ALL)
+  prepareConfig;
+
   async onReady() {
     console.log('ready');
+    assert(this.prepareConfig['prepare'] === 'remote data');
   }
 }

--- a/packages/bootstrap/test/fixtures/mix-app/src/index.ts
+++ b/packages/bootstrap/test/fixtures/mix-app/src/index.ts
@@ -1,0 +1,1 @@
+export * from './service/remoteConfigService';

--- a/packages/bootstrap/test/fixtures/mix-app/src/service/remoteConfigService.ts
+++ b/packages/bootstrap/test/fixtures/mix-app/src/service/remoteConfigService.ts
@@ -1,15 +1,22 @@
-import { Provide, sleep } from '@midwayjs/decorator';
+import { App, Provide, sleep } from '@midwayjs/decorator';
+import { IMidwayApplication } from '@midwayjs/core';
 
 @Provide()
 export class RemoteConfigService {
+
+  @App()
+  app: IMidwayApplication;
 
   innerData = Math.random();
 
   async getRemoteConfig() {
     await sleep(1000);
-    return {
+    const data = {
       prepare: 'remote data',
       id: this.innerData,
     }
+
+    this.app.addConfigObject(data);
+    return data;
   }
 }

--- a/packages/bootstrap/test/fixtures/mix-app/src/service/remoteConfigService.ts
+++ b/packages/bootstrap/test/fixtures/mix-app/src/service/remoteConfigService.ts
@@ -1,0 +1,11 @@
+import { Provide, sleep } from '@midwayjs/decorator';
+
+@Provide()
+export class RemoteConfigService {
+  async getRemoteConfig() {
+    await sleep(1000);
+    return {
+      prepare: 'remote data',
+    }
+  }
+}

--- a/packages/bootstrap/test/fixtures/mix-app/src/service/remoteConfigService.ts
+++ b/packages/bootstrap/test/fixtures/mix-app/src/service/remoteConfigService.ts
@@ -2,10 +2,14 @@ import { Provide, sleep } from '@midwayjs/decorator';
 
 @Provide()
 export class RemoteConfigService {
+
+  innerData = Math.random();
+
   async getRemoteConfig() {
     await sleep(1000);
     return {
       prepare: 'remote data',
+      id: this.innerData,
     }
   }
 }

--- a/packages/core/src/context/midwayContainer.ts
+++ b/packages/core/src/context/midwayContainer.ts
@@ -1,9 +1,6 @@
 import {
-  AspectMetadata,
   getProviderId,
-  IMethodAspect,
   isProvide,
-  listModule,
   ObjectDefinitionOptions,
   ObjectIdentifier,
   PIPELINE_IDENTIFIER,
@@ -20,10 +17,6 @@ import {
   getConstructorInject,
   TAGGED_PROP,
   getObjectDefProps,
-  getClassMetadata,
-  ASPECT_KEY,
-  listPreloadModule,
-  isProxy,
   INJECT_CLASS_KEY_PREFIX,
   DecoratorManager,
   ResolveFilter,
@@ -45,13 +38,13 @@ import { MidwayEnvironmentService } from '../service/environmentService';
 import { pipelineFactory } from '../features/pipeline';
 import { ResolverHandler } from './resolverHandler';
 import { run } from '@midwayjs/glob';
-import * as pm from 'picomatch';
 import { BaseApplicationContext } from './applicationContext';
 import * as util from 'util';
 import { getOwnMetadata, recursiveGetPrototypeOf } from '../common/reflectTool';
 import { ObjectDefinition } from '../definitions/objectDefinition';
 import { FunctionDefinition } from '../definitions/functionDefinition';
 import { ManagedReference, ManagedValue } from './managed';
+import { MidwayAspectService } from '../service/aspectService';
 
 const DEFAULT_PATTERN = ['**/**.ts', '**/**.tsx', '**/**.js'];
 const DEFAULT_IGNORE_PATTERN = [
@@ -90,8 +83,7 @@ export class MidwayContainer
   private likeMainConfiguration: IContainerConfiguration[] = [];
   protected configService: IConfigService;
   protected environmentService: IEnvironmentService;
-  protected aspectMappingMap: WeakMap<any, Map<string, any[]>>;
-  private aspectModuleSet: Set<any>;
+  protected aspectService;
   private directoryFilterArray: ResolveFilter[] = [];
 
   /**
@@ -116,9 +108,6 @@ export class MidwayContainer
   }
 
   init(): void {
-    this.aspectMappingMap = new WeakMap();
-    this.aspectModuleSet = new Set();
-
     this.initService();
 
     this.resolverHandler = new ResolverHandler(
@@ -133,6 +122,7 @@ export class MidwayContainer
   initService() {
     this.environmentService = new MidwayEnvironmentService();
     this.configService = new MidwayConfigService(this);
+    this.aspectService = new MidwayAspectService(this);
   }
 
   /**
@@ -574,6 +564,10 @@ export class MidwayContainer
     return this.environmentService;
   }
 
+  getAspectService() {
+    return this.aspectService;
+  }
+
   getCurrentEnv() {
     return this.environmentService.getCurrentEnvironment();
   }
@@ -594,7 +588,7 @@ export class MidwayContainer
       identifier = this.getIdentifier(identifier);
     }
     const ins: any = super.get<T>(identifier, args);
-    return this.wrapperAspectToInstance(ins);
+    return this.aspectService.wrapperAspectToInstance(ins);
   }
 
   async getAsync<T>(identifier: any, args?: any): Promise<T> {
@@ -603,7 +597,7 @@ export class MidwayContainer
     }
 
     const ins: any = await super.getAsync<T>(identifier, args);
-    return this.wrapperAspectToInstance(ins);
+    return this.aspectService.wrapperAspectToInstance(ins);
   }
 
   protected getIdentifier(target: any) {
@@ -611,17 +605,10 @@ export class MidwayContainer
   }
 
   async ready() {
+    if (this.readied) return;
     await super.ready();
-    if (this.configService) {
-      // 加载配置
-      await this.configService.load();
-    }
-
-    // 切面支持
-    await this.loadAspect();
-
-    // 预加载模块支持
-    await this.loadPreloadModule();
+    // 加载配置
+    await this.configService.load();
   }
 
   async stop(): Promise<void> {
@@ -718,236 +705,6 @@ export class MidwayContainer
 
   public getResolverHandler() {
     return this.resolverHandler;
-  }
-
-  /**
-   * load aspect method for container
-   * @private
-   */
-  private async loadAspect() {
-    // for aop implementation
-    const aspectModules = listModule(ASPECT_KEY);
-    // sort for aspect target
-    let aspectDataList = [];
-    for (const module of aspectModules) {
-      const data = getClassMetadata(ASPECT_KEY, module);
-      aspectDataList = aspectDataList.concat(
-        data.map(el => {
-          el.aspectModule = module;
-          return el;
-        })
-      );
-    }
-
-    // sort priority
-    aspectDataList.sort((pre, next) => {
-      return (next.priority || 0) - (pre.priority || 0);
-    });
-
-    for (const aspectData of aspectDataList) {
-      const aspectIns = await this.getAsync<IMethodAspect>(
-        aspectData.aspectModule
-      );
-      await this.addAspect(aspectIns, aspectData);
-    }
-
-    // 合并拦截器方法，提升性能
-    for (const module of this.aspectModuleSet) {
-      const aspectMapping = this.aspectMappingMap.get(module);
-      for (const [method, aspectFn] of aspectMapping) {
-        const composeFn = (ins, originMethod) => {
-          for (const fn of aspectFn) {
-            originMethod = fn(ins, originMethod);
-          }
-          return originMethod;
-        };
-        aspectMapping.set(method, [composeFn]);
-      }
-    }
-    // 绑定完后清理 Set 记录
-    this.aspectModuleSet.clear();
-  }
-
-  public async addAspect(aspectIns: IMethodAspect, aspectData: AspectMetadata) {
-    const module = aspectData.aspectTarget;
-    const names = Object.getOwnPropertyNames(module.prototype);
-    const isMatch = aspectData.match ? pm(aspectData.match) : () => true;
-
-    // 存到 set 里用来做循环
-    this.aspectModuleSet.add(module);
-
-    /**
-     * 拦截器流程
-     * 1、在每个被拦截的 class 上做拦截标记，记录哪些方法需要被拦截
-     * 2、Container 保存每个 class 的方法对应的拦截器数组
-     * 3、创建完实例后，在返回前执行包裹逻辑，把需要拦截的方法都执行一遍拦截（不对原型做修改）
-     */
-
-    for (const name of names) {
-      if (name === 'constructor' || !isMatch(name)) {
-        continue;
-      }
-      const descriptor = Object.getOwnPropertyDescriptor(
-        module.prototype,
-        name
-      );
-      if (!descriptor || descriptor.writable === false) {
-        continue;
-      }
-
-      // 把拦截器和当前容器绑定
-      if (!this.aspectMappingMap.has(module)) {
-        this.aspectMappingMap.set(module, new Map());
-      }
-
-      const mappingMap = this.aspectMappingMap.get(module);
-      if (!mappingMap.has(name)) {
-        mappingMap.set(name, []);
-      }
-      // 把拦截器本身加到数组中
-      const methodAspectCollection = mappingMap.get(name);
-
-      if (isAsyncFunction(descriptor.value)) {
-        this.debugLogger(
-          `aspect [#${module.name}:${name}], isAsync=true, aspect class=[${aspectIns.constructor.name}]`
-        );
-
-        const fn = (ins, originMethod) => {
-          return async (...args) => {
-            let error, result;
-            const newProceed = (...args) => {
-              return originMethod.apply(ins, args);
-            };
-            const joinPoint = {
-              methodName: name,
-              target: ins,
-              args: args,
-              proceed: newProceed,
-            };
-            try {
-              await aspectIns.before?.(joinPoint);
-              if (aspectIns.around) {
-                result = await aspectIns.around(joinPoint);
-              } else {
-                result = await originMethod.apply(ins, joinPoint.args);
-              }
-              joinPoint.proceed = undefined;
-              const resultTemp = await aspectIns.afterReturn?.(
-                joinPoint,
-                result
-              );
-              result = typeof resultTemp === 'undefined' ? result : resultTemp;
-              return result;
-            } catch (err) {
-              joinPoint.proceed = undefined;
-              error = err;
-              if (aspectIns.afterThrow) {
-                await aspectIns.afterThrow(joinPoint, error);
-              } else {
-                throw err;
-              }
-            } finally {
-              await aspectIns.after?.(joinPoint, result, error);
-            }
-          };
-        };
-
-        methodAspectCollection.push(fn);
-      } else {
-        this.debugLogger(
-          `aspect [#${module.name}:${name}], isAsync=false, aspect class=[${aspectIns.constructor.name}]`
-        );
-        const fn = (ins, originMethod) => {
-          return (...args) => {
-            let error, result;
-            const newProceed = (...args) => {
-              return originMethod.apply(ins, args);
-            };
-            const joinPoint = {
-              methodName: name,
-              target: ins,
-              args: args,
-              proceed: newProceed,
-            };
-            try {
-              aspectIns.before?.(joinPoint);
-              if (aspectIns.around) {
-                result = aspectIns.around(joinPoint);
-              } else {
-                result = originMethod.apply(ins, joinPoint.args);
-              }
-              const resultTemp = aspectIns.afterReturn?.(joinPoint, result);
-              result = typeof resultTemp === 'undefined' ? result : resultTemp;
-              return result;
-            } catch (err) {
-              error = err;
-              if (aspectIns.afterThrow) {
-                aspectIns.afterThrow(joinPoint, error);
-              } else {
-                throw err;
-              }
-            } finally {
-              aspectIns.after?.(joinPoint, result, error);
-            }
-          };
-        };
-
-        methodAspectCollection.push(fn);
-      }
-    }
-  }
-
-  /**
-   * wrapper aspect method before instance return
-   * @param ins
-   * @protected
-   */
-  protected wrapperAspectToInstance(ins) {
-    let proxy = null;
-    /**
-     * 过滤循环依赖创建的对象
-     */
-    if (!isProxy(ins) && ins?.constructor) {
-      // 动态处理拦截器
-      let methodAspectCollection;
-      if (this.aspectMappingMap?.has(ins.constructor)) {
-        methodAspectCollection = this.aspectMappingMap.get(ins.constructor);
-      } else if (
-        (this?.parent as MidwayContainer)?.aspectMappingMap?.has(
-          ins.constructor
-        )
-      ) {
-        // for requestContainer
-        methodAspectCollection = (this
-          ?.parent as MidwayContainer)?.aspectMappingMap.get(ins.constructor);
-      }
-
-      if (methodAspectCollection) {
-        proxy = new Proxy(ins, {
-          get: (obj, prop) => {
-            if (typeof prop === 'string' && methodAspectCollection.has(prop)) {
-              const aspectFn = methodAspectCollection.get(prop);
-              return aspectFn[0](ins, obj[prop]);
-            }
-            return obj[prop];
-          },
-        });
-      }
-    }
-    return proxy || ins;
-  }
-
-  /**
-   * load preload module for container
-   * @private
-   */
-  private async loadPreloadModule() {
-    // some common decorator implementation
-    const modules = listPreloadModule();
-    for (const module of modules) {
-      // preload init context
-      await this.getAsync(module);
-    }
   }
 
   public addDirectoryFilter(directoryFilter) {

--- a/packages/core/src/context/requestContainer.ts
+++ b/packages/core/src/context/requestContainer.ts
@@ -11,6 +11,7 @@ export class MidwayRequestContainer extends MidwayContainer {
     this.applicationContext = applicationContext;
     this.configService = this.applicationContext.getConfigService();
     this.environmentService = this.applicationContext.getEnvironmentService();
+    this.aspectService = this.applicationContext.getAspectService();
 
     // register ctx
     this.registerObject(REQUEST_CTX_KEY, ctx);
@@ -43,7 +44,7 @@ export class MidwayRequestContainer extends MidwayContainer {
     }
     if (this.registry.hasObject(identifier)) {
       const ins = this.registry.getObject(identifier);
-      return this.wrapperAspectToInstance(ins);
+      return this.aspectService.wrapperAspectToInstance(ins);
     }
     const definition = this.applicationContext.registry.getDefinition(
       identifier
@@ -58,7 +59,7 @@ export class MidwayRequestContainer extends MidwayContainer {
           definition,
           args,
         });
-        return this.wrapperAspectToInstance(ins);
+        return this.aspectService.wrapperAspectToInstance(ins);
       }
     }
 
@@ -76,7 +77,7 @@ export class MidwayRequestContainer extends MidwayContainer {
 
     if (this.registry.hasObject(identifier)) {
       const ins = this.registry.getObject(identifier);
-      return this.wrapperAspectToInstance(ins);
+      return this.aspectService.wrapperAspectToInstance(ins);
     }
 
     const definition = this.applicationContext.registry.getDefinition(
@@ -92,7 +93,7 @@ export class MidwayRequestContainer extends MidwayContainer {
           definition,
           args,
         });
-        return this.wrapperAspectToInstance(ins);
+        return this.aspectService.wrapperAspectToInstance(ins);
       }
     }
 

--- a/packages/core/src/interface.ts
+++ b/packages/core/src/interface.ts
@@ -273,12 +273,9 @@ export interface IMidwayContainer extends IApplicationContext {
   addConfiguration(configuration: IContainerConfiguration);
   getConfigService(): IConfigService;
   getEnvironmentService(): IEnvironmentService;
+  getAspectService(): IAspectService;
   getCurrentEnv(): string;
   getResolverHandler(): IResolverHandler;
-  addAspect(
-    aspectIns: IMethodAspect,
-    aspectData: AspectMetadata
-  );
   addDirectoryFilter(filter: ResolveFilter[]);
 }
 
@@ -294,6 +291,13 @@ export interface IEnvironmentService {
   getCurrentEnvironment(): string;
   setCurrentEnvironment(environment: string);
   isDevelopmentEnvironment(): boolean;
+}
+
+export interface IAspectService {
+  loadAspect();
+  addAspect(aspectIns: IMethodAspect, aspectData: AspectMetadata);
+  wrapperAspectToInstance(ins);
+  hasAspect(module): boolean;
 }
 
 export interface IMiddleware<T> {
@@ -335,6 +339,7 @@ export interface IMidwayApplication<T extends IMidwayContext = IMidwayContext> {
   getProjectName(): string;
   createAnonymousContext(...args): T;
   setContextLoggerClass(BaseContextLoggerClass: any): void;
+  addConfigObject(obj: any);
 }
 
 /**
@@ -357,6 +362,7 @@ export interface IMidwayBootstrapOptions {
   applicationContext?: IMidwayContainer;
   isMainFramework?: boolean;
   globalApplicationHandler?: (type: MidwayFrameworkType) => IMidwayApplication;
+  globalConfig?: any;
 }
 
 export interface IConfigurationOptions {

--- a/packages/core/src/loader.ts
+++ b/packages/core/src/loader.ts
@@ -87,6 +87,7 @@ export class ContainerLoader {
 
   async refresh() {
     await this.applicationContext.ready();
+    await this.applicationContext.getAspectService().loadAspect();
     await this.loadLifeCycles();
   }
 

--- a/packages/core/src/service/aspectService.ts
+++ b/packages/core/src/service/aspectService.ts
@@ -1,0 +1,247 @@
+import {
+  ASPECT_KEY,
+  AspectMetadata,
+  getClassMetadata,
+  IMethodAspect,
+  isAsyncFunction,
+  isProxy,
+  listModule,
+} from '@midwayjs/decorator';
+import * as pm from 'picomatch';
+import { IAspectService, IMidwayContainer } from '../interface';
+import * as util from 'util';
+
+const debugLogger = util.debuglog('midway:container:aspect');
+
+export class MidwayAspectService implements IAspectService {
+  protected aspectMappingMap: WeakMap<any, Map<string, any[]>>;
+  private aspectModuleSet: Set<any>;
+  private container: IMidwayContainer;
+
+  constructor(container) {
+    this.container = container;
+    this.aspectMappingMap = new WeakMap();
+    this.aspectModuleSet = new Set();
+  }
+  /**
+   * load aspect method for container
+   * @private
+   */
+  public async loadAspect() {
+    // for aop implementation
+    const aspectModules = listModule(ASPECT_KEY);
+    // sort for aspect target
+    let aspectDataList = [];
+    for (const module of aspectModules) {
+      const data = getClassMetadata(ASPECT_KEY, module);
+      aspectDataList = aspectDataList.concat(
+        data.map(el => {
+          el.aspectModule = module;
+          return el;
+        })
+      );
+    }
+
+    // sort priority
+    aspectDataList.sort((pre, next) => {
+      return (next.priority || 0) - (pre.priority || 0);
+    });
+
+    for (const aspectData of aspectDataList) {
+      const aspectIns = await this.container.getAsync<IMethodAspect>(
+        aspectData.aspectModule
+      );
+      await this.addAspect(aspectIns, aspectData);
+    }
+
+    // 合并拦截器方法，提升性能
+    for (const module of this.aspectModuleSet) {
+      const aspectMapping = this.aspectMappingMap.get(module);
+      for (const [method, aspectFn] of aspectMapping) {
+        const composeFn = (ins, originMethod) => {
+          for (const fn of aspectFn) {
+            originMethod = fn(ins, originMethod);
+          }
+          return originMethod;
+        };
+        aspectMapping.set(method, [composeFn]);
+      }
+    }
+    // 绑定完后清理 Set 记录
+    this.aspectModuleSet.clear();
+  }
+
+  public async addAspect(aspectIns: IMethodAspect, aspectData: AspectMetadata) {
+    const module = aspectData.aspectTarget;
+    const names = Object.getOwnPropertyNames(module.prototype);
+    const isMatch = aspectData.match ? pm(aspectData.match) : () => true;
+
+    // 存到 set 里用来做循环
+    this.aspectModuleSet.add(module);
+
+    /**
+     * 拦截器流程
+     * 1、在每个被拦截的 class 上做拦截标记，记录哪些方法需要被拦截
+     * 2、Container 保存每个 class 的方法对应的拦截器数组
+     * 3、创建完实例后，在返回前执行包裹逻辑，把需要拦截的方法都执行一遍拦截（不对原型做修改）
+     */
+
+    for (const name of names) {
+      if (name === 'constructor' || !isMatch(name)) {
+        continue;
+      }
+      const descriptor = Object.getOwnPropertyDescriptor(
+        module.prototype,
+        name
+      );
+      if (!descriptor || descriptor.writable === false) {
+        continue;
+      }
+
+      // 把拦截器和当前容器绑定
+      if (!this.aspectMappingMap.has(module)) {
+        this.aspectMappingMap.set(module, new Map());
+      }
+
+      const mappingMap = this.aspectMappingMap.get(module);
+      if (!mappingMap.has(name)) {
+        mappingMap.set(name, []);
+      }
+      // 把拦截器本身加到数组中
+      const methodAspectCollection = mappingMap.get(name);
+
+      if (isAsyncFunction(descriptor.value)) {
+        debugLogger(
+          `aspect [#${module.name}:${name}], isAsync=true, aspect class=[${aspectIns.constructor.name}]`
+        );
+
+        const fn = (ins, originMethod) => {
+          return async (...args) => {
+            let error, result;
+            const newProceed = (...args) => {
+              return originMethod.apply(ins, args);
+            };
+            const joinPoint = {
+              methodName: name,
+              target: ins,
+              args: args,
+              proceed: newProceed,
+            };
+            try {
+              await aspectIns.before?.(joinPoint);
+              if (aspectIns.around) {
+                result = await aspectIns.around(joinPoint);
+              } else {
+                result = await originMethod.apply(ins, joinPoint.args);
+              }
+              joinPoint.proceed = undefined;
+              const resultTemp = await aspectIns.afterReturn?.(
+                joinPoint,
+                result
+              );
+              result = typeof resultTemp === 'undefined' ? result : resultTemp;
+              return result;
+            } catch (err) {
+              joinPoint.proceed = undefined;
+              error = err;
+              if (aspectIns.afterThrow) {
+                await aspectIns.afterThrow(joinPoint, error);
+              } else {
+                throw err;
+              }
+            } finally {
+              await aspectIns.after?.(joinPoint, result, error);
+            }
+          };
+        };
+
+        methodAspectCollection.push(fn);
+      } else {
+        debugLogger(
+          `aspect [#${module.name}:${name}], isAsync=false, aspect class=[${aspectIns.constructor.name}]`
+        );
+        const fn = (ins, originMethod) => {
+          return (...args) => {
+            let error, result;
+            const newProceed = (...args) => {
+              return originMethod.apply(ins, args);
+            };
+            const joinPoint = {
+              methodName: name,
+              target: ins,
+              args: args,
+              proceed: newProceed,
+            };
+            try {
+              aspectIns.before?.(joinPoint);
+              if (aspectIns.around) {
+                result = aspectIns.around(joinPoint);
+              } else {
+                result = originMethod.apply(ins, joinPoint.args);
+              }
+              const resultTemp = aspectIns.afterReturn?.(joinPoint, result);
+              result = typeof resultTemp === 'undefined' ? result : resultTemp;
+              return result;
+            } catch (err) {
+              error = err;
+              if (aspectIns.afterThrow) {
+                aspectIns.afterThrow(joinPoint, error);
+              } else {
+                throw err;
+              }
+            } finally {
+              aspectIns.after?.(joinPoint, result, error);
+            }
+          };
+        };
+
+        methodAspectCollection.push(fn);
+      }
+    }
+  }
+
+  /**
+   * wrapper aspect method before instance return
+   * @param ins
+   * @protected
+   */
+  public wrapperAspectToInstance(ins) {
+    let proxy = null;
+    /**
+     * 过滤循环依赖创建的对象
+     */
+    if (!isProxy(ins) && ins?.constructor) {
+      // 动态处理拦截器
+      let methodAspectCollection;
+      if (this.aspectMappingMap?.has(ins.constructor)) {
+        methodAspectCollection = this.aspectMappingMap.get(ins.constructor);
+      } else if (
+        (this.container?.parent as IMidwayContainer)
+          ?.getAspectService()
+          .hasAspect(ins.constructor)
+      ) {
+        // for requestContainer
+        methodAspectCollection = (this.container?.parent as IMidwayContainer)
+          ?.getAspectService()
+          .hasAspect(ins.constructor);
+      }
+
+      if (methodAspectCollection) {
+        proxy = new Proxy(ins, {
+          get: (obj, prop) => {
+            if (typeof prop === 'string' && methodAspectCollection.has(prop)) {
+              const aspectFn = methodAspectCollection.get(prop);
+              return aspectFn[0](ins, obj[prop]);
+            }
+            return obj[prop];
+          },
+        });
+      }
+    }
+    return proxy || ins;
+  }
+
+  hasAspect(module): boolean {
+    return this.aspectMappingMap.has(module);
+  }
+}

--- a/packages/core/src/service/configService.ts
+++ b/packages/core/src/service/configService.ts
@@ -76,6 +76,7 @@ export class MidwayConfigService implements IConfigService {
   }
 
   async load() {
+    if (this.isReady) return;
     // get default
     const defaultSet = this.getEnvSet('default');
     // get current set

--- a/packages/core/src/util/emptyFramework.ts
+++ b/packages/core/src/util/emptyFramework.ts
@@ -31,8 +31,8 @@ export class EmptyFramework extends BaseFramework<any, any, any> {
   }
 
   async containerReady() {}
-
   async afterContainerReady() {}
+  async loadExtension() {}
 }
 
 /**
@@ -58,8 +58,8 @@ export class ConfigFramework extends BaseFramework<any, any, any> {
   async containerReady() {
     await this.applicationContext.ready();
   }
-
   async afterContainerReady() {}
+  async loadExtension() {}
 }
 
 /**

--- a/packages/core/src/util/emptyFramework.ts
+++ b/packages/core/src/util/emptyFramework.ts
@@ -53,6 +53,7 @@ export class ConfigFramework extends BaseFramework<any, any, any> {
 
   async applicationInitialize(options: IMidwayBootstrapOptions) {
     this.app = {} as IMidwayApplication;
+    this.defineApplicationProperties();
   }
 
   async containerReady() {
@@ -78,5 +79,6 @@ export class LightFramework extends BaseFramework<any, any, any> {
 
   async applicationInitialize(options: IMidwayBootstrapOptions) {
     this.app = {} as IMidwayApplication;
+    this.defineApplicationProperties();
   }
 }

--- a/packages/web/app.js
+++ b/packages/web/app.js
@@ -31,7 +31,7 @@ class AppBootHook {
   }
 
   async willReady() {
-    await this.app.webFramework.loadLifeCycles(true);
+    await this.app.webFramework.loadExtension();
     const middlewareNames = this.coreMiddleware.concat(this.appMiddleware);
     // 等 midway 加载完成后，再去 use 中间件
     for (const name of middlewareNames) {

--- a/packages/web/src/interface.ts
+++ b/packages/web/src/interface.ts
@@ -29,6 +29,7 @@ declare module 'egg' {
     createLogger(name: string, options: LoggerOptions);
     getProjectName(): string;
     setContextLoggerClass(BaseContextLoggerClass: any): void;
+    addConfigObject(obj: any);
   }
 
   interface Context {


### PR DESCRIPTION
fix: #969 
close: #958

示例如下：

```js
Bootstrap
  .load(globalConfig => {
    // 加载主 web 框架
    const framework = new WebFramemwork();
    framework.configure(globalConfig.cluster);
    return framework;
  })
  .load(globalConfig => {
    // 加载副 socket.io 框架
    const framework = new SocketFramemwork();
    framework.configure();
    return framework;
  })
  .before(async (container) => {
    const configService = await container.getAsync('remoteConfigService');
    const data = await configService.getRemoteConfig();
    container.getConfigService().addObject(data);
  })
  .run();

```