### PR TITLE
fix redis onStop

### DIFF
--- a/packages/redis/src/configuration.ts
+++ b/packages/redis/src/configuration.ts
@@ -13,6 +13,8 @@ export class AutoConfiguration {
 
   async onStop(container): Promise<void> {
     const factory = await container.getAsync(RedisServiceFactory);
-    await factory.stop();
+    factory.clients.forEach(client=>{
+        client.disconnect();
+    });
   }
 }


### PR DESCRIPTION
error info 
```
ERROR 75501 nodejs.TypeError: factory.stop is not a function
    at AutoConfiguration.onStop (./node_modules/@midwayjs/redis/dist/configuration.js:19:23)
```

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
