### PR TITLE
fix: hide real error when user code throw error

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -35,6 +35,12 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
+
+    - name: Start MongoDB
+        uses: supercharge/mongodb-github-action@1.6.0
+        with:
+          mongodb-version: 4.2
+
     - run: npm install && npm install codecov
     - run: npm run bootstrap
     - run: npm run build --if-present

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -37,9 +37,9 @@ jobs:
         node-version: ${{ matrix.node-version }}
 
     - name: Start MongoDB
-        uses: supercharge/mongodb-github-action@1.6.0
-        with:
-          mongodb-version: 4.2
+      uses: supercharge/mongodb-github-action@1.6.0
+      with:
+        mongodb-version: 4.2
 
     - run: npm install && npm install codecov
     - run: npm run bootstrap

--- a/packages-serverless/serverless-fc-starter/src/runtime.ts
+++ b/packages-serverless/serverless-fc-starter/src/runtime.ts
@@ -242,12 +242,26 @@ export class FCRuntime extends ServerlessLightRuntime {
     // format context
     const newCtx = {
       logger: context.logger || console,
+      originEvent: event,
       originContext: context,
     };
     // 其他事件场景
     return this.invokeHandlerWrapper(newCtx, async () => {
       args[0] = newCtx;
-      return handler.apply(handler, args);
+
+      try {
+        if (!handler) {
+          return await this.defaultInvokeHandler(...args);
+        } else {
+          return await handler.apply(handler, args);
+        }
+      } catch (err) {
+        if (isOutputError()) {
+          throw err;
+        } else {
+          throw new Error('Internal Server Error');
+        }
+      }
     });
   }
 

--- a/packages-serverless/serverless-fc-starter/test/index.test.ts
+++ b/packages-serverless/serverless-fc-starter/test/index.test.ts
@@ -232,7 +232,7 @@ describe('/test/index.test.ts', () => {
       }
 
       assert.ok(err);
-      assert.equal(err.message, 'ooops!');
+      assert.equal(err.message, 'Internal Server Error');
     });
 
     it('should ok with asyncWrap when not async functions', async () => {

--- a/packages-serverless/serverless-fc-starter/test/index.test.ts
+++ b/packages-serverless/serverless-fc-starter/test/index.test.ts
@@ -58,6 +58,11 @@ function send(request: events.EventEmitter, data: string) {
 }
 
 describe('/test/index.test.ts', () => {
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  });
+
   describe('wrapper normal event', () => {
     it('should wrap in init function', async () => {
       const handle = asyncWrapper(async context => {
@@ -76,6 +81,38 @@ describe('/test/index.test.ts', () => {
       });
       const res: any = await test(handle).run({ data: 1 }, {});
       assert.equal(res, 1);
+    });
+
+    it('should wrap with event and throw error', async () => {
+      const runtime = await start({});
+
+      let err;
+
+      try {
+        await runtime.asyncEvent(async (ctx, event) => {
+          throw new Error('abc');
+        })();
+      } catch (error) {
+        err = error;
+      }
+      expect(err.message).toEqual('Internal Server Error');
+    });
+
+    it('should wrap with event and throw real error with env', async () => {
+      process.env.SERVERLESS_OUTPUT_ERROR_STACK = 'true';
+      const runtime = await start({});
+
+      let err;
+
+      try {
+        await runtime.asyncEvent(async (ctx, event) => {
+          throw new Error('abc');
+        })();
+      } catch (error) {
+        err = error;
+      }
+      expect(err.message).toEqual('abc');
+      process.env.SERVERLESS_OUTPUT_ERROR_STACK = '';
     });
   });
 
@@ -500,7 +537,14 @@ describe('/test/index.test.ts', () => {
     });
   });
 
-  describe('test entry param', () => {
+  describe('test new property', () => {
+
+    it('should get app', async () => {
+      const runtime = await start();
+      const app = runtime.getApplication();
+      expect(app.use).toBeDefined();
+    });
+
     it('should get function name and service name from init context', async () => {
       const runtime = await start({
         initContext:{

--- a/packages-serverless/serverless-scf-starter/src/runtime.ts
+++ b/packages-serverless/serverless-scf-starter/src/runtime.ts
@@ -126,15 +126,25 @@ export class SCFRuntime extends ServerlessLightRuntime {
     // format context
     const newCtx = {
       logger: console,
+      originEvent: event,
       originContext: context,
     };
     const args = [newCtx, event];
     // 其他事件场景
     return this.invokeHandlerWrapper(context, async () => {
-      if (!handler) {
-        return this.defaultInvokeHandler(...args);
+      try {
+        if (!handler) {
+          return this.defaultInvokeHandler(...args);
+        } else {
+          return handler.apply(handler, args);
+        }
+      } catch (err) {
+        if (isOutputError()) {
+          throw err;
+        } else {
+          throw new Error('Internal Server Error');
+        }
       }
-      return handler.apply(handler, args);
     });
   }
 

--- a/packages-serverless/serverless-scf-starter/src/runtime.ts
+++ b/packages-serverless/serverless-scf-starter/src/runtime.ts
@@ -134,9 +134,9 @@ export class SCFRuntime extends ServerlessLightRuntime {
     return this.invokeHandlerWrapper(context, async () => {
       try {
         if (!handler) {
-          return this.defaultInvokeHandler(...args);
+          return await this.defaultInvokeHandler(...args);
         } else {
-          return handler.apply(handler, args);
+          return await handler.apply(handler, args);
         }
       } catch (err) {
         if (isOutputError()) {

--- a/packages-serverless/serverless-scf-starter/test/index.test.ts
+++ b/packages-serverless/serverless-scf-starter/test/index.test.ts
@@ -36,6 +36,11 @@ function test(handler) {
 }
 
 describe('/test/index.test.ts', () => {
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  });
+
   describe('wrapper normal event', () => {
     it('should wrap in init function', async () => {
       const handle = asyncWrapper(async context => {
@@ -54,6 +59,38 @@ describe('/test/index.test.ts', () => {
       });
       const res: any = await test(handle).run({ data: 1 }, {});
       assert.equal(res, 1);
+    });
+
+    it('should wrap with event and throw error', async () => {
+      const runtime = await start({});
+
+      let err;
+
+      try {
+        await runtime.asyncEvent(async (ctx, event) => {
+          throw new Error('abc');
+        })();
+      } catch (error) {
+        err = error;
+      }
+      expect(err.message).toEqual('Internal Server Error');
+    });
+
+    it('should wrap with event and throw real error with env', async () => {
+      process.env.SERVERLESS_OUTPUT_ERROR_STACK = 'true';
+      const runtime = await start({});
+
+      let err;
+
+      try {
+        await runtime.asyncEvent(async (ctx, event) => {
+          throw new Error('abc');
+        })();
+      } catch (error) {
+        err = error;
+      }
+      expect(err.message).toEqual('abc');
+      process.env.SERVERLESS_OUTPUT_ERROR_STACK = '';
     });
   });
 
@@ -435,6 +472,12 @@ describe('/test/index.test.ts', () => {
       expect(runtime.getFunctionName()).toEqual('aaa');
       expect(runtime.getFunctionServiceName()).toEqual('');
       mm.restore();
+    });
+
+    it('should get app', async () => {
+      const runtime = await start();
+      const app = runtime.getApplication();
+      expect(app.use).toBeDefined();
     });
   })
 });

--- a/packages/typegoose/test/index.test.ts
+++ b/packages/typegoose/test/index.test.ts
@@ -1,19 +1,20 @@
 import { createApp, close } from '@midwayjs/mock';
 import { Framework } from '@midwayjs/koa'
 import { join } from 'path';
-import { closeMongoServer, createMongoServer } from './util';
+// import { closeMongoServer, createMongoServer } from './util';
 
 describe('/test/index.test.ts', () => {
 
-  beforeAll(async () => {
-    await createMongoServer();
-  })
-
-  afterAll(async () => {
-    await closeMongoServer();
-  })
+  // beforeAll(async () => {
+  //   await createMongoServer();
+  // })
+  //
+  // afterAll(async () => {
+  //   await closeMongoServer();
+  // })
 
   it('should connect mongodb', async () => {
+    process.env.MONGO_URI = 'mongodb://localhost:27017';
     let app = await createApp(join(__dirname, 'fixtures', 'base-app'), {}, Framework);
     await close(app);
   });


### PR DESCRIPTION
- 1、在线上抛出带堆栈的错误时，隐藏用户的真实错误信息
- 2、在非 http 触发器场景增加 ctx.originEvent