### PR TITLE
fix: remove winston-daily-rotate-file

### DIFF
--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -4,12 +4,15 @@
   "main": "dist/index",
   "typings": "dist/index.d.ts",
   "dependencies": {
+    "file-stream-rotator": "^0.5.7",
+    "object-hash": "^2.0.1",
     "triple-beam": "^1.3.0",
     "winston": "^3.3.3",
-    "winston-daily-rotate-file": "^4.5.0",
-    "winston-transport": "^4.4.0"
+    "winston-transport": "^4.4.0",
+    "zlib": "^1.0.5"
   },
   "devDependencies": {
+    "dayjs": "^1.10.4",
     "egg-logger": "^2.4.2",
     "fs-extra": "^8.0.1"
   },

--- a/packages/logger/src/interface.ts
+++ b/packages/logger/src/interface.ts
@@ -1,4 +1,5 @@
 import * as logform from 'logform';
+import TransportStream = require('winston-transport');
 
 export interface ILogger {
   info(msg: any, ...args: any[]): void;
@@ -6,7 +7,6 @@ export interface ILogger {
   error(msg: any, ...args: any[]): void;
   warn(msg: any, ...args: any[]): void;
 }
-
 
 export type LoggerCustomInfoHandler = (
   info: MidwayTransformableInfo
@@ -81,4 +81,79 @@ export interface MidwayTransformableInfo {
   defaultLabel: string;
   originError?: Error;
   stack?: string;
+}
+
+export interface GeneralDailyRotateFileTransportOptions extends TransportStream.TransportStreamOptions {
+  json?: boolean;
+  eol?: string;
+
+  /**
+   * A string representing the moment.js date format to be used for rotating. The meta characters used in this string will dictate the frequency of the file rotation. For example, if your datePattern is simply 'HH' you will end up with 24 log files that are picked up and appended to every day. (default 'YYYY-MM-DD')
+   */
+  datePattern?: string;
+
+  /**
+   * A boolean to define whether or not to gzip archived log files. (default 'false')
+   */
+  zippedArchive?: boolean;
+
+  /**
+   * Filename to be used to log to. This filename can include the %DATE% placeholder which will include the formatted datePattern at that point in the filename. (default: 'winston.log.%DATE%)
+   */
+  filename?: string;
+
+  /**
+   * The directory name to save log files to. (default: '.')
+   */
+  dirname?: string;
+
+  /**
+   * Write directly to a custom stream and bypass the rotation capabilities. (default: null)
+   */
+  stream?: NodeJS.WritableStream;
+
+  /**
+   * Maximum size of the file after which it will rotate. This can be a number of bytes, or units of kb, mb, and gb. If using the units, add 'k', 'm', or 'g' as the suffix. The units need to directly follow the number. (default: null)
+   */
+  maxSize?: string | number;
+
+  /**
+   * Maximum number of logs to keep. If not set, no logs will be removed. This can be a number of files or number of days. If using days, add 'd' as the suffix. (default: null)
+   */
+  maxFiles?: string | number;
+
+  /**
+   * An object resembling https://nodejs.org/api/fs.html#fs_fs_createwritestream_path_options indicating additional options that should be passed to the file stream. (default: `{ flags: 'a' }`)
+   */
+  options?: string | object;
+
+  /**
+   * A string representing the name of the name of the audit file. (default: './hash-audit.json')
+   */
+  auditFile?: string;
+
+  /**
+   * A string representing the frequency of rotation. (default: 'custom')
+   */
+  frequency?: string;
+
+  /**
+   * A boolean whether or not to generate file name from "datePattern" in UTC format. (default: false)
+   */
+  utc?: boolean;
+
+  /**
+   * A string representing an extension to be added to the filename, if not included in the filename property. (default: '')
+   */
+  extension?: string;
+
+  /**
+   * Create a tailable symlink to the current active log file. (default: false)
+   */
+  createSymlink?: boolean;
+
+  /**
+   * The name of the tailable symlink. (default: 'current.log')
+   */
+  symlinkName?: string;
 }

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -1,5 +1,5 @@
 import { createLogger, transports, Logger, format } from 'winston';
-import * as DailyRotateFileTransport from 'winston-daily-rotate-file';
+import { DailyRotateFileTransport } from './rotate';
 import {
   DelegateLoggerOptions,
   LoggerLevel,

--- a/packages/logger/src/rotate.ts
+++ b/packages/logger/src/rotate.ts
@@ -70,7 +70,7 @@ export class DailyRotateFileTransport extends Transport {
   filename: string;
 
   constructor(options: GeneralDailyRotateFileTransportOptions = {}) {
-    super();
+    super(options);
     this.options = Object.assign({}, loggerDefaults, options);
 
     if (options.stream) {

--- a/packages/logger/src/rotate.ts
+++ b/packages/logger/src/rotate.ts
@@ -1,0 +1,176 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as zlib from 'zlib';
+import * as hash from 'object-hash';
+import { MESSAGE } from 'triple-beam';
+import { PassThrough } from 'stream';
+import Transport = require('winston-transport');
+import rotator = require('file-stream-rotator');
+import { GeneralDailyRotateFileTransportOptions } from './interface';
+
+const loggerDefaults = {
+  json: false,
+  colorize: false,
+  eol: os.EOL,
+  logstash: null,
+  prettyPrint: false,
+  label: null,
+  stringify: false,
+  depth: null,
+  showLevel: true,
+  timestamp: function () {
+    return new Date().toISOString();
+  },
+};
+
+const noop = function () {};
+
+function isValidFileName(filename) {
+  // eslint-disable-next-line no-control-regex
+  return !/["<>|:*?\\/\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f]/g.test(
+    filename
+  );
+}
+
+function isValidDirName(dirname) {
+  // eslint-disable-next-line no-control-regex
+  return !/["<>|\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f]/g.test(
+    dirname
+  );
+}
+
+function getMaxSize(size) {
+  if (size && typeof size === 'string') {
+    const _s = size.toLowerCase().match(/^((?:0\.)?\d+)([k|m|g])$/);
+    if (_s) {
+      return size;
+    }
+  } else if (size && Number.isInteger(size)) {
+    const sizeK = Math.round(size / 1024);
+    return sizeK === 0 ? '1k' : sizeK + 'k';
+  }
+
+  return null;
+}
+
+function throwIf(options, ...args) {
+  Array.prototype.slice.call(args, 1).forEach(name => {
+    if (options[name]) {
+      throw new Error('Cannot set ' + name + ' and ' + args[0] + ' together');
+    }
+  });
+}
+
+export class DailyRotateFileTransport extends Transport {
+  options;
+  logStream;
+  name = 'dailyRotateFile';
+  dirname: string;
+  filename: string;
+
+  constructor(options: GeneralDailyRotateFileTransportOptions = {}) {
+    super();
+    this.options = Object.assign({}, loggerDefaults, options);
+
+    if (options.stream) {
+      throwIf(options, 'stream', 'filename', 'maxsize');
+      this.logStream = new PassThrough();
+      this.logStream.pipe(options.stream);
+    } else {
+      this.filename = options.filename
+        ? path.basename(options.filename)
+        : 'winston.log';
+      this.dirname = options.dirname || path.dirname(options.filename);
+
+      if (!isValidFileName(this.filename) || !isValidDirName(this.dirname)) {
+        throw new Error('Your path or filename contain an invalid character.');
+      }
+
+      this.logStream = rotator.getStream({
+        filename: path.join(this.dirname, this.filename),
+        frequency: options.frequency ? options.frequency : 'custom',
+        date_format: options.datePattern ? options.datePattern : 'YYYY-MM-DD',
+        verbose: false,
+        size: getMaxSize(options.maxSize),
+        max_logs: options.maxFiles,
+        end_stream: true,
+        audit_file: options.auditFile
+          ? options.auditFile
+          : path.join(this.dirname, '.' + hash(options) + '-audit.json'),
+        file_options: options.options ? options.options : { flags: 'a' },
+        utc: options.utc ? options.utc : false,
+        extension: options.extension ? options.extension : '',
+        create_symlink: options.createSymlink ? options.createSymlink : false,
+        symlink_name: options.symlinkName ? options.symlinkName : 'current.log',
+      });
+
+      this.logStream.on('new', newFile => {
+        this.emit('new', newFile);
+      });
+
+      this.logStream.on('rotate', (oldFile, newFile) => {
+        this.emit('rotate', oldFile, newFile);
+      });
+
+      this.logStream.on('logRemoved', params => {
+        if (options.zippedArchive) {
+          const gzName = params.name + '.gz';
+          if (fs.existsSync(gzName)) {
+            try {
+              fs.unlinkSync(gzName);
+            } catch (_err) {
+              // file is there but we got an error when trying to delete,
+              // so permissions problem or concurrency issue and another
+              // process already deleted it we could detect the concurrency
+              // issue by checking err.type === ENOENT or EACCESS for
+              // permissions ... but then?
+            }
+            this.emit('logRemoved', gzName);
+            return;
+          }
+        }
+        this.emit('logRemoved', params.name);
+      });
+
+      if (options.zippedArchive) {
+        this.logStream.on('rotate', oldFile => {
+          const oldFileExist = fs.existsSync(oldFile);
+          const gzExist = fs.existsSync(oldFile + '.gz');
+          if (!oldFileExist || gzExist) {
+            return;
+          }
+
+          const gzip = zlib.createGzip();
+          const inp = fs.createReadStream(oldFile);
+          const out = fs.createWriteStream(oldFile + '.gz');
+          inp
+            .pipe(gzip)
+            .pipe(out)
+            .on('finish', () => {
+              if (fs.existsSync(oldFile)) {
+                fs.unlinkSync(oldFile);
+              }
+              this.emit('archive', oldFile + '.gz');
+            });
+        });
+      }
+    }
+  }
+
+  log(info, callback) {
+    callback = callback || noop;
+
+    this.logStream.write(info[MESSAGE] + this.options.eol);
+    this.emit('logged', info);
+    callback(null, true);
+  }
+
+  close() {
+    if (this.logStream) {
+      this.logStream.end(() => {
+        this.emit('finish');
+      });
+    }
+  }
+}

--- a/packages/logger/test/memory-stream.ts
+++ b/packages/logger/test/memory-stream.ts
@@ -1,0 +1,33 @@
+import { Writable } from 'stream';
+
+export class MemoryStream extends Writable {
+
+  _writableState;
+
+  write(...args) {
+    const ret = Writable.prototype.write.apply(this, args);
+    if (!ret) {
+      this.emit('drain');
+    }
+
+    return ret;
+  }
+
+  _write(chunk, encoding, callback) {
+    this.write(chunk, encoding, callback);
+  }
+
+  toString() {
+    return this.toBuffer().toString();
+  }
+
+  toBuffer() {
+    const buffers = [];
+    this._writableState.getBuffer().forEach(function (data) {
+      buffers.push(data.chunk);
+    });
+
+    return Buffer.concat(buffers);
+  };
+
+}

--- a/packages/logger/test/random-string.ts
+++ b/packages/logger/test/random-string.ts
@@ -1,0 +1,31 @@
+const uppers = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+const lowers = 'abcdefghijklmnopqrstuvwxyz';
+const numbers = '0123456789';
+const specials = '_-|@.,?/!~#$%^&*(){}[]+=';
+const charClasses = [uppers, lowers, numbers, specials];
+const minLen = charClasses.length;
+function chooseRandom(x) {
+  const i = Math.floor(Math.random() * x.length);
+  return (typeof (x) === 'string') ? x.substr(i, 1) : x[i];
+}
+
+export const randomString = (maxLen) => {
+  maxLen = (maxLen || 36);
+  if (maxLen < minLen) {
+    throw new Error('length must be >= ' + minLen);
+  }
+
+  let str = '';
+  const usedClasses = {};
+  let charClass;
+  do { // Append a random char from a random char class.
+    while (str.length < maxLen) {
+      charClass = chooseRandom(charClasses);
+      usedClasses[charClass] = true;
+      str += chooseRandom(charClass);
+    }
+    // Ensure we have picked from every char class.
+  } while (Object.keys(usedClasses).length !== charClasses.length);
+
+  return str;
+}

--- a/packages/logger/test/rotate.test.ts
+++ b/packages/logger/test/rotate.test.ts
@@ -1,0 +1,200 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as winston from 'winston';
+import * as rimraf from 'rimraf';
+import * as dayjs from 'dayjs';
+
+import * as utc from 'dayjs/plugin/utc';
+dayjs.extend(utc)
+
+import { DailyRotateFileTransport as DailyRotateFile } from '../src/rotate';
+import { MemoryStream } from './memory-stream';
+import { randomString } from './random-string';
+
+function sendLogItem(transport, level, message, meta?, cb?) {
+  const logger = winston.createLogger({
+    transports: [transport]
+  });
+
+  transport.on('logged', function () {
+    if (cb) {
+      cb(null, true);
+    }
+  });
+
+  logger.info({
+    level: level,
+    message: message
+  });
+}
+
+describe('winston/transports/daily-rotate-file', function () {
+
+  let transport;
+  let stream;
+
+  beforeEach(function () {
+    stream = new MemoryStream();
+    transport = new DailyRotateFile({
+      json: true,
+      stream,
+    });
+  });
+
+  it('should have the proper methods defined', function () {
+    const transport = new DailyRotateFile({stream: new MemoryStream()});
+    expect(transport).toBeInstanceOf(DailyRotateFile);
+    expect(transport['log']).toBeDefined();
+  });
+
+  it('should not allow invalid characters in the filename', function () {
+    expect(function () {
+      // eslint-disable-next-line no-new
+      new DailyRotateFile({
+        filename: 'test\0log.log'
+      });
+    }).toThrow();
+  });
+
+  it('should not allow invalid characters in the dirname', function () {
+    expect(function () {
+      // eslint-disable-next-line no-new
+      new DailyRotateFile({
+        dirname: 'C:\\application<logs>',
+        filename: 'test_%DATE%.log'
+      });
+    }).toThrow();
+  });
+
+  it('should write to the stream', function (done) {
+    sendLogItem(transport, 'info', 'this message should write to the stream', {}, (err, logged) => {
+      expect(err).toBeNull();
+      expect(logged).toBeTruthy();
+      const logEntry = JSON.parse(stream.toString());
+      expect(logEntry.level).toEqual('info')
+      expect(logEntry.message).toEqual('this message should write to the stream');
+      done();
+    });
+  });
+
+  describe('when passed metadata', function () {
+    const circular = {} as any;
+    circular.metadata = circular;
+
+    const params = {
+      no: {},
+      object: {metadata: true},
+      primitive: 'metadata',
+      circular: circular
+    };
+
+    Object.keys(params).forEach(function (param) {
+      it('should accept log messages with ' + param + ' metadata', function (done) {
+        sendLogItem(transport, 'info', 'test log message', params[param], function (err, logged) {
+          expect(err).toBeNull();
+          expect(logged).toBeTruthy();
+          // TODO parse the metadata value to make sure its set properly
+          done();
+        });
+      });
+    });
+  });
+
+  describe('when using a filename or dirname', function () {
+    const logDir = path.join(__dirname, 'logs');
+    const now = dayjs().utc().format('YYYY-MM-DD-HH');
+    const filename = path.join(logDir, 'application-' + now + '.testlog');
+    const options = {
+      json: true,
+      dirname: logDir,
+      filename: 'application-%DATE%',
+      datePattern: 'YYYY-MM-DD-HH',
+      utc: true,
+      extension: '.testlog'
+    };
+
+    beforeEach(function (done) {
+      rimraf(logDir, () => {
+        transport = new DailyRotateFile(options);
+        done();
+      });
+    });
+
+    it('should write to the file', function (done) {
+      transport.on('finish', function () {
+        const logEntries = fs.readFileSync(filename).toString().split('\n').slice(0, -1);
+        expect(logEntries.length).toEqual(1);
+
+        const logEntry = JSON.parse(logEntries[0]);
+        expect(logEntry.level).toEqual('info');
+        expect(logEntry.message).toEqual('this message should write to the file');
+        done();
+      });
+
+      sendLogItem(transport, 'info', 'this message should write to the file', {}, function (err, logged) {
+        expect(err).toBeNull();
+        expect(logged).toBeTruthy();
+      });
+
+      transport.close();
+    });
+
+    it('should not allow the stream to be set', function () {
+      const opts: any = Object.assign({}, options);
+      opts.stream = new MemoryStream();
+      expect(function () {
+        const transport = new DailyRotateFile(opts);
+        expect(transport).not.toBeNull();
+      }).toThrow();
+    });
+
+    it.skip('should raise the new event for a new log file', function (done) {
+      transport.on('new', function (newFile) {
+        expect(newFile).toEqual(filename);
+        done();
+      });
+
+      sendLogItem(transport, 'info', 'this message should write to the file');
+      transport.close();
+    });
+
+    it('should raise the logRemoved event when pruning old log files', function (done) {
+      const opts: any = Object.assign({}, options);
+      opts.maxSize = '1k';
+      opts.maxFiles = 1;
+
+      transport = new DailyRotateFile(opts);
+
+      transport.on('logRemoved', function (removedFilename) {
+        expect(removedFilename).toEqual(filename);
+        done();
+      });
+
+      sendLogItem(transport, 'info', randomString(1056));
+      sendLogItem(transport, 'info', randomString(1056));
+      transport.close();
+    });
+
+    describe('when setting zippedArchive', function () {
+      it('should archive the log after rotating', function (done) {
+        const opts: any = Object.assign({}, options);
+        opts.zippedArchive = true;
+        opts.maxSize = '1k';
+
+        transport = new DailyRotateFile(opts);
+
+        transport.on('finish', function () {
+          fs.readdir(logDir, function (err, files) {
+            expect(files.filter(function (file) {
+              return path.extname(file) === '.gz';
+            }).length).toEqual(1);
+            done();
+          });
+        });
+        sendLogItem(transport, 'info', randomString(1056));
+        sendLogItem(transport, 'info', randomString(1056));
+        transport.close();
+      });
+    });
+  });
+});


### PR DESCRIPTION
由于 winston-daily-rotate-file 里直接依赖了 tar 包导致私有环境可能无法下载，将 winston-daily-rotate-file 代码直接合并进 logger。

把 logger.query 方法去掉了，目前没有用到。