### PR TITLE
fix(view-nunjucks): add autoescape config && add ts interface

### DIFF
--- a/packages/view-nunjucks/src/config/config.default.ts
+++ b/packages/view-nunjucks/src/config/config.default.ts
@@ -1,3 +1,5 @@
+import { INunjucksConfig } from '../interface';
+
 export default {
   nunjucks: {
     autoescape: true,
@@ -7,37 +9,5 @@ export default {
     cache: true,
   },
 } as {
-  nunjucks: {
-    /**
-     * controls if output with dangerous characters are escaped automatically.
-     */
-    autoescape: boolean;
-    /**
-     * throw errors when outputting a null/undefined value
-     */
-    throwOnUndefined: boolean;
-    /**
-     * automatically remove trailing newlines from a block/tag
-     */
-    trimBlocks: boolean;
-    /**
-     * automatically remove leading whitespace from a block/tag
-     */
-    lstripBlocks: boolean;
-    /**
-     * use a cache and recompile templates each time. false in local env.
-     */
-    cache: boolean;
-    /**
-     * defines the syntax for nunjucks tags.
-     */
-    tags?: {
-      blockStart?: string;
-      blockEnd?: string;
-      variableStart?: string;
-      variableEnd?: string;
-      commentStart?: string;
-      commentEnd?: string;
-    };
-  };
+  nunjucks: INunjucksConfig;
 };

--- a/packages/view-nunjucks/src/interface.ts
+++ b/packages/view-nunjucks/src/interface.ts
@@ -1,0 +1,34 @@
+
+export interface INunjucksConfig {
+  /**
+   * controls if output with dangerous characters are escaped automatically.
+   */
+  autoescape: boolean;
+  /**
+   * throw errors when outputting a null/undefined value
+   */
+  throwOnUndefined: boolean;
+  /**
+   * automatically remove trailing newlines from a block/tag
+   */
+  trimBlocks: boolean;
+  /**
+   * automatically remove leading whitespace from a block/tag
+   */
+  lstripBlocks: boolean;
+  /**
+   * use a cache and recompile templates each time. false in local env.
+   */
+  cache: boolean;
+  /**
+   * defines the syntax for nunjucks tags.
+   */
+  tags?: {
+    blockStart?: string;
+    blockEnd?: string;
+    variableStart?: string;
+    variableEnd?: string;
+    commentStart?: string;
+    commentEnd?: string;
+  };
+};


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
- [x] fix view-nunjuck engine doesn't pass through parameter 'autoescape' into nunjucks engine config
- [x] add typescript interface for the  view-nunjucks component default config 