### PR TITLE
doc: fix wrong identifier for the sequelize examples.

### DIFF
--- a/site/docs/extensions/sequelize.md
+++ b/site/docs/extensions/sequelize.md
@@ -185,7 +185,7 @@ export class HomeController {
 
   @Post('/delete')
   async home() {
-    await UserModel.destroy({
+    await Photo.destroy({
       where: {
         name: '123'
       }
@@ -207,7 +207,7 @@ export class HomeController {
 
   @Post('/delete')
   async home() {
-    let result = await UserModel.findOne({
+    let result = await Photo.findOne({
       where: {
         name: '123'
       }


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] documentation is changed or added

##### Affected core subsystem(s)
None.

##### Description of change
Fix the wrong identifiers `UserModel` for the Sequelize examples, should use `Photo` instead.
