### PR TITLE
fix: logger create failed cause file size too large to create V8 string

### DIFF
--- a/packages/web/src/logger.ts
+++ b/packages/web/src/logger.ts
@@ -5,13 +5,7 @@ import {
   LoggerOptions,
 } from '@midwayjs/logger';
 import { join, isAbsolute, dirname, basename } from 'path';
-import {
-  existsSync,
-  lstatSync,
-  statSync,
-  renameSync,
-  unlinkSync,
-} from 'fs';
+import { existsSync, lstatSync, statSync, renameSync, unlinkSync } from 'fs';
 import { Application, EggLogger } from 'egg';
 import { getCurrentDateString } from './utils';
 import * as os from 'os';

--- a/packages/web/src/logger.ts
+++ b/packages/web/src/logger.ts
@@ -8,7 +8,7 @@ import { join, isAbsolute, dirname, basename } from 'path';
 import {
   existsSync,
   lstatSync,
-  readFileSync,
+  statSync,
   renameSync,
   unlinkSync,
 } from 'fs';
@@ -26,10 +26,7 @@ const debug = debuglog('midway:debug');
 const isWindows = os.platform() === 'win32';
 
 function isEmptyFile(p: string) {
-  const content = readFileSync(p, {
-    encoding: 'utf8',
-  });
-  return content === null || content === undefined || content === '';
+  return statSync(p).size === 0;
 }
 
 const levelTransform = level => {


### PR DESCRIPTION
While the readFileSync got a file size reach the size limit, which is 0x1fffffe8 (512MB), the V8 will throw a new Error: `Cannot create a string longer than 0x1fffffe8 characters`.

Thus, I recommend use `statSync` instead of `readFileSync` to check if the file is empty or not.

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->

This bad case (while log file is over 512MB) will block the midway core startup process.

##### Description of change
<!-- Provide a description of the change below this comment. -->
 
Using `statSync` instead of `readFileSync` to check if the file is empty or not. This may bring a litte speed up, and more robustness.
