### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/packages/core/src/util/index.ts
+++ b/packages/core/src/util/index.ts
@@ -89,7 +89,7 @@ export function safelyGet(
  */
 export function parsePrefix(provideId: string) {
   if (provideId.includes('@')) {
-    return provideId.substr(1);
+    return provideId.slice(1);
   }
   return provideId;
 }

--- a/packages/core/src/util/pathToRegexp.ts
+++ b/packages/core/src/util/pathToRegexp.ts
@@ -89,7 +89,7 @@ function parse(str, options) {
 
   // Match any characters still remaining.
   if (index < str.length) {
-    path += str.substr(index);
+    path += str.slice(index);
   }
 
   // If the path exists, push it onto the end.

--- a/packages/decorator/src/util/uuid.ts
+++ b/packages/decorator/src/util/uuid.ts
@@ -21,7 +21,7 @@ function rng() {
 const byteToHex = [];
 
 for (let i = 0; i < 256; ++i) {
-  byteToHex.push((i + 0x100).toString(16).substr(1));
+  byteToHex.push((i + 0x100).toString(16).slice(1));
 }
 
 function unsafeStringify(arr, offset = 0) {

--- a/packages/processAgent/src/configuration.ts
+++ b/packages/processAgent/src/configuration.ts
@@ -35,7 +35,7 @@ export class ProcessAgentConfiguration {
         }
         this.http_server = http
           .createServer((req, res) => {
-            const query = qs.parse(req.url.substr('/?'.length));
+            const query = qs.parse(req.url.slice('/?'.length));
             const params = JSON.parse(query.params as string);
             handlers[`${query.path}`](...params)
               .then(result => {

--- a/packages/prometheus/src/configuration.ts
+++ b/packages/prometheus/src/configuration.ts
@@ -48,7 +48,7 @@ export class PrometheusConfiguration {
         }
         this.http_server = http
           .createServer((req, res) => {
-            const query = qs.parse(req.url.substr('/?'.length));
+            const query = qs.parse(req.url.slice('/?'.length));
             const params = JSON.parse(query.params as string);
             handlers[`${query.path}`](...params).then(result => {
               res.end(result);

--- a/packages/swagger/src/swaggerExplorer.ts
+++ b/packages/swagger/src/swaggerExplorer.ts
@@ -767,7 +767,7 @@ function parseParamsInPath(url: string) {
   const names: string[] = [];
   url.split('/').forEach(item => {
     if (item.startsWith(':')) {
-      const paramName = item.substr(1);
+      const paramName = item.slice(1);
       names.push(paramName);
     }
   });


### PR DESCRIPTION
##### Checklist

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

- core
- processAgent
- prometheus
- swagger

##### Description of change

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.
