### PR TITLE
fix: remove reset bootstrap logger

### DIFF
--- a/packages/bootstrap/src/bootstrap.ts
+++ b/packages/bootstrap/src/bootstrap.ts
@@ -266,7 +266,6 @@ export class Bootstrap {
   }
 
   static reset() {
-    this.logger = null;
     this.configured = false;
     this.starter = null;
   }


### PR DESCRIPTION
修复 bootstrap 在 stop 的时候，把 logger 清掉导致关闭的时候会出现一个 logger 为空的报错。

![image](https://user-images.githubusercontent.com/418820/114744182-00d0f100-9d80-11eb-9ae4-e27fe0ab99a1.png)
