### PR TITLE
docs: update validate.md

### DIFF
--- a/site/docs/extensions/validate.md
+++ b/site/docs/extensions/validate.md
@@ -176,6 +176,7 @@ export class UserDTO {
 // src/controller/home.ts
 import { Controller, Get, Provide } from "@midwayjs/decorator";
 import { UserDTO } from './dto/user';
+import { Validate } from '@midwayjs/validate';
 
 @Controller('/api/user')
 export class HomeController {

--- a/site/docs/extensions/validate.md
+++ b/site/docs/extensions/validate.md
@@ -128,7 +128,7 @@ export class ContainerLifeCycle {
 
 ```typescript
 // src/dto/user.ts
-import { Rule, RuleType } from "@midwayjs/validate";
+import { Rule, RuleType } from '@midwayjs/validate';
 
 export class UserDTO {
   @Rule(RuleType.number().required())
@@ -174,9 +174,9 @@ export class UserDTO {
 
 ```typescript
 // src/controller/home.ts
-import { Controller, Get, Provide } from "@midwayjs/decorator";
-import { UserDTO } from './dto/user';
+import { Controller, Get, Provide } from '@midwayjs/decorator';
 import { Validate } from '@midwayjs/validate';
+import { UserDTO } from './dto/user';
 
 @Controller('/api/user')
 export class HomeController {
@@ -245,7 +245,7 @@ Midway 支持每个校验的 Class 中的属性依旧是一个对象。
 我们给 `UserDTO` 增加一个属性 `school` ，并且赋予一个 `SchoolDTO` 类型。
 
 ```typescript
-import { Rule, RuleType } from "@midwayjs/validate";
+import { Rule, RuleType } from '@midwayjs/validate';
 
 export class SchoolDTO {
   @Rule(RuleType.string().required())
@@ -288,7 +288,7 @@ Midway 支持校验继承方式，满足开发者抽离通用的对象属性的�
 例如我们下面  `CommonUserDTO` 抽离接口的通用的一些属性，然后 `UserDTO` 作为特殊接口需要的特定参数。
 
 ```typescript
-import { Rule, RuleType } from "@midwayjs/validate";
+import { Rule, RuleType } from '@midwayjs/validate';
 
 export class CommonUserDTO {
   @Rule(RuleType.string().required())
@@ -328,7 +328,7 @@ Midway 提供了 `PickDto` 和 `OmitDto` 两个方法根据现有的的 DTO 类�
 
 ```typescript
 // src/dto/user.ts
-import { Rule, RuleType, PickDto } from "@midwayjs/validate";
+import { Rule, RuleType, PickDto } from '@midwayjs/validate';
 
 export class UserDTO {
   @Rule(RuleType.number().required())


### PR DESCRIPTION
二号标题中 校验参数 的示例， @Validate 装饰器的使用，应该在头部引入 import { Validate } from '@midwayjs/validate'; 否则新手会不清楚 @Validate 装饰器从哪里来。

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
