### PR TITLE
fix: midway-schedule can't find schedule by key

### DIFF
--- a/packages/midway-schedule/agent.ts
+++ b/packages/midway-schedule/agent.ts
@@ -73,6 +73,7 @@ export = agent => {
       }
 
       const instance = new Strategy(opts, agent, key);
+      agent.schedule[STRATEGY_INSTANCE].set(key, instance);
       instance.start();
     }
   });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->
midway-schedule

##### Description of change
<!-- Provide a description of the change below this comment. -->
将`midway`生成的`schedule`注册进`egg`的`schedule`中。确保`schedule`可以被找到，避免只能通过`agent.schedule.closed`的方式才能关停`schedule`，而导致所有`schedule`都关闭。