### PR TITLE
fix: missing appDir value with egg-scripts cluster mode 

### DIFF
--- a/packages/web/src/cluster.ts
+++ b/packages/web/src/cluster.ts
@@ -18,7 +18,7 @@ const isAgent = runInAgent();
 debug(
   '[egg]: run with egg-scripts in worker and init midway container in cluster mode'
 );
-const appDir = process.cwd();
+const appDir = JSON.parse(process.argv[2])?.baseDir ?? process.cwd();
 let baseDir;
 
 if (isTypeScriptEnvironment()) {


### PR DESCRIPTION
egg-scripts start ./apps/api --daemon --title=api --framework=@midwayjs/web --port=7001
使用lerna多项目中，没有传递正确得到appDir路径，导致工程加载失败。

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x ] `npm test` passes
- [x ] tests and/or benchmarks are included
- [x ] documentation is changed or added
- [x ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
