### PR TITLE
fix: ci、build and type error with rabbitmq

### DIFF
--- a/packages/rabbitmq/src/interface.ts
+++ b/packages/rabbitmq/src/interface.ts
@@ -1,12 +1,11 @@
 import { IConfigurationOptions, IMidwayApplication, IMidwayContext } from '@midwayjs/core';
 import { ConsumeMessage, Options } from 'amqplib/properties';
 import { RabbitMQListenerOptions } from '@midwayjs/decorator';
-import * as amqp from 'amqplib';
-import { Channel } from 'amqplib';
+import type { ConfirmChannel, Channel, Options as AmqpOptions } from 'amqplib';
 
 export interface IRabbitMQApplication {
   connect(...args): Promise<void>;
-  createChannel(): Promise<void>;
+  createChannel(): Promise<Channel | ConfirmChannel>;
   createConsumer(listenerOptions: RabbitMQListenerOptions, listenerCallback: (msg: ConsumeMessage | null, channel: Channel, channelWrapper) => Promise<void>): Promise<void>;
   close(): Promise<void>;
 }
@@ -28,11 +27,11 @@ export interface IMidwayRabbitMQConfigurationOptions extends IConfigurationOptio
 }
 
 export type IMidwayRabbitMQContext = IMidwayContext<{
-  channel: amqp.Channel;
+  channel: Channel;
   queueName: string;
   ack: (data: any) => void;
 }>;
 
 export type Application = IMidwayRabbitMQApplication;
 export interface Context extends IMidwayRabbitMQContext {}
-export type DefaultConfig = string | amqp.Options.Connect;
+export type DefaultConfig = string | AmqpOptions.Connect;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

## Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->

无

## 关于本次改动的说明
<!-- Provide a description of the change below this comment. -->

最近的 CI 无法通过 `npm run build`，究其原因，为其中 `rabbitmq` 中的一些问题。

最近的更新中使用了 [amqp-connection-manager](https://github.com/jwalton/node-amqp-connection-manager) 这个库，而该库对 `amqplib` 进行了进一步的封装 (`conection.connection`)，没有`connection.createConfirmChannel` 这个 API。

根据源码来看，当它调用了 `connection.createChannel` 时，默认建立的就是 `confirmChannel`。

``` js
const channel = await connection.createConfirmChannel();
```

而在我们需要建立 confirmChannel 时，可通过 `connection.connection.createConfirmChannel` 建立。

另外，修改了一些关于 type 的小问题