### PR TITLE
chore: support use class in middleware

### DIFF
--- a/packages/faas/src/interface.ts
+++ b/packages/faas/src/interface.ts
@@ -17,7 +17,7 @@ export type IMidwayFaaSApplication = IMidwayApplication<FaaSContext, {
   getInitializeContext();
   use(middleware: FaaSMiddleware);
   useMiddleware(mw: string[]);
-  generateMiddleware(middlewareId: string): Promise<FaaSMiddleware>;
+  generateMiddleware(middlewareId: any): Promise<FaaSMiddleware>;
 
   /**
    * Get function name in serverless environment


### PR DESCRIPTION
支持函数下 `app.use(await this.app.generateMiddlware(xxxx))`  直接传入依赖注入类。