### PR TITLE
fix: use redis client before it's ready, most likely to occur during unit test

### DIFF
--- a/packages/redis/src/manager.ts
+++ b/packages/redis/src/manager.ts
@@ -74,12 +74,15 @@ export class RedisServiceFactory extends ServiceFactory<Redis> {
       client = new Redis(config);
     }
 
-    client.on('connect', () => {
-      this.logger.info('[midway:redis] client connect success');
-    });
-    client.on('error', err => {
-      this.logger.error('[midway:redis] client error: %s', err);
-      this.logger.error(err);
+    await new Promise<void>((resolve, reject) => {
+      client.on('connect', () => {
+        this.logger.info('[midway:redis] client connect success');
+        resolve();
+      });
+      client.on('error', err => {
+        this.logger.error('[midway:redis] client error: %s', err);
+        reject(err);
+      });
     });
 
     return client;

--- a/packages/redis/test/fixtures/base-app-bad-client/package.json
+++ b/packages/redis/test/fixtures/base-app-bad-client/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "base-app",
+  "version": "1.0.0",
+  "dependencies": {
+  }
+}

--- a/packages/redis/test/fixtures/base-app-bad-client/src/config.default.ts
+++ b/packages/redis/test/fixtures/base-app-bad-client/src/config.default.ts
@@ -1,6 +1,6 @@
 export const redis = {
   client: {
-    host: '127.0.0.2',
+    host: '128.0.0.2',
     port: 6379,
     password: '',
     db: '0',

--- a/packages/redis/test/fixtures/base-app-bad-client/src/config.default.ts
+++ b/packages/redis/test/fixtures/base-app-bad-client/src/config.default.ts
@@ -1,0 +1,10 @@
+export const redis = {
+  client: {
+    host: '127.0.0.2',
+    port: 6379,
+    password: '',
+    db: '0',
+    connectTimeout: 2e3,
+    retryStrategy: () => null
+  },
+};

--- a/packages/redis/test/fixtures/base-app-bad-client/src/configuration.ts
+++ b/packages/redis/test/fixtures/base-app-bad-client/src/configuration.ts
@@ -1,0 +1,14 @@
+import { Configuration } from '@midwayjs/decorator';
+import { join } from 'path';
+
+@Configuration({
+  imports: [
+    require('../../../../src')
+  ],
+  importConfigs: [
+    join(__dirname, './config.default'),
+  ]
+})
+export class AutoConfiguration {
+
+}

--- a/packages/redis/test/index.test.ts
+++ b/packages/redis/test/index.test.ts
@@ -58,4 +58,10 @@ describe('/test/index.test.ts', () => {
     await close(app);
   });
 
+  it('should fail when unable to connect redis', async () => {
+    await expect(createLightApp(join(__dirname, './fixtures/base-app-bad-client')))
+      .rejects
+      .toThrow('connect ETIMEDOUT');
+  });
+
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
