### PR TITLE
fix: circular inject for provide uuid

### DIFF
--- a/packages/core/src/context/managedResolverFactory.ts
+++ b/packages/core/src/context/managedResolverFactory.ts
@@ -708,6 +708,21 @@ export class ManagedResolverFactory {
           if (ref && ref.name) {
             iden = ref.name;
           }
+          let subDefinition = this.context.registry.getDefinition(iden);
+          if (!subDefinition && this.context.parent) {
+            subDefinition = this.context.parent.registry.getDefinition(iden);
+          }
+          // find uuid
+          if (!subDefinition && /:/.test(iden)) {
+            iden = iden.replace(/^.*?:/, '');
+            subDefinition = this.context.registry.getDefinition(iden);
+            if (!subDefinition && this.context.parent) {
+              subDefinition = this.context.parent.registry.getDefinition(iden);
+            }
+          }
+          if (subDefinition) {
+            iden = subDefinition.id;
+          }
           if (iden === identifier) {
             debug(
               'dfs exist in properties key %s == %s.',
@@ -728,10 +743,6 @@ export class ManagedResolverFactory {
           } else {
             depth.push(iden);
             debug('dfs depth push %s == %s, %j.', identifier, iden, depth);
-          }
-          let subDefinition = this.context.registry.getDefinition(iden);
-          if (!subDefinition && this.context.parent) {
-            subDefinition = this.context.parent.registry.getDefinition(iden);
           }
           if (this.depthFirstSearch(identifier, subDefinition, depth)) {
             debug(

--- a/packages/core/test/baseFramework.test.ts
+++ b/packages/core/test/baseFramework.test.ts
@@ -466,7 +466,7 @@ describe('/test/baseFramework.test.ts', () => {
     expect(await home.hello1()).toEqual('hello world 1');
     expect(await home.hello2()).toEqual('hello worldcccppp');
 
-    const ctx1 = {id: 1};
+    const ctx1 = { id: 1 };
     const requestContext = new MidwayRequestContainer(ctx1, framework.getApplicationContext());
     const userController1: any = await requestContext.getAsync('userController');
     try {
@@ -734,6 +734,21 @@ describe('/test/baseFramework.test.ts', () => {
     expect((global as any).container_not_null).toBeTruthy();
   });
 
+  it('component circular dependency should be ok', async () => {
+    const framework = new LightFramework();
+    await framework.initialize({
+      baseDir: path.join(
+        __dirname,
+        './fixtures/app-with-component-inject-with-class/main/src'
+      ),
+    });
+
+    const appCtx = framework.getApplicationContext();
+    const circularService = await appCtx.getAsync('circular:circularService');
+
+    expect(circularService).not.toBeNull();
+    await framework.stop();
+  });
 
   it('should test global framework', async () => {
     const framework = new LightFramework();

--- a/packages/core/test/fixtures/app-with-component-inject-with-class/circular/package.json
+++ b/packages/core/test/fixtures/app-with-component-inject-with-class/circular/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "circular-component",
+  "main": "src/index.ts"
+}

--- a/packages/core/test/fixtures/app-with-component-inject-with-class/circular/src/a.ts
+++ b/packages/core/test/fixtures/app-with-component-inject-with-class/circular/src/a.ts
@@ -1,0 +1,8 @@
+import { Inject, Provide } from '@midwayjs/decorator';
+import { B } from '.';
+
+@Provide()
+export class A {
+  @Inject()
+  b: B;
+}

--- a/packages/core/test/fixtures/app-with-component-inject-with-class/circular/src/b.ts
+++ b/packages/core/test/fixtures/app-with-component-inject-with-class/circular/src/b.ts
@@ -1,0 +1,8 @@
+import { Inject, Provide } from '@midwayjs/decorator';
+import { A } from './a';
+
+@Provide()
+export class B {
+  @Inject()
+  a: A;
+}

--- a/packages/core/test/fixtures/app-with-component-inject-with-class/circular/src/circularService.ts
+++ b/packages/core/test/fixtures/app-with-component-inject-with-class/circular/src/circularService.ts
@@ -1,0 +1,8 @@
+import { Inject, Provide } from "@midwayjs/decorator";
+import { A } from ".";
+
+@Provide()
+export class CircularService {
+  @Inject()
+  a: A;
+}

--- a/packages/core/test/fixtures/app-with-component-inject-with-class/circular/src/configuration.ts
+++ b/packages/core/test/fixtures/app-with-component-inject-with-class/circular/src/configuration.ts
@@ -1,0 +1,8 @@
+import { Configuration } from '@midwayjs/decorator';
+
+@Configuration({
+  namespace: 'circular'
+})
+export class CircularConfiguration {
+
+}

--- a/packages/core/test/fixtures/app-with-component-inject-with-class/circular/src/index.ts
+++ b/packages/core/test/fixtures/app-with-component-inject-with-class/circular/src/index.ts
@@ -1,0 +1,4 @@
+export { CircularConfiguration as Configuration } from './configuration';
+export { A } from './a';
+export { B } from './b';
+export { CircularService } from './circularService';

--- a/packages/core/test/fixtures/app-with-component-inject-with-class/main/src/configuration.ts
+++ b/packages/core/test/fixtures/app-with-component-inject-with-class/main/src/configuration.ts
@@ -1,12 +1,13 @@
 import { Configuration } from '@midwayjs/decorator';
 import { ILifeCycle } from "../../../../../src";
 import * as bookComponent from '../../book';
+import * as circularComponent from '../../circular';
 import * as path from 'path';
-
 @Configuration({
   imports: [
     bookComponent,
-    path.resolve(path.join(__dirname, '../../bookstr'))
+    path.resolve(path.join(__dirname, '../../bookstr')),
+    circularComponent
   ],
 })
 export class AutoConfiguration implements ILifeCycle {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

在组件中使用循环依赖会导致程序卡死，2.13.0版本增加了providerUUId之后出现的问题，之前版本正常