### PR TITLE
refactor: add mock support

### DIFF
--- a/packages/core/src/baseFramework.ts
+++ b/packages/core/src/baseFramework.ts
@@ -27,6 +27,8 @@ import { MidwayLoggerService } from './service/loggerService';
 import { ContextMiddlewareManager } from './common/middlewareManager';
 import { MidwayMiddlewareService } from './service/middlewareService';
 import { FilterManager } from './common/filterManager';
+import { MidwayMockService } from './service/mockService';
+
 import * as util from 'util';
 const debug = util.debuglog('midway:debug');
 
@@ -63,6 +65,9 @@ export abstract class BaseFramework<
 
   @Inject()
   middlewareService: MidwayMiddlewareService<CTX, ResOrNext, Next>;
+
+  @Inject()
+  mockService: MidwayMockService;
 
   constructor(readonly applicationContext: IMidwayContainer) {}
 
@@ -333,6 +338,7 @@ export abstract class BaseFramework<
   ): Promise<MiddlewareRespond<CTX, R, N>> {
     if (!this.composeMiddleware) {
       this.middlewareManager.insertFirst((async (ctx: any, next: any) => {
+        this.mockService.applyContextMocks(this.app, ctx);
         let returnResult = undefined;
         try {
           const result = await next();

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -30,6 +30,7 @@ export { MidwayAspectService } from './service/aspectService';
 export { MidwayLifeCycleService } from './service/lifeCycleService';
 export { MidwayMiddlewareService } from './service/middlewareService';
 export { MidwayDecoratorService } from './service/decoratorService';
+export { MidwayMockService } from './service/mockService';
 export * from './service/pipelineService';
 export * from './util/contextUtil';
 export * from './common/serviceFactory';

--- a/packages/core/src/service/mockService.ts
+++ b/packages/core/src/service/mockService.ts
@@ -1,0 +1,127 @@
+import { Destroy, Provide, Scope, ScopeEnum } from '@midwayjs/decorator';
+import {
+  IMidwayApplication,
+  IMidwayContainer,
+  IMidwayContext,
+} from '../interface';
+
+@Provide()
+@Scope(ScopeEnum.Singleton)
+export class MidwayMockService {
+  protected mocks = [];
+  protected contextMocks: Array<{
+    app: IMidwayApplication;
+    key: string;
+    value: any;
+  }> = [];
+  protected cache = new Map();
+  constructor(readonly applicationContext: IMidwayContainer) {}
+
+  mockClassProperty(
+    clzz: new (...args) => any,
+    propertyName: string,
+    value: (...args) => any
+  ) {
+    return this.mockProperty(clzz.prototype, propertyName, value);
+  }
+
+  mockProperty(obj: any, key: string, value) {
+    // eslint-disable-next-line no-prototype-builtins
+    const hasOwnProperty = obj.hasOwnProperty(key);
+    this.mocks.push({
+      obj,
+      key,
+      descriptor: Object.getOwnPropertyDescriptor(obj, key),
+      // Make sure the key exists on object not the prototype
+      hasOwnProperty,
+    });
+
+    // Delete the origin key, redefine it below
+    if (hasOwnProperty) {
+      delete obj[key];
+    }
+
+    // Set a flag that checks if it is mocked
+    let flag = this.cache.get(obj);
+    if (!flag) {
+      flag = new Set();
+      this.cache.set(obj, flag);
+    }
+    flag.add(key);
+
+    const descriptor = this.overridePropertyDescriptor(value);
+    Object.defineProperty(obj, key, descriptor);
+  }
+
+  mockContext(
+    app: IMidwayApplication,
+    key: string,
+    value: PropertyDescriptor | any
+  ) {
+    this.contextMocks.push({
+      app,
+      key,
+      value,
+    });
+  }
+
+  @Destroy()
+  restore() {
+    for (let i = this.mocks.length - 1; i >= 0; i--) {
+      const m = this.mocks[i];
+      if (!m.hasOwnProperty) {
+        // Delete the mock key, use key on the prototype
+        delete m.obj[m.key];
+      } else {
+        // Redefine the origin key instead of the mock key
+        Object.defineProperty(m.obj, m.key, m.descriptor);
+      }
+    }
+    this.mocks = [];
+    this.contextMocks = [];
+    this.cache.clear();
+  }
+
+  isMocked(obj, key) {
+    const flag = this.cache.get(obj);
+    return flag ? flag.has(key) : false;
+  }
+
+  applyContextMocks(app: IMidwayApplication, ctx: IMidwayContext) {
+    if (this.contextMocks.length > 0) {
+      for (const mockItem of this.contextMocks) {
+        if (mockItem.app === app) {
+          const descriptor = this.overridePropertyDescriptor(mockItem.value);
+          Object.defineProperty(ctx, mockItem.key, descriptor);
+        }
+      }
+    }
+  }
+
+  getContextMocksSize() {
+    return this.contextMocks.length;
+  }
+
+  getMocksSize() {
+    return this.mocks.length;
+  }
+
+  private overridePropertyDescriptor(value) {
+    const descriptor = {
+      configurable: true,
+      enumerable: true,
+    } as PropertyDescriptor;
+
+    if (value && (value.get || value.set)) {
+      // Default to undefined
+      descriptor.get = value.get;
+      descriptor.set = value.set;
+    } else {
+      // Without getter/setter mode
+      descriptor.value = value;
+      descriptor.writable = true;
+    }
+
+    return descriptor;
+  }
+}

--- a/packages/core/src/service/mockService.ts
+++ b/packages/core/src/service/mockService.ts
@@ -11,7 +11,7 @@ export class MidwayMockService {
   protected mocks = [];
   protected contextMocks: Array<{
     app: IMidwayApplication;
-    key: string;
+    key: string | ((ctx: IMidwayContext) => void);
     value: any;
   }> = [];
   protected cache = new Map();
@@ -20,7 +20,7 @@ export class MidwayMockService {
   mockClassProperty(
     clzz: new (...args) => any,
     propertyName: string,
-    value: (...args) => any
+    value: any
   ) {
     return this.mockProperty(clzz.prototype, propertyName, value);
   }
@@ -55,8 +55,8 @@ export class MidwayMockService {
 
   mockContext(
     app: IMidwayApplication,
-    key: string,
-    value: PropertyDescriptor | any
+    key: string | ((ctx: IMidwayContext) => void),
+    value?: PropertyDescriptor | any
   ) {
     this.contextMocks.push({
       app,
@@ -92,7 +92,11 @@ export class MidwayMockService {
       for (const mockItem of this.contextMocks) {
         if (mockItem.app === app) {
           const descriptor = this.overridePropertyDescriptor(mockItem.value);
-          Object.defineProperty(ctx, mockItem.key, descriptor);
+          if (typeof mockItem.key === 'string') {
+            Object.defineProperty(ctx, mockItem.key, descriptor);
+          } else {
+            mockItem.key(ctx);
+          }
         }
       }
     }

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -13,6 +13,7 @@ import {
   MidwayMiddlewareService,
   MidwayDecoratorService,
   MidwayApplicationManager,
+  MidwayMockService,
   safeRequire,
 } from './';
 import defaultConfig from './config/config.default';
@@ -137,6 +138,7 @@ export function prepareGlobalApplicationContext(
   applicationContext.bindClass(MidwayFrameworkService);
   applicationContext.bindClass(MidwayMiddlewareService);
   applicationContext.bindClass(MidwayLifeCycleService);
+  applicationContext.bindClass(MidwayMockService);
 
   // bind preload module
   if (globalOptions.preloadModules && globalOptions.preloadModules.length) {

--- a/packages/core/test/fixtures/base-app-ctx-mock/package.json
+++ b/packages/core/test/fixtures/base-app-ctx-mock/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "ali-demo"
+}

--- a/packages/core/test/fixtures/base-app-ctx-mock/src/configuration.ts
+++ b/packages/core/test/fixtures/base-app-ctx-mock/src/configuration.ts
@@ -1,0 +1,37 @@
+import { Configuration, App, Logger, Provide } from '@midwayjs/decorator';
+import { IMidwayApplication } from '../../../../src';
+import { ILogger } from '@midwayjs/logger';
+
+@Provide()
+export class UserService {
+  async invoke() {
+    return 'hello world';
+  }
+}
+
+@Configuration({
+  importConfigs: {
+    midwayLogger: {
+      default: {
+        enableFile: false,
+        enableError: false,
+      },
+      clients: {
+        customLogger: {
+          enableConsole: true,
+        }
+      }
+    }
+  }
+})
+export class AutoConfiguration {
+
+  @App()
+  app: IMidwayApplication;
+
+  @Logger()
+  logger: ILogger;
+
+  async onReady() {
+  }
+}

--- a/packages/core/test/service/mockService.test.ts
+++ b/packages/core/test/service/mockService.test.ts
@@ -14,6 +14,9 @@ describe('/service/mockService.test.ts', () => {
     const app = framework.getApplication() as IMidwayApplication;
     const mockService = framework.getApplicationContext().get(MidwayMockService);
     mockService.mockContext(app, 'user', 'zhangting');
+    mockService.mockContext(app, (ctx) => {
+      ctx['bbbb'] = 'cccc';
+    });
 
     let data = 'abc';
     mockService.mockContext(app, 'abc', {
@@ -30,6 +33,7 @@ describe('/service/mockService.test.ts', () => {
     await fn(ctx);
 
     expect(ctx['user']).toEqual('zhangting');
+    expect(ctx['bbbb']).toEqual('cccc');
     expect(ctx['abc']).toEqual('abc');
     ctx['abc'] = 'abc';
     expect(ctx['abc']).toEqual('abcc');

--- a/packages/core/test/service/mockService.test.ts
+++ b/packages/core/test/service/mockService.test.ts
@@ -1,0 +1,65 @@
+import { createLightFramework } from '../util';
+import * as path from 'path';
+import { MidwayMockService, IMidwayApplication } from '../../src';
+import { UserService } from '../fixtures/base-app-ctx-mock/src/configuration';
+
+describe('/service/mockService.test.ts', () => {
+
+  it('should test mock context', async () => {
+    const framework = await createLightFramework(path.join(
+      __dirname,
+      './fixtures/base-app-ctx-mock/src'
+    ));
+
+    const app = framework.getApplication() as IMidwayApplication;
+    const mockService = framework.getApplicationContext().get(MidwayMockService);
+    mockService.mockContext(app, 'user', 'zhangting');
+
+    let data = 'abc';
+    mockService.mockContext(app, 'abc', {
+      get: ()  => {
+        return data;
+      },
+      set: (ddd) => {
+        data = ddd + 'c';
+      }
+    });
+
+    const ctx = app.createAnonymousContext();
+    const fn = await framework.applyMiddleware();
+    await fn(ctx);
+
+    expect(ctx['user']).toEqual('zhangting');
+    expect(ctx['abc']).toEqual('abc');
+    ctx['abc'] = 'abc';
+    expect(ctx['abc']).toEqual('abcc');
+
+    framework.getApplicationContext().bindClass(UserService);
+
+    mockService.mockClassProperty(UserService, 'invoke', () => {
+      return '1112';
+    });
+
+    const userService = await framework.getApplicationContext().getAsync(UserService);
+    expect(userService.invoke()).toEqual('1112');
+
+    mockService.restore();
+
+    expect(mockService.getContextMocksSize()).toEqual(0);
+    expect(mockService.getMocksSize()).toEqual(0);
+
+    expect(await userService.invoke()).toEqual('hello world');
+
+    mockService.mockProperty(userService, 'invoke',  async () => {
+      return 'abc'
+    });
+
+    expect(await userService.invoke()).toEqual('abc');
+
+    mockService.restore();
+
+    expect(await userService.invoke()).toEqual('hello world');
+
+    await framework.stop();
+  });
+});

--- a/packages/core/test/util.ts
+++ b/packages/core/test/util.ts
@@ -18,7 +18,7 @@ import * as getRawBody from 'raw-body';
  * 任意一个数组中的对象，和预期的对象属性一致即可
  * @param arr
  * @param matchObject
- * @param ignoreProperties
+ * @param debug
  */
 export function matchObjectPropertyInArray(arr, matchObject, debug = false): boolean {
   let matched = false;

--- a/packages/mock/src/index.ts
+++ b/packages/mock/src/index.ts
@@ -7,3 +7,4 @@ export {
 } from './creator';
 export * from './client/index';
 export { transformFrameworkToConfiguration } from './utils';
+export * from './mock';

--- a/packages/mock/src/mock.ts
+++ b/packages/mock/src/mock.ts
@@ -1,0 +1,75 @@
+import {
+  getCurrentMainApp,
+  IMidwayApplication,
+  IMidwayContext,
+  MidwayMockService,
+} from '@midwayjs/core';
+
+function getMockService(app?): MidwayMockService {
+  if (!app) {
+    app = getCurrentMainApp();
+  }
+  if (!app.getApplicationContext) {
+    throw new Error('[mock]: app.getApplicationContext is undefined.');
+  }
+
+  const applicationContext = app.getApplicationContext();
+  const mockService = applicationContext.get(MidwayMockService);
+  if (!mockService) {
+    throw new Error('[mock]: MidwayMockService is undefined.');
+  }
+  return mockService;
+}
+
+export function mockSession(
+  app: IMidwayApplication,
+  key: string,
+  value: string
+) {
+  const mockService = getMockService(app);
+  mockService.mockContext(app, (ctx: any) => {
+    if (!ctx.session) {
+      ctx.session = {};
+    }
+    ctx.session[key] = value;
+  });
+}
+
+export function mockHeader(
+  app: IMidwayApplication,
+  headerKey: string,
+  headerValue: string
+) {
+  const mockService = getMockService(app);
+  mockService.mockContext(app, (ctx: any) => {
+    ctx.headers[headerKey] = headerValue;
+  });
+}
+
+export function mockClassProperty(
+  clzz: new (...args) => any,
+  propertyName: string,
+  value: any
+) {
+  const mockService = getMockService();
+  return mockService.mockClassProperty(clzz, propertyName, value);
+}
+
+export function mockProperty(obj: any, key: string, value) {
+  const mockService = getMockService();
+  return mockService.mockProperty(obj, key, value);
+}
+
+export function restoreAllMocks() {
+  const mockService = getMockService();
+  mockService.restore();
+}
+
+export function mockContext(
+  app: IMidwayApplication,
+  key: string | ((ctx: IMidwayContext) => void),
+  value?: PropertyDescriptor | any
+) {
+  const mockService = getMockService(app);
+  mockService.mockContext(app, key, value);
+}

--- a/packages/mock/test/fixtures/base-app-koa/src/controller/hone.ts
+++ b/packages/mock/test/fixtures/base-app-koa/src/controller/hone.ts
@@ -1,11 +1,23 @@
-import { Controller, Get, Provide, Query } from '@midwayjs/decorator';
+import { Inject, Controller, Get, Provide, Query } from '@midwayjs/decorator';
 
 @Provide()
 @Controller('/')
 export class HomeController {
 
+  @Inject()
+  ctx;
+
   @Get()
   async index(@Query('name') name) {
     return `hello world, ${name}`;
+  }
+
+  @Get('/mock')
+  async mock() {
+    return {
+      abc: this.ctx.abc,
+      header: this.ctx.headers['x-bbb'],
+      session: this.ctx.session['ccc'],
+    }
   }
 }

--- a/packages/web-express/src/framework.ts
+++ b/packages/web-express/src/framework.ts
@@ -98,6 +98,14 @@ export class MidwayExpressFramework extends BaseFramework<
     // load controller，must apply router filter here
     const routerMiddlewares = await this.loadMidwayController();
 
+    if (this.mockService.getContextMocksSize() > 0) {
+      const mockMiddleware = (req, res, next) => {
+        this.mockService.applyContextMocks(this.app, req);
+        next();
+      };
+      this.app.use(mockMiddleware);
+      debug('[express]: use and apply mock framework');
+    }
     // use global middleware
     const globalMiddleware = await this.applyMiddleware();
     debug('[express]: use and apply all framework and global middleware');

--- a/packages/web/src/cluster.ts
+++ b/packages/web/src/cluster.ts
@@ -30,7 +30,7 @@ if (isTypeScriptEnvironment()) {
 prepareGlobalApplicationContext({
   appDir,
   baseDir,
-  ignore: ['**/app/extend/**'],
+  ignore: ['**/app/extend/**', '**/app/public/**'],
 });
 
 if (!isAgent) {


### PR DESCRIPTION
related: #531

- [x] mock service API
- [x] mock context
- [x] mock method
- [x] mock class property & method
- [ ] ~@Mock decorator support~
- [x] app.mockSession 等扩展方案