### PR TITLE
fix: configuration file path join on windows

### DIFF
--- a/packages/core/src/context/configuration.ts
+++ b/packages/core/src/context/configuration.ts
@@ -193,7 +193,7 @@ export class ContainerConfiguration implements IContainerConfiguration {
       }
     }
     if (!configuration) {
-      cfgFile = join(`${packageBaseDir}`, 'configuration');
+      cfgFile = join(packageBaseDir, 'configuration');
       configuration = safeRequire(cfgFile);
       debug('current case 2 => configuration file "%s".', cfgFile);
       loadDir = packageBaseDir;

--- a/packages/core/src/context/configuration.ts
+++ b/packages/core/src/context/configuration.ts
@@ -193,7 +193,7 @@ export class ContainerConfiguration implements IContainerConfiguration {
       }
     }
     if (!configuration) {
-      cfgFile = `${packageBaseDir}/configuration`;
+      cfgFile = join(`${packageBaseDir}`, 'configuration');
       configuration = safeRequire(cfgFile);
       debug('current case 2 => configuration file "%s".', cfgFile);
       loadDir = packageBaseDir;


### PR DESCRIPTION
在[configuration.ts](https://github.com/midwayjs/midway/blob/2.x/packages/core/src/context/configuration.ts)中，存在一处路径硬拼接问题。可通过以下步骤重现：

于windows平台
1. `npm init midway -- --type=web my_midway_app`
2. `npm run dev`
3. 报错了

此提交改为path.join拼接路径