### PR TITLE
fix(serverless-app): fix findNpmModule in pnp

### DIFF
--- a/packages-serverless/serverless-app/src/utils.ts
+++ b/packages-serverless/serverless-app/src/utils.ts
@@ -1,6 +1,19 @@
-import { join } from 'path';
+import { join, dirname } from 'path';
 import { existsSync } from 'fs';
+const findNpmModuleByResolve = (cwd, modName) => {
+  try {
+    return dirname(
+      require.resolve(`${modName}/package.json`, { paths: [cwd] })
+    );
+  } catch (e) {
+    return;
+  }
+};
+
 export const findNpmModule = (cwd, modName) => {
+  if ('pnp' in process.versions) {
+    return findNpmModuleByResolve(cwd, modName);
+  }
   const modPath = join(cwd, 'node_modules', modName);
   if (existsSync(modPath)) {
     return modPath;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->
serverless-app

##### Description of change
<!-- Provide a description of the change below this comment. -->
`findNpmModule` always returns `false` when using yarn pnp. This PR detects pnp environment and uses `require.resolve` in pnp.