### PR TITLE
fix: logger parameter join output

### DIFF
--- a/packages-serverless/runtime-engine/src/lightRuntime.ts
+++ b/packages-serverless/runtime-engine/src/lightRuntime.ts
@@ -11,8 +11,9 @@ export abstract class ServerlessLightRuntime
   implements LightRuntime
 {
   async invokeHandlerWrapper(context, invokeHandler) {
+    const contextExtensions = this.getContextExtensions() || [];
     // load context extension
-    for (const contextExtension of this.getContextExtensions() || []) {
+    for (const contextExtension of contextExtensions) {
       await contextExtension(context, this);
     }
     try {

--- a/packages/logger/src/format.ts
+++ b/packages/logger/src/format.ts
@@ -80,7 +80,8 @@ export const displayCommonMessage = format(
         return el instanceof Error;
       });
       if (err) {
-        info.message = info.message.replace(err.message, '').trimEnd() + ' ' + err.stack;
+        info.message =
+          info.message.replace(err.message, '').trimEnd() + ' ' + err.stack;
         info[MESSAGE] = info[MESSAGE] || info.message + err.stack;
         info.originError = err;
         info.stack = err.stack;

--- a/packages/logger/src/format.ts
+++ b/packages/logger/src/format.ts
@@ -80,7 +80,7 @@ export const displayCommonMessage = format(
         return el instanceof Error;
       });
       if (err) {
-        info.message = info.message.replace(err.message, '') + ' ' + err.stack;
+        info.message = info.message.replace(err.message, '').trimEnd() + ' ' + err.stack;
         info[MESSAGE] = info[MESSAGE] || info.message + err.stack;
         info.originError = err;
         info.stack = err.stack;

--- a/packages/logger/src/format.ts
+++ b/packages/logger/src/format.ts
@@ -1,7 +1,5 @@
 import { format } from 'winston';
-import { inspect, types } from 'util';
 import { IMidwayLogger } from './interface';
-const { LEVEL, MESSAGE, SPLAT } = require('triple-beam');
 
 export const displayCommonMessage = format(
   (
@@ -31,61 +29,6 @@ export const displayCommonMessage = format(
     if (!info.defaultLabel) {
       info.defaultLabel =
         opts.defaultLabel || opts.target?.getDefaultLabel() || '';
-    }
-
-    if (info instanceof Error) {
-      // 参数只是 error 的情况
-      return Object.assign(
-        {
-          level: info.level,
-          [LEVEL]: info[LEVEL] || info['level'],
-          message: info.stack,
-          [MESSAGE]: info[MESSAGE] || info.stack,
-          originError: info,
-          stack: info.stack,
-          pid: info.pid,
-          LEVEL: info.LEVEL,
-          defaultLabel: info.defaultLabel,
-          ignoreFormat: info.ignoreFormat,
-          ctx: null,
-        },
-        opts.defaultMeta || opts.target?.getDefaultMeta() || {}
-      );
-    }
-
-    // error(new Error(''), {label: 1}) 的情况
-    if (info.message['stack'] && info.message['message']) {
-      const err = new Error(info.message['message']);
-      err.name = info.message['name'];
-      err.stack = info.message['stack'];
-      info.originError = err;
-      info.stack = info.message['stack'];
-      info.message = err.stack;
-      info[MESSAGE] = info[MESSAGE] || info.message;
-    }
-
-    // 处理数组，Map，Set 的 message
-    if (
-      Array.isArray(info.message) ||
-      types.isSet(info.message) ||
-      types.isMap(info.message)
-    ) {
-      info.message = inspect(info.message);
-    }
-
-    // error 参数在最后的情况
-    if (info[SPLAT] && info[SPLAT].length > 0) {
-      // err 位置不定
-      const err = info[SPLAT].find(el => {
-        return el instanceof Error;
-      });
-      if (err) {
-        info.message =
-          info.message.replace(err.message, '').trimEnd() + ' ' + err.stack;
-        info[MESSAGE] = info[MESSAGE] || info.message + err.stack;
-        info.originError = err;
-        info.stack = err.stack;
-      }
     }
 
     return Object.assign(

--- a/packages/logger/src/format.ts
+++ b/packages/logger/src/format.ts
@@ -75,10 +75,12 @@ export const displayCommonMessage = format(
 
     // error 参数在最后的情况
     if (info[SPLAT] && info[SPLAT].length > 0) {
-      // 目前只会有一个 error，只会在最后一个参数
-      const err = info[SPLAT][info[SPLAT].length - 1];
-      if (err instanceof Error) {
-        info.message = info.message.replace(err.message, '') + err.stack;
+      // err 位置不定
+      const err = info[SPLAT].find(el => {
+        return el instanceof Error;
+      });
+      if (err) {
+        info.message = info.message.replace(err.message, '') + ' ' + err.stack;
         info[MESSAGE] = info[MESSAGE] || info.message + err.stack;
         info.originError = err;
         info.stack = err.stack;

--- a/packages/logger/test/index.test.ts
+++ b/packages/logger/test/index.test.ts
@@ -312,7 +312,7 @@ describe('/test/index.test.ts', () => {
 
     await sleep();
     expect(fileExists(join(logsDir, 'test-logger.log'))).toBeTruthy();
-    expect(includeContent(join(logsDir, 'test-logger.log'), 'bbb.my-site error first message my error')).toBeTruthy();
+    expect(includeContent(join(logsDir, 'test-logger.log'), 'bbb.my-site error first message Error: my error')).toBeTruthy();
     expect(includeContent(join(logsDir, 'test-logger.log'), 'my-another-group.my-another-site error second message Error: my error')).toBeTruthy();
 
     const customFormatLogger = createLogger<IMidwayLogger>('testLogger1', {

--- a/packages/logger/test/index.test.ts
+++ b/packages/logger/test/index.test.ts
@@ -81,7 +81,7 @@ describe('/test/index.test.ts', () => {
         ['key2', 'value2'],
       ])
     );
-    expect(fn.mock.calls[12][0].message).toEqual('{ \'key1\' => \'value1\', \'key2\' => \'value2\' }');
+    expect(fn.mock.calls[12][0].message).toContain('{ \'key1\' => \'value1\', \'key2\' => \'value2\' }');
     // warn object
     logger.warn({ name: 'Jack' });
     expect(fn.mock.calls[13][0].message).toEqual('{ name: \'Jack\' }');

--- a/packages/logger/test/index.test.ts
+++ b/packages/logger/test/index.test.ts
@@ -93,7 +93,8 @@ describe('/test/index.test.ts', () => {
     error.name = 'NamedError';
     // 直接输出 error
     logger.error(error);
-    expect(fn.mock.calls[15][0].message).toContain('Error [NamedError]: named error instance');
+    expect(fn.mock.calls[15][0].message).toContain('NamedError');
+    expect(fn.mock.calls[15][0].message).toContain('named error instance');
   });
 
   it('should test create logger', async () => {
@@ -404,7 +405,7 @@ describe('/test/index.test.ts', () => {
     expect(
       includeContent(
         join(logsDir, 'custom-logger.log'),
-        '[NamedError]: named error instance'
+        'named error instance'
       )
     ).toBeTruthy();
     expect(

--- a/packages/logger/test/index.test.ts
+++ b/packages/logger/test/index.test.ts
@@ -73,7 +73,7 @@ describe('/test/index.test.ts', () => {
     expect(fn.mock.calls[10][0].message).toEqual('format log, {\"a\":1}');
     // set
     logger.info(new Set([2, 3, 4]));
-    expect(fn.mock.calls[11][0].message).toEqual('Set(3) { 2, 3, 4 }');
+    expect(fn.mock.calls[11][0].message).toContain('{ 2, 3, 4 }');
     // map
     logger.info(
       new Map([

--- a/packages/logger/test/index.test.ts
+++ b/packages/logger/test/index.test.ts
@@ -164,7 +164,9 @@ describe('/test/index.test.ts', () => {
       disableError: true,
     });
 
-    logger.debug('test');
+    logger.debug('test', 'test1', 'test2', 'test3');
+    logger.warn('test', 'test4', 'test5', 123, new Error('bcd'));
+    logger.error('test2', 'test6', 123, 'test7', new Error('ef'), { label: '123' });
     logger.info('hello world', { label: ['a', 'b']});
     logger.warn('warn: hello world', {label: 'UserService'});
     logger.info('%s %d', 'aaa', 222);
@@ -204,7 +206,9 @@ describe('/test/index.test.ts', () => {
 
     expect(fileExists(join(logsDir, 'custom-logger.log'))).toBeTruthy();
     expect(fileExists(join(logsDir, 'common-error.log'))).toBeFalsy();
-    expect(includeContent(join(logsDir, 'custom-logger.log'), 'test')).toBeTruthy();
+    expect(includeContent(join(logsDir, 'custom-logger.log'), 'test test1 test2 test3')).toBeTruthy();
+    expect(includeContent(join(logsDir, 'custom-logger.log'), 'test test4 test5 123 Error: bcd')).toBeTruthy();
+    expect(includeContent(join(logsDir, 'custom-logger.log'), 'test2 test6 123 test7 Error: ef')).toBeTruthy();
     expect(includeContent(join(logsDir, 'custom-logger.log'), '[a:b] hello world')).toBeTruthy();
     expect(includeContent(join(logsDir, 'custom-logger.log'), '[UserService] warn: hello world')).toBeTruthy();
     expect(includeContent(join(logsDir, 'custom-logger.log'), 'aaa 222')).toBeTruthy();
@@ -227,6 +231,7 @@ describe('/test/index.test.ts', () => {
   it('should create console file', async () => {
     await removeFileOrDir(join(process.cwd(), 'common-error.log'));
     const consoleLogger = createConsoleLogger('consoleLogger');
+    consoleLogger.debug('test', 'test1', 'test2', 'test3');
     consoleLogger.error('test console error');
     console.log('---');
     const err = new Error('custom error');

--- a/packages/logger/test/index.test.ts
+++ b/packages/logger/test/index.test.ts
@@ -81,7 +81,7 @@ describe('/test/index.test.ts', () => {
         ['key2', 'value2'],
       ])
     );
-    expect(fn.mock.calls[12][0].message).toEqual('Map(2) { \'key1\' => \'value1\', \'key2\' => \'value2\' }');
+    expect(fn.mock.calls[12][0].message).toEqual('{ \'key1\' => \'value1\', \'key2\' => \'value2\' }');
     // warn object
     logger.warn({ name: 'Jack' });
     expect(fn.mock.calls[13][0].message).toEqual('{ name: \'Jack\' }');


### PR DESCRIPTION
支持 logger 在多个参数时候的输出问题。

比如

```ts
logger.info('test', 'test1', 'test2', new Error('xxx'));
```