### PR TITLE
fix: serverless logger rotator error

### DIFF
--- a/packages-serverless/runtime-engine/src/lib/logger.ts
+++ b/packages-serverless/runtime-engine/src/lib/logger.ts
@@ -105,9 +105,9 @@ export class ServerlessLogger extends Logger implements IServerlessLogger {
 
   protected async checkAndRotate(transport) {
     const maxFileSize =
-        this.options.maxFileSize ||
-        Number(process.env.LOG_ROTATE_FILE_SIZE) ||
-        DEFAULT_MAX_FILE_SIZE;
+      this.options.maxFileSize ||
+      Number(process.env.LOG_ROTATE_FILE_SIZE) ||
+      DEFAULT_MAX_FILE_SIZE;
     const stat = await fs.fstat(transport._stream.fd);
     if (stat.size >= maxFileSize) {
       this.info(

--- a/packages-serverless/runtime-engine/src/lib/logger.ts
+++ b/packages-serverless/runtime-engine/src/lib/logger.ts
@@ -78,23 +78,35 @@ export class ServerlessLogger extends Logger implements IServerlessLogger {
    */
   protected async rotateLogBySize(): Promise<void> {
     try {
-      const maxFileSize =
-        this.options.maxFileSize ||
-        Number(process.env.LOG_ROTATE_FILE_SIZE) ||
-        DEFAULT_MAX_FILE_SIZE;
       const transport: any = this.get('file');
       if (transport?._stream?.writable) {
-        const stat = await fs.fstat(transport._stream.fd);
-        if (stat.size >= maxFileSize) {
-          this.info(
-            `File ${transport._stream.path} (fd ${transport._stream.fd}) reach the maximum file size, current size: ${stat.size}, max size: ${maxFileSize}`
-          );
-          await this.rotateBySize();
+        if (transport._stream.fd) {
+          await this.checkAndRotate(transport);
+        } else {
+          // 如果没有 fd，这里需要监听 open 事件，这时候才会有 fd，否则直接抛异常了
+          transport._stream.on('open', async (fd: number) => {
+            await this.checkAndRotate(transport);
+          });
         }
       }
     } catch (e) {
+      debuglog('rotateLogBySize error =>' + e.stack);
       e.message = `${e.message}`;
       this.error(e);
+    }
+  }
+
+  protected async checkAndRotate(transport) {
+    const maxFileSize =
+        this.options.maxFileSize ||
+        Number(process.env.LOG_ROTATE_FILE_SIZE) ||
+        DEFAULT_MAX_FILE_SIZE;
+    const stat = await fs.fstat(transport._stream.fd);
+    if (stat.size >= maxFileSize) {
+      this.info(
+        `File ${transport._stream.path} (fd ${transport._stream.fd}) reach the maximum file size, current size: ${stat.size}, max size: ${maxFileSize}`
+      );
+      await this.rotateBySize();
     }
   }
 

--- a/packages-serverless/runtime-engine/test/lib/logger.test.ts
+++ b/packages-serverless/runtime-engine/test/lib/logger.test.ts
@@ -114,4 +114,24 @@ describe('logger.test.ts', () => {
       });
     });
   });
+
+  describe('logger benchmark', () => {
+    it('logger benchmark should be ok', async () => {
+      const loggerFactory = new BaseLoggerFactory(__dirname);
+      const log = (loggerFactory as any).createLogger(path.join(__dirname, '_benchmarks/test.log'), {
+        fileClearInterval: 100,
+        maxFileSize: 1,
+        maxFiles: 2,
+      });
+
+      for (let i = 0; i < 100000; i++) {
+        log.info('asjdfaoj230u4u9rpasdjfasjdfpoaiweurpoqwurapsjf;lasdjfopasiefpoqwuerpoajsdpfjasdjfa;lsdjfaosdfjpawierpqoiwe ==> i = %s', i);
+        log.error('asjdfaoj230u4u9rpasdjfasjdfpoaiweurpoqwurapsjf;lasdjfopasiefpoqwuerpoajsdpfjasdjfa;lsdjfaosdfjpawierpqoiwe ==> i = %s', i);
+
+        // await new Promise<void>(resolve => {
+        //   setTimeout(() => resolve(), 50);
+        // });
+      }
+    });
+  });
 });


### PR DESCRIPTION
* 日志轮转时如果写入频率高， stream 的 fd 为空，会导致轮转判断出错