### PR TITLE
chore: remove types for mongoose

### DIFF
--- a/packages/typegoose/package.json
+++ b/packages/typegoose/package.json
@@ -23,8 +23,7 @@
     "@midwayjs/koa": "^2.10.18",
     "@midwayjs/mock": "^2.10.18",
     "@typegoose/typegoose": "^7.4.7",
-    "@types/mongoose": "~5.10.3",
-    "mongoose": "5.10.18",
+    "mongoose": "^5.10.18",
     "mongodb-memory-server": "^6.9.6"
   }
 }


### PR DESCRIPTION
mongoose 的定义已经从 @types/mongoose 变为自带，需要移除。