### PR TITLE
docs(Context): fix ctx.getAttr() syntax error

### DIFF
--- a/site/docs/req_res_app.md
+++ b/site/docs/req_res_app.md
@@ -113,10 +113,10 @@ import * as ws from '@midwayjs/ws';
 export class ContainerConfiguration implements ILifeCycle {
   @App()
   koaApp: koa.Application;
-  
+
   @App(MidwayFrameworkType.WS)
   wsApp: ws.Application;
-  
+
   async onReady() {
     this.koaApp.useMiddleweare(...);
     this.wsApp.useMiddleweare(...);
@@ -331,9 +331,8 @@ this.ctx.setAttr('abc', {
 在另一个地方获取即可。
 
 ```typescript
-this.ctx.getAttr('abc', {
-  a: 1,
-  b: 2,
-});
+const value = this.ctx.getAttr('abc');
+// { a: 1, b: 2 }
+console.log(value);
 ```
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
在midway v3文档中`this.ctx.getAttr()`的示例接收了2个参数.但是代码里的类型定义中,该方法只接受一个参数.
`this.ctx.getAttr()`的类型定义: https://github.com/midwayjs/midway/blob/413ec44ea309077ce482fe55db3819aaab45894a/packages/core/src/interface.ts#L378
