### PR TITLE
chore(web): fix style of @deprecated comment

### DIFF
--- a/packages/web/src/interface.ts
+++ b/packages/web/src/interface.ts
@@ -94,13 +94,13 @@ export interface IMidwayWebConfigurationOptions extends IConfigurationOptions {
 
 /**
  * @deprecated since version 3.0.0
- * Please use IMiddleware from @midwayjs/core
+ * Please use IMiddleware from '@midwayjs/core'
  */
 export type MidwayWebMiddleware = Middleware<DefaultState, Context>;
 
 /**
  * @deprecated since version 3.0.0
- * Please use IMiddleware from @midwayjs/core
+ * Please use IMiddleware from '@midwayjs/core'
  */
 export interface IWebMiddleware {
   resolve(): MidwayWebMiddleware;


### PR DESCRIPTION
修复 `@deprecated` 注释后面 `@scope`  IDE 渲染容易让人混淆问题