### PR TITLE
fix: output serverless error in some environment

### DIFF
--- a/packages-serverless/serverless-fc-starter/src/runtime.ts
+++ b/packages-serverless/serverless-fc-starter/src/runtime.ts
@@ -10,10 +10,13 @@ import {
 } from '@midwayjs/serverless-http-parser';
 import * as util from 'util';
 
-const isLocalEnv = () => {
+const isOutputError = () => {
   return (
-    process.env.MIDWAY_SERVER_ENV === 'local' ||
-    process.env.NODE_ENV === 'local'
+    process.env.SERVERLESS_OUTPUT_ERROR_STACK === 'true' ||
+    ['local', 'development', 'prepub'].includes(
+      process.env.MIDWAY_SERVER_ENV
+    ) ||
+    ['local', 'development', 'prepub'].includes(process.env.NODE_ENV)
   );
 };
 
@@ -201,13 +204,13 @@ export class FCRuntime extends ServerlessLightRuntime {
             ctx.logger.error(err);
             if (res.send) {
               res.setStatusCode(500);
-              res.send(isLocalEnv() ? err.stack : 'Internal Server Error');
+              res.send(isOutputError() ? err.stack : 'Internal Server Error');
             }
             return {
               isBase64Encoded: false,
               statusCode: 500,
               headers: {},
-              body: isLocalEnv() ? err.stack : 'Internal Server Error',
+              body: isOutputError() ? err.stack : 'Internal Server Error',
             };
           });
       },

--- a/packages-serverless/serverless-fc-starter/src/runtime.ts
+++ b/packages-serverless/serverless-fc-starter/src/runtime.ts
@@ -13,10 +13,10 @@ import * as util from 'util';
 const isOutputError = () => {
   return (
     process.env.SERVERLESS_OUTPUT_ERROR_STACK === 'true' ||
-    ['local', 'development', 'prepub'].includes(
+    ['local', 'development'].includes(
       process.env.MIDWAY_SERVER_ENV
     ) ||
-    ['local', 'development', 'prepub'].includes(process.env.NODE_ENV)
+    ['local', 'development'].includes(process.env.NODE_ENV)
   );
 };
 

--- a/packages-serverless/serverless-scf-starter/src/runtime.ts
+++ b/packages-serverless/serverless-scf-starter/src/runtime.ts
@@ -9,10 +9,10 @@ import {
 const isOutputError = () => {
   return (
     process.env.SERVERLESS_OUTPUT_ERROR_STACK === 'true' ||
-    ['local', 'development', 'prepub'].includes(
+    ['local', 'development'].includes(
       process.env.MIDWAY_SERVER_ENV
     ) ||
-    ['local', 'development', 'prepub'].includes(process.env.NODE_ENV)
+    ['local', 'development'].includes(process.env.NODE_ENV)
   );
 };
 

--- a/packages-serverless/serverless-scf-starter/src/runtime.ts
+++ b/packages-serverless/serverless-scf-starter/src/runtime.ts
@@ -6,10 +6,13 @@ import {
   HTTPResponse,
 } from '@midwayjs/serverless-http-parser';
 
-const isLocalEnv = () => {
+const isOutputError = () => {
   return (
-    process.env.MIDWAY_SERVER_ENV === 'local' ||
-    process.env.NODE_ENV === 'local'
+    process.env.SERVERLESS_OUTPUT_ERROR_STACK === 'true' ||
+    ['local', 'development', 'prepub'].includes(
+      process.env.MIDWAY_SERVER_ENV
+    ) ||
+    ['local', 'development', 'prepub'].includes(process.env.NODE_ENV)
   );
 };
 
@@ -110,7 +113,7 @@ export class SCFRuntime extends ServerlessLightRuntime {
               isBase64Encoded: false,
               statusCode: 500,
               headers: {},
-              body: isLocalEnv() ? err.stack : 'Internal Server Error',
+              body: isOutputError() ? err.stack : 'Internal Server Error',
             };
           });
       },


### PR DESCRIPTION
开放特定的环境变量下的堆栈输出，方便开发和排错。同时，增加一个特定的环境变量，用于明确需要显示错误堆栈的场景。

```
process.env.SERVERLESS_OUTPUT_ERROR_STACK = 'true'
```