### PR TITLE
refactor: modify the comment typo about web socket event OnMessage to…

### DIFF
--- a/packages/decorator/src/ws/webSocketEvent.ts
+++ b/packages/decorator/src/ws/webSocketEvent.ts
@@ -111,7 +111,7 @@ export function WSBroadCast(
 }
 
 /**
- * @deprecated please use @OnWSDisConnection
+ * @deprecated please use @OnWSMessage
  */
 export const OnMessage = OnWSMessage;
 /**


### PR DESCRIPTION
…ct recommand event `OnWSMessage`

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
fix the typo comment about deprecated function OnMessage "@OnWSDisConnection ==> @OnWSMessage" to avoid lint message misleading developer.
