### PR TITLE
test: perf_hooks observers no longer receive events immediately

### DIFF
--- a/packages-serverless/runtime-engine/src/engine.ts
+++ b/packages-serverless/runtime-engine/src/engine.ts
@@ -86,9 +86,9 @@ export class BaseRuntimeEngine implements RuntimeEngine {
   private measureMarksOnReady() {
     [
       'runtimeStart',
-      'functionStart',
       'beforeRuntimeStartHandler',
       'afterRuntimeStartHandler',
+      'functionStart',
       'beforeFunctionStartHandler',
       'afterFunctionStartHandler',
     ].forEach(it => {


### PR DESCRIPTION


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change

Fixes Node.js v16 compatibility
