### PR TITLE
fix: @Func decorator with empty metadata

### DIFF
--- a/packages/core/src/util/webRouterCollector.ts
+++ b/packages/core/src/util/webRouterCollector.ts
@@ -353,15 +353,12 @@ export class WebRouterCollector {
       } else {
         // 老的 @Func 写法
         if (webRouter['path'] || webRouter['middleware']) {
-          if (!webRouter['key']) {
-            continue;
-          }
           const data: RouterInfo = {
             prefix,
             routerName: '',
             url: webRouter['path'] ?? '',
             requestMethod: webRouter['method'] ?? 'get',
-            method: webRouter['key'],
+            method: webRouter['key'] ?? '',
             description: '',
             summary: '',
             handlerName: `${controllerId}.${webRouter['key']}`,
@@ -375,7 +372,7 @@ export class WebRouterCollector {
           };
           if (functionMeta) {
             // get function information
-            data.functionName = controllerId + '-' + webRouter['key'];
+            data.functionName = controllerId + '-' + (webRouter['key'] ?? '');
             data.functionTriggerName = ServerlessTriggerType.HTTP;
             data.functionTriggerMetadata = {
               path: webRouter['path'] ?? '/',

--- a/packages/core/src/util/webRouterCollector.ts
+++ b/packages/core/src/util/webRouterCollector.ts
@@ -359,7 +359,7 @@ export class WebRouterCollector {
           const data: RouterInfo = {
             prefix,
             routerName: '',
-            url: webRouter['path'] ?? '/',
+            url: webRouter['path'] ?? '',
             requestMethod: webRouter['method'] ?? 'get',
             method: webRouter['key'],
             description: '',

--- a/packages/core/src/util/webRouterCollector.ts
+++ b/packages/core/src/util/webRouterCollector.ts
@@ -353,6 +353,9 @@ export class WebRouterCollector {
       } else {
         // 老的 @Func 写法
         if (webRouter['path'] || webRouter['middleware']) {
+          if (!webRouter['key']) {
+            continue;
+          }
           const data: RouterInfo = {
             prefix,
             routerName: '',

--- a/packages/core/test/fixtures/base-app-func-router/src/function/index.ts
+++ b/packages/core/test/fixtures/base-app-func-router/src/function/index.ts
@@ -1,0 +1,38 @@
+import { Provide, Func } from '@midwayjs/decorator';
+
+@Provide()
+@Func('index.handler', { middleware: ['bottleServiceMiddleware'] })
+export class IndexHandler {
+  /**
+   * @param event
+   */
+  async handler(event) {
+    return {
+      data: 'hello world'
+    };
+  }
+}
+
+
+@Provide()
+export class IndexOneHandler {
+  /**
+   * @param event
+   */
+  @Func('indexone.handler')
+  async handlerone(event) {
+    return {
+      data: 'hello world one'
+    };
+  }
+
+  /**
+   * @param event
+   */
+   @Func('indextwo.handler')
+   async handlertwo(event) {
+     return {
+       data: 'hello world two'
+     };
+   }
+}

--- a/packages/core/test/fixtures/base-app-func-router/src/function/index.ts
+++ b/packages/core/test/fixtures/base-app-func-router/src/function/index.ts
@@ -19,7 +19,7 @@ export class IndexOneHandler {
   /**
    * @param event
    */
-  @Func('indexone.handler')
+  @Func('indexone.handler', { middleware: ['bottleServiceMiddleware'] })
   async handlerone(event) {
     return {
       data: 'hello world one'

--- a/packages/core/test/util/webRouterCollector.test.ts
+++ b/packages/core/test/util/webRouterCollector.test.ts
@@ -26,7 +26,7 @@ describe('/test/util/webRouterCollector.test.ts', function () {
     clearContainerCache();
     const collector = new WebRouterCollector(join(__dirname, '../fixtures/base-app-func-router'), { includeFunctionRouter: true});
     const result = await collector.getFlattenRouterTable();
-    expect(result.length).toEqual(6);
+    expect(result.length).toEqual(7);
     expect(matchObjectPropertyInArray(result, {
       'controllerId': 'helloHttpService',
       'funcHandlerName': 'helloHttpService.upload',
@@ -70,7 +70,7 @@ describe('/test/util/webRouterCollector.test.ts', function () {
 
     expect(matchObjectPropertyInArray(result, {
       "prefix": "/",
-      "url": "/",
+      "url": "",
       "requestMethod": "get",
       "method": "upload",
       "handlerName": "helloHttpService.upload",

--- a/packages/core/test/util/webRouterCollector.test.ts
+++ b/packages/core/test/util/webRouterCollector.test.ts
@@ -26,7 +26,7 @@ describe('/test/util/webRouterCollector.test.ts', function () {
     clearContainerCache();
     const collector = new WebRouterCollector(join(__dirname, '../fixtures/base-app-func-router'), { includeFunctionRouter: true});
     const result = await collector.getFlattenRouterTable();
-    expect(result.length).toEqual(7);
+    expect(result.length).toEqual(8);
     expect(matchObjectPropertyInArray(result, {
       'controllerId': 'helloHttpService',
       'funcHandlerName': 'helloHttpService.upload',

--- a/packages/faas/test/fixtures/base-app-new/src/index.ts
+++ b/packages/faas/test/fixtures/base-app-new/src/index.ts
@@ -7,7 +7,7 @@ import { FunctionHandler } from '../../../../src';
 })
 export class HelloService implements FunctionHandler {
   @Inject()
-  ctx; // context
+  ctx: any; // context
 
   async handler(event) {
     return event.text + this.ctx.text;


### PR DESCRIPTION
* 修复 @Fun 装饰器支持 bug

```
@Provide()
@Fun('index.handler')
class XXX {

}
```