### PR TITLE
fix: disable performance marking for invoke handlers

### DIFF
--- a/packages-serverless/runtime-engine/src/engine.ts
+++ b/packages-serverless/runtime-engine/src/engine.ts
@@ -8,7 +8,7 @@ import {
 } from './interface';
 import { ServerlessBaseRuntime } from './runtime';
 import { completeAssign } from './util';
-import { performance } from 'perf_hooks';
+import performance from './lib/performance';
 
 export class BaseRuntimeEngine implements RuntimeEngine {
   runtimeExtensions = [];
@@ -98,5 +98,7 @@ export class BaseRuntimeEngine implements RuntimeEngine {
         `midway-faas:${it}:end`
       );
     });
+    // Disable midway performance marks.
+    performance.disable();
   }
 }

--- a/packages-serverless/runtime-engine/src/lib/performance.ts
+++ b/packages-serverless/runtime-engine/src/lib/performance.ts
@@ -1,0 +1,20 @@
+import { performance } from 'perf_hooks';
+
+let enabled = true;
+
+export function mark(name: string) {
+  if (!enabled) {
+    return;
+  }
+  performance.mark(name);
+}
+
+export function disable() {
+  enabled = false;
+}
+
+export default {
+  mark,
+  measure: performance.measure,
+  disable,
+};

--- a/packages-serverless/runtime-engine/src/runtime.ts
+++ b/packages-serverless/runtime-engine/src/runtime.ts
@@ -12,7 +12,7 @@ import {
 import { EnvPropertyParser } from './lib/parser';
 import { DebugLogger } from './lib/debug';
 import { getHandlerMeta } from './util';
-import { performance } from 'perf_hooks';
+import performance from './lib/performance';
 
 export class BaseLoggerFactory implements LoggerFactory {
   createLogger(...args) {


### PR DESCRIPTION

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->
- runtime-engine

##### Description of change
<!-- Provide a description of the change below this comment. -->

- disable marks on invoke handlers. we do only care about timings on start.
