### PR TITLE
feat(core): DataSourceManager accepts 2nd generic type SourceName (default string)

### DIFF
--- a/packages/core/src/common/dataSourceManager.ts
+++ b/packages/core/src/common/dataSourceManager.ts
@@ -65,7 +65,9 @@ export abstract class DataSourceManager<T, SourceName extends string = string> {
    * get a data source instance
    * @param dataSourceName
    */
-  public getDataSource(dataSourceName: SourceName) {
+  public getDataSource(
+    dataSourceName: SourceName
+  ): string extends SourceName ? T | undefined : T {
     return this.dataSource.get(dataSourceName);
   }
 

--- a/packages/core/src/common/dataSourceManager.ts
+++ b/packages/core/src/common/dataSourceManager.ts
@@ -9,11 +9,11 @@ import { Types } from '@midwayjs/decorator';
 
 const DEFAULT_PATTERN = ['**/**.ts', '**/**.js'];
 
-export interface DataSourceConfig<SourceName extends string = string> {
+export interface DataSourceConfig<SourceName extends PropertyKey = string> {
   dataSource: DataSource<SourceName>;
   [prop: string]: any;
 }
-export type DataSource<SourceName extends string = string> = Record<
+export type DataSource<SourceName extends PropertyKey = string> = Record<
   SourceName,
   DataSourceItem
 >;
@@ -21,7 +21,10 @@ export interface DataSourceItem {
   [prop: string]: any;
 }
 
-export abstract class DataSourceManager<T, SourceName extends string = string> {
+export abstract class DataSourceManager<
+  T,
+  SourceName extends PropertyKey = string
+> {
   protected dataSource: Map<SourceName, T> = new Map();
   protected options = {};
   protected modelMapping = new WeakMap();

--- a/packages/core/src/common/dataSourceManager.ts
+++ b/packages/core/src/common/dataSourceManager.ts
@@ -127,9 +127,12 @@ export abstract class DataSourceManager<
   protected abstract destroyDataSource(dataSource: T): Promise<void>;
 
   public async stop(): Promise<void> {
-    for (const value of this.dataSource.values()) {
-      await this.destroyDataSource(value);
-    }
+    const arr = Array.from(this.dataSource.values());
+    await Promise.all(
+      arr.map(dbh => {
+        return this.destroyDataSource(dbh);
+      })
+    );
     this.dataSource.clear();
   }
 }

--- a/packages/core/src/common/dataSourceManager.ts
+++ b/packages/core/src/common/dataSourceManager.ts
@@ -118,7 +118,7 @@ export abstract class DataSourceManager<
     return this.modelMapping.get(modelOrRepository);
   }
 
-  public abstract getName(): string;
+  public abstract getName(): SourceName;
   protected abstract createDataSource(
     config: DataSourceItem,
     dataSourceName: SourceName

--- a/packages/core/src/common/dataSourceManager.ts
+++ b/packages/core/src/common/dataSourceManager.ts
@@ -102,7 +102,7 @@ export abstract class DataSourceManager<T> {
     dataSourceName: string
   ): Promise<T | void> | (T | void);
   protected abstract checkConnected(dataSource: T): Promise<boolean>;
-  protected async destroyDataSource(dataSource: T): Promise<void> {}
+  protected abstract destroyDataSource(dataSource: T): Promise<void>;
 
   public async stop(): Promise<void> {
     for (const value of this.dataSource.values()) {

--- a/packages/core/src/common/dataSourceManager.ts
+++ b/packages/core/src/common/dataSourceManager.ts
@@ -71,9 +71,7 @@ export abstract class DataSourceManager<
    * get a data source instance
    * @param dataSourceName
    */
-  public getDataSource(
-    dataSourceName: SourceName
-  ): string extends SourceName ? T | undefined : T {
+  public getDataSource(dataSourceName: SourceName): T | undefined {
     return this.dataSource.get(dataSourceName);
   }
 

--- a/packages/core/src/common/dataSourceManager.ts
+++ b/packages/core/src/common/dataSourceManager.ts
@@ -10,13 +10,16 @@ import { Types } from '@midwayjs/decorator';
 const DEFAULT_PATTERN = ['**/**.ts', '**/**.js'];
 
 export interface DataSourceConfig<SourceName extends string = string> {
-  dataSource: DataSourceOptions<SourceName>;
+  dataSource: DataSource<SourceName>;
   [prop: string]: any;
 }
-export type DataSourceOptions<SourceName extends string = string> = Record<
+export type DataSource<SourceName extends string = string> = Record<
   SourceName,
-  any
+  DataSourceItem
 >;
+export interface DataSourceItem {
+  [prop: string]: any;
+}
 
 export abstract class DataSourceManager<T, SourceName extends string = string> {
   protected dataSource: Map<SourceName, T> = new Map();
@@ -30,7 +33,7 @@ export abstract class DataSourceManager<T, SourceName extends string = string> {
     this.options = options;
     if (options.dataSource) {
       for (const dataSourceName in options.dataSource) {
-        const dataSourceOptions: DataSourceOptions<SourceName> =
+        const dataSourceOptions: DataSourceItem =
           options.dataSource[dataSourceName];
         if (dataSourceOptions['entities']) {
           const entities = new Set();
@@ -92,7 +95,7 @@ export abstract class DataSourceManager<T, SourceName extends string = string> {
   }
 
   public async createInstance(
-    config: DataSourceOptions<SourceName>,
+    config: DataSourceItem,
     clientName: SourceName
   ): Promise<T | void> {
     // options.default will be merge in to options.clients[id]
@@ -116,7 +119,7 @@ export abstract class DataSourceManager<T, SourceName extends string = string> {
 
   public abstract getName(): string;
   protected abstract createDataSource(
-    config: DataSourceOptions<SourceName>,
+    config: DataSourceItem,
     dataSourceName: SourceName
   ): Promise<T | void> | (T | void);
   protected abstract checkConnected(dataSource: T): Promise<boolean>;

--- a/packages/core/test/common/dataSourceManager-SourceName.test.ts
+++ b/packages/core/test/common/dataSourceManager-SourceName.test.ts
@@ -2,7 +2,6 @@ import { relative } from 'path'
 
 import { DataSourceManager } from '../../src';
 import {
-  DataSource,
   DataSourceConfig,
   DataSourceItem,
   globModels,

--- a/packages/core/test/common/dataSourceManager-SourceName.test.ts
+++ b/packages/core/test/common/dataSourceManager-SourceName.test.ts
@@ -1,4 +1,4 @@
-import { relative } from 'node:path'
+import { relative } from 'path'
 
 import { DataSourceManager } from '../../src';
 import { DataSourceConfig, DataSourceItem, globModels } from '../../src/common/dataSourceManager';
@@ -72,9 +72,9 @@ describe(filename, () => {
     await instance.init(config)
     expect(instance.getDataSourceNames()).toEqual(['default', 'test']);
     expect(instance.hasDataSource('default')).toBeTruthy();
-    expect(instance.getDataSource('default')).toMatchSnapshot();
+    // expect(instance.getDataSource('default')).toMatchSnapshot();
     expect(instance.getDataSource('default').entitiesLength).toEqual(2);
-    expect(instance.getDataSource('test')).toMatchSnapshot();
+    // expect(instance.getDataSource('test')).toMatchSnapshot();
     expect(instance.getDataSource('test').entitiesLength).toEqual(1);
     // @ts-expect-error
     expect(instance.getDataSource('fff')).not.toBeDefined();
@@ -120,7 +120,7 @@ describe(filename, () => {
 
     await instance.init(config)
     expect(instance.getDataSourceNames()).toEqual(['test']);
-    expect(instance.getDataSource('test')).toMatchSnapshot();
+    // expect(instance.getDataSource('test')).toMatchSnapshot();
   });
 
   it('should test will got error when no data source', async () => {
@@ -177,9 +177,9 @@ describe(filename, () => {
     await instance.init(config)
     expect(instance.getDataSourceNames()).toEqual(['default', 'test']);
     expect(instance.hasDataSource('default')).toBeTruthy();
-    expect(instance.getDataSource('default')).toMatchSnapshot();
+    // expect(instance.getDataSource('default')).toMatchSnapshot();
     expect(instance.getDataSource('default').entitiesLength).toEqual(2);
-    expect(instance.getDataSource('test')).toMatchSnapshot();
+    // expect(instance.getDataSource('test')).toMatchSnapshot();
     expect(instance.getDataSource('test').entitiesLength).toEqual(1);
     // @ts-expect-error
     expect(instance.getDataSource('fff')).not.toBeDefined();

--- a/packages/core/test/common/dataSourceManager-SourceName.test.ts
+++ b/packages/core/test/common/dataSourceManager-SourceName.test.ts
@@ -1,7 +1,11 @@
-import { DataSourceManager } from '../../src';
-import { DataSource, DataSourceConfig, DataSourceItem, globModels } from '../../src/common/dataSourceManager';
+import { relative } from 'node:path'
 
-describe('test/common/dataSourceManager.test.ts', () => {
+import { DataSourceManager } from '../../src';
+import { DataSourceConfig, DataSourceItem, globModels } from '../../src/common/dataSourceManager';
+
+const filename = relative(process.cwd(), __filename).replace(/\\/ug, '/')
+
+describe(filename, () => {
 
   class CustomDataSourceFactory<SourceName extends string> extends DataSourceManager<any, SourceName> {
     getName() {

--- a/packages/core/test/common/dataSourceManager-SourceName.test.ts
+++ b/packages/core/test/common/dataSourceManager-SourceName.test.ts
@@ -1,0 +1,191 @@
+import { DataSourceManager } from '../../src';
+import { DataSource, DataSourceConfig, DataSourceItem, globModels } from '../../src/common/dataSourceManager';
+
+describe('test/common/dataSourceManager.test.ts', () => {
+
+  class CustomDataSourceFactory<SourceName extends string> extends DataSourceManager<any, SourceName> {
+    getName() {
+      return 'test';
+    }
+    async init(options: DataSourceConfig<SourceName>) {
+      return super.initDataSource(options, __dirname);
+    }
+
+    protected createDataSource(
+      config: DataSourceItem,
+      dataSourceName: SourceName
+      ): any {
+
+      config.entitiesLength = config.entities.length;
+      return config;
+    }
+
+    protected async checkConnected(dataSource: any) {
+      return false;
+    }
+
+    protected async destroyDataSource(dataSource: any): Promise<void> {
+      return;
+    }
+  }
+
+  it('should test base data source', async () => {
+    class EntityA {}
+
+    class EntityB {}
+
+    const config = {
+      dataSource: {
+        default: {
+          host: 'localhost',    //数据库地址,默认本机
+          port:'3306',
+          dialect: 'mysql',
+          pool: {   //连接池设置
+            max: 5, //最大连接数
+            min: 0, //最小连接数
+            idle: 10000
+          },
+          entities: [EntityA, EntityB]
+        },
+        test: {
+          host: 'localhost',    //数据库地址,默认本机
+          port:'3306',
+          dialect: 'mysql',
+          pool: {   //连接池设置
+            max: 5, //最大连接数
+            min: 0, //最小连接数
+            idle: 10000
+          },
+          dataSourceGroup: 'bb',
+          entities: [EntityA]
+        }
+      },
+    } as const
+
+    const instance = new CustomDataSourceFactory<keyof typeof config.dataSource>();
+    expect(instance.getName()).toEqual('test');
+
+    await instance.init(config)
+    expect(instance.getDataSourceNames()).toEqual(['default', 'test']);
+    expect(instance.hasDataSource('default')).toBeTruthy();
+    expect(instance.getDataSource('default')).toMatchSnapshot();
+    expect(instance.getDataSource('default').entitiesLength).toEqual(2);
+    expect(instance.getDataSource('test')).toMatchSnapshot();
+    expect(instance.getDataSource('test').entitiesLength).toEqual(1);
+    // @ts-expect-error
+    expect(instance.getDataSource('fff')).not.toBeDefined();
+
+    expect(await instance.isConnected('default')).toBeFalsy();
+
+    expect(instance.getDataSourceNameByModel(EntityB)).toEqual('default');
+    expect(instance.getDataSourceNameByModel(EntityA)).toEqual('test');
+
+    await instance.stop();
+    expect(instance.getDataSourceNames()).toEqual([]);
+  });
+
+  it('should test glob model', function () {
+    let result = globModels('dd', __dirname);
+    expect(result).toEqual([]);
+
+    result = globModels('abc', __dirname);
+    expect(result.length).toEqual(4);
+  });
+
+  it('should test with glob model', async () => {
+    class EntityA {}
+
+    const config = {
+      dataSource: {
+        test: {
+          host: 'localhost',    //数据库地址,默认本机
+          port:'3306',
+          dialect: 'mysql',
+          pool: {   //连接池设置
+            max: 5, //最大连接数
+            min: 0, //最小连接数
+            idle: 10000
+          },
+          entities: [EntityA, EntityA, '/abc']
+        },
+      },
+    }
+
+    const instance = new CustomDataSourceFactory<keyof typeof config.dataSource>();
+    expect(instance.getName()).toEqual('test');
+
+    await instance.init(config)
+    expect(instance.getDataSourceNames()).toEqual(['test']);
+    expect(instance.getDataSource('test')).toMatchSnapshot();
+  });
+
+  it('should test will got error when no data source', async () => {
+    const instance = new CustomDataSourceFactory();
+    let e;
+    try {
+      // @ts-expect-error
+      await instance.init({});
+    } catch (err) {
+      e = err;
+    }
+
+    expect(e).toBeDefined();
+  });
+
+  it('should test base data source with types', async () => {
+    class EntityA {}
+
+    class EntityB {}
+
+    type Config = DataSourceConfig<'default' | 'test'>
+
+    const config: Config = {
+      dataSource: {
+        default: {
+          host: 'localhost',    //数据库地址,默认本机
+          port:'3306',
+          dialect: 'mysql',
+          pool: {   //连接池设置
+            max: 5, //最大连接数
+            min: 0, //最小连接数
+            idle: 10000
+          },
+          entities: [EntityA, EntityB]
+        },
+        test: {
+          host: 'localhost',    //数据库地址,默认本机
+          port:'3306',
+          dialect: 'mysql',
+          pool: {   //连接池设置
+            max: 5, //最大连接数
+            min: 0, //最小连接数
+            idle: 10000
+          },
+          dataSourceGroup: 'bb',
+          entities: [EntityA]
+        }
+      },
+    }
+
+    const instance = new CustomDataSourceFactory<keyof Config['dataSource']>();
+    expect(instance.getName()).toEqual('test');
+
+    await instance.init(config)
+    expect(instance.getDataSourceNames()).toEqual(['default', 'test']);
+    expect(instance.hasDataSource('default')).toBeTruthy();
+    expect(instance.getDataSource('default')).toMatchSnapshot();
+    expect(instance.getDataSource('default').entitiesLength).toEqual(2);
+    expect(instance.getDataSource('test')).toMatchSnapshot();
+    expect(instance.getDataSource('test').entitiesLength).toEqual(1);
+    // @ts-expect-error
+    expect(instance.getDataSource('fff')).not.toBeDefined();
+
+    expect(await instance.isConnected('default')).toBeFalsy();
+
+    expect(instance.getDataSourceNameByModel(EntityB)).toEqual('default');
+    expect(instance.getDataSourceNameByModel(EntityA)).toEqual('test');
+
+    await instance.stop();
+    expect(instance.getDataSourceNames()).toEqual([]);
+  });
+});

--- a/packages/core/test/common/dataSourceManager-SourceName.test.ts
+++ b/packages/core/test/common/dataSourceManager-SourceName.test.ts
@@ -48,7 +48,7 @@ describe(filename, () => {
 
   class CustomDataSourceFactory<SourceName extends PropertyKey> extends DataSourceManager<any, SourceName> {
     getName() {
-      return 'test';
+      return 'test' as SourceName;
     }
     async init(options: DataSourceConfig<SourceName>) {
       return super.initDataSource(options, __dirname);

--- a/packages/core/test/common/dataSourceManager-T-SourceName.test.ts
+++ b/packages/core/test/common/dataSourceManager-T-SourceName.test.ts
@@ -87,11 +87,11 @@ describe(filename, () => {
     expect(instance.getDataSourceNames()).toEqual(['default', 'test']);
     expect(instance.hasDataSource('default')).toBeTruthy();
     // expect(instance.getDataSource('default')).toMatchSnapshot();
-    expect(instance.getDataSource('default').entitiesLength).toEqual(2);
-    expect(instance.getDataSource('default').host).toEqual(host);
+    expect(instance.getDataSource('default')?.entitiesLength).toEqual(2);
+    expect(instance.getDataSource('default')?.host).toEqual(host);
     // expect(instance.getDataSource('test')).toMatchSnapshot();
-    expect(instance.getDataSource('test').entitiesLength).toEqual(1);
-    expect(instance.getDataSource('test').host).toEqual(host);
+    expect(instance.getDataSource('test')?.entitiesLength).toEqual(1);
+    expect(instance.getDataSource('test')?.host).toEqual(host);
     // @ts-expect-error
     expect(instance.getDataSource('fff')).not.toBeDefined();
 
@@ -161,9 +161,9 @@ describe(filename, () => {
     expect(instance.getDataSourceNames()).toEqual(['default', 'test']);
     expect(instance.hasDataSource('default')).toBeTruthy();
     // expect(instance.getDataSource('default')).toMatchSnapshot();
-    expect(instance.getDataSource('default').entitiesLength).toEqual(2);
+    expect(instance.getDataSource('default')?.entitiesLength).toEqual(2);
     // expect(instance.getDataSource('test')).toMatchSnapshot();
-    expect(instance.getDataSource('test').entitiesLength).toEqual(1);
+    expect(instance.getDataSource('test')?.entitiesLength).toEqual(1);
     // @ts-expect-error
     expect(instance.getDataSource('fff')).not.toBeDefined();
 

--- a/packages/core/test/common/dataSourceManager-T-SourceName.test.ts
+++ b/packages/core/test/common/dataSourceManager-T-SourceName.test.ts
@@ -201,4 +201,60 @@ describe(filename, () => {
     await instance.stop();
     expect(instance.getDataSourceNames()).toEqual([]);
   });
+
+  it('should test base data source without types', async () => {
+    class EntityA {}
+
+    class EntityB {}
+
+    type Config = DataSourceConfig
+
+    const config: Config = {
+      dataSource: {
+        default: {
+          host: 'localhost',    //数据库地址,默认本机
+          port:'3306',
+          dialect: 'mysql',
+          pool: {   //连接池设置
+            max: 5, //最大连接数
+            min: 0, //最小连接数
+            idle: 10000
+          },
+          entities: [EntityA, EntityB]
+        },
+        test: {
+          host: 'localhost',    //数据库地址,默认本机
+          port:'3306',
+          dialect: 'mysql',
+          pool: {   //连接池设置
+            max: 5, //最大连接数
+            min: 0, //最小连接数
+            idle: 10000
+          },
+          dataSourceGroup: 'bb',
+          entities: [EntityA]
+        }
+      },
+    }
+
+    const instance = new CustomDataSourceFactory();
+    expect(instance.getName()).toEqual('test');
+
+    await instance.init(config)
+    expect(instance.getDataSourceNames()).toEqual(['default', 'test']);
+    expect(instance.hasDataSource('default')).toBeTruthy();
+    // expect(instance.getDataSource('default')).toMatchSnapshot();
+    expect(instance.getDataSource('default')?.entitiesLength).toEqual(2);
+    // expect(instance.getDataSource('test')).toMatchSnapshot();
+    expect(instance.getDataSource('test')?.entitiesLength).toEqual(1);
+    expect(instance.getDataSource('fff')).not.toBeDefined();
+
+    expect(await instance.isConnected('default')).toBeFalsy();
+
+    expect(instance.getDataSourceNameByModel(EntityB)).toEqual('default');
+    expect(instance.getDataSourceNameByModel(EntityA)).toEqual('test');
+
+    await instance.stop();
+    expect(instance.getDataSourceNames()).toEqual([]);
+  });
 });

--- a/packages/core/test/common/dataSourceManager-T-SourceName.test.ts
+++ b/packages/core/test/common/dataSourceManager-T-SourceName.test.ts
@@ -2,7 +2,6 @@ import { relative } from 'path'
 
 import { DataSourceManager } from '../../src';
 import {
-  DataSource,
   DataSourceConfig,
   DataSourceItem,
   globModels,

--- a/packages/core/test/common/dataSourceManager-T-SourceName.test.ts
+++ b/packages/core/test/common/dataSourceManager-T-SourceName.test.ts
@@ -1,0 +1,200 @@
+import { DataSourceManager } from '../../src';
+import { DataSource, DataSourceConfig, DataSourceItem, globModels } from '../../src/common/dataSourceManager';
+
+describe('test/common/dataSourceManager.test.ts', () => {
+
+  const host = `schema://${Math.random().toString()}`;
+  interface Dbh {
+    host: string;
+    entitiesLength: number;
+  }
+
+  class CustomDataSourceFactory<SourceName extends string> extends DataSourceManager<Dbh, SourceName> {
+    getName() {
+      return 'test';
+    }
+    async init(options: DataSourceConfig<SourceName>) {
+      return super.initDataSource(options, __dirname);
+    }
+
+    protected createDataSource(
+      config: DataSourceItem,
+      dataSourceName: SourceName
+      ): any {
+
+      config.entitiesLength = config.entities.length;
+      config.host = host
+      return config;
+    }
+
+    protected async checkConnected(dataSource: any) {
+      return false;
+    }
+
+    protected async destroyDataSource(dataSource: any): Promise<void> {
+      return;
+    }
+  }
+
+  it('should test base data source', async () => {
+    class EntityA {}
+
+    class EntityB {}
+
+    const config = {
+      dataSource: {
+        default: {
+          host: 'localhost',    //数据库地址,默认本机
+          port:'3306',
+          dialect: 'mysql',
+          pool: {   //连接池设置
+            max: 5, //最大连接数
+            min: 0, //最小连接数
+            idle: 10000
+          },
+          entities: [EntityA, EntityB]
+        },
+        test: {
+          host: 'localhost',    //数据库地址,默认本机
+          port:'3306',
+          dialect: 'mysql',
+          pool: {   //连接池设置
+            max: 5, //最大连接数
+            min: 0, //最小连接数
+            idle: 10000
+          },
+          dataSourceGroup: 'bb',
+          entities: [EntityA]
+        }
+      },
+    } as const
+
+    const instance = new CustomDataSourceFactory<keyof typeof config.dataSource>();
+    expect(instance.getName()).toEqual('test');
+
+    await instance.init(config)
+    expect(instance.getDataSourceNames()).toEqual(['default', 'test']);
+    expect(instance.hasDataSource('default')).toBeTruthy();
+    expect(instance.getDataSource('default')).toMatchSnapshot();
+    expect(instance.getDataSource('default').entitiesLength).toEqual(2);
+    expect(instance.getDataSource('default').host).toEqual(host);
+    expect(instance.getDataSource('test')).toMatchSnapshot();
+    expect(instance.getDataSource('test').entitiesLength).toEqual(1);
+    expect(instance.getDataSource('test').host).toEqual(host);
+    // @ts-expect-error
+    expect(instance.getDataSource('fff')).not.toBeDefined();
+
+    expect(await instance.isConnected('default')).toBeFalsy();
+
+    expect(instance.getDataSourceNameByModel(EntityB)).toEqual('default');
+    expect(instance.getDataSourceNameByModel(EntityA)).toEqual('test');
+
+    await instance.stop();
+    expect(instance.getDataSourceNames()).toEqual([]);
+  });
+
+  it('should test glob model', function () {
+    let result = globModels('dd', __dirname);
+    expect(result).toEqual([]);
+
+    result = globModels('abc', __dirname);
+    expect(result.length).toEqual(4);
+  });
+
+  it('should test with glob model', async () => {
+    class EntityA {}
+
+    const config = {
+      dataSource: {
+        test: {
+          host: 'localhost',    //数据库地址,默认本机
+          port:'3306',
+          dialect: 'mysql',
+          pool: {   //连接池设置
+            max: 5, //最大连接数
+            min: 0, //最小连接数
+            idle: 10000
+          },
+          entities: [EntityA, EntityA, '/abc']
+        },
+      },
+    }
+
+    const instance = new CustomDataSourceFactory<keyof typeof config.dataSource>();
+    expect(instance.getName()).toEqual('test');
+
+    await instance.init(config)
+    expect(instance.getDataSourceNames()).toEqual(['test']);
+    expect(instance.getDataSource('test')).toMatchSnapshot();
+  });
+
+  it('should test will got error when no data source', async () => {
+    const instance = new CustomDataSourceFactory();
+    let e;
+    try {
+      // @ts-expect-error
+      await instance.init({});
+    } catch (err) {
+      e = err;
+    }
+
+    expect(e).toBeDefined();
+  });
+
+  it('should test base data source with types', async () => {
+    class EntityA {}
+
+    class EntityB {}
+
+    type Config = DataSourceConfig<'default' | 'test'>
+
+    const config: Config = {
+      dataSource: {
+        default: {
+          host: 'localhost',    //数据库地址,默认本机
+          port:'3306',
+          dialect: 'mysql',
+          pool: {   //连接池设置
+            max: 5, //最大连接数
+            min: 0, //最小连接数
+            idle: 10000
+          },
+          entities: [EntityA, EntityB]
+        },
+        test: {
+          host: 'localhost',    //数据库地址,默认本机
+          port:'3306',
+          dialect: 'mysql',
+          pool: {   //连接池设置
+            max: 5, //最大连接数
+            min: 0, //最小连接数
+            idle: 10000
+          },
+          dataSourceGroup: 'bb',
+          entities: [EntityA]
+        }
+      },
+    }
+
+    const instance = new CustomDataSourceFactory<keyof Config['dataSource']>();
+    expect(instance.getName()).toEqual('test');
+
+    await instance.init(config)
+    expect(instance.getDataSourceNames()).toEqual(['default', 'test']);
+    expect(instance.hasDataSource('default')).toBeTruthy();
+    expect(instance.getDataSource('default')).toMatchSnapshot();
+    expect(instance.getDataSource('default').entitiesLength).toEqual(2);
+    expect(instance.getDataSource('test')).toMatchSnapshot();
+    expect(instance.getDataSource('test').entitiesLength).toEqual(1);
+    // @ts-expect-error
+    expect(instance.getDataSource('fff')).not.toBeDefined();
+
+    expect(await instance.isConnected('default')).toBeFalsy();
+
+    expect(instance.getDataSourceNameByModel(EntityB)).toEqual('default');
+    expect(instance.getDataSourceNameByModel(EntityA)).toEqual('test');
+
+    await instance.stop();
+    expect(instance.getDataSourceNames()).toEqual([]);
+  });
+});

--- a/packages/core/test/common/dataSourceManager-T-SourceName.test.ts
+++ b/packages/core/test/common/dataSourceManager-T-SourceName.test.ts
@@ -1,7 +1,12 @@
 import { relative } from 'path'
 
 import { DataSourceManager } from '../../src';
-import { DataSourceConfig, DataSourceItem, globModels } from '../../src/common/dataSourceManager';
+import {
+  DataSource,
+  DataSourceConfig,
+  DataSourceItem,
+  globModels,
+} from '../../src/common/dataSourceManager';
 
 const filename = relative(process.cwd(), __filename).replace(/\\/ug, '/')
 
@@ -13,7 +18,42 @@ describe(filename, () => {
     entitiesLength: number;
   }
 
-  class CustomDataSourceFactory<SourceName extends string> extends DataSourceManager<Dbh, SourceName> {
+  class EntityA {}
+
+  class EntityB {}
+
+  type DataSourceName = 'default' | 'test'
+  type Config = DataSourceConfig<DataSourceName>
+
+  const config: Config = {
+    dataSource: {
+      default: {
+        host: 'localhost',    //数据库地址,默认本机
+        port:'3306',
+        dialect: 'mysql',
+        pool: {   //连接池设置
+          max: 5, //最大连接数
+          min: 0, //最小连接数
+          idle: 10000
+        },
+        entities: [EntityA, EntityB]
+      },
+      test: {
+        host: 'localhost',    //数据库地址,默认本机
+        port:'3306',
+        dialect: 'mysql',
+        pool: {   //连接池设置
+          max: 5, //最大连接数
+          min: 0, //最小连接数
+          idle: 10000
+        },
+        dataSourceGroup: 'bb',
+        entities: [EntityA]
+      }
+    },
+  }
+
+  class CustomDataSourceFactory<SourceName extends PropertyKey> extends DataSourceManager<Dbh, SourceName> {
     getName() {
       return 'test';
     }
@@ -41,39 +81,7 @@ describe(filename, () => {
   }
 
   it('should test base data source', async () => {
-    class EntityA {}
-
-    class EntityB {}
-
-    const config = {
-      dataSource: {
-        default: {
-          host: 'localhost',    //数据库地址,默认本机
-          port:'3306',
-          dialect: 'mysql',
-          pool: {   //连接池设置
-            max: 5, //最大连接数
-            min: 0, //最小连接数
-            idle: 10000
-          },
-          entities: [EntityA, EntityB]
-        },
-        test: {
-          host: 'localhost',    //数据库地址,默认本机
-          port:'3306',
-          dialect: 'mysql',
-          pool: {   //连接池设置
-            max: 5, //最大连接数
-            min: 0, //最小连接数
-            idle: 10000
-          },
-          dataSourceGroup: 'bb',
-          entities: [EntityA]
-        }
-      },
-    } as const
-
-    const instance = new CustomDataSourceFactory<keyof typeof config.dataSource>();
+    const instance = new CustomDataSourceFactory<DataSourceName>();
     expect(instance.getName()).toEqual('test');
 
     await instance.init(config)
@@ -124,7 +132,7 @@ describe(filename, () => {
       },
     }
 
-    const instance = new CustomDataSourceFactory<keyof typeof config.dataSource>();
+    const instance = new CustomDataSourceFactory<'test'>();
     expect(instance.getName()).toEqual('test');
 
     await instance.init(config)
@@ -146,41 +154,8 @@ describe(filename, () => {
   });
 
   it('should test base data source with types', async () => {
-    class EntityA {}
 
-    class EntityB {}
-
-    type Config = DataSourceConfig<'default' | 'test'>
-
-    const config: Config = {
-      dataSource: {
-        default: {
-          host: 'localhost',    //数据库地址,默认本机
-          port:'3306',
-          dialect: 'mysql',
-          pool: {   //连接池设置
-            max: 5, //最大连接数
-            min: 0, //最小连接数
-            idle: 10000
-          },
-          entities: [EntityA, EntityB]
-        },
-        test: {
-          host: 'localhost',    //数据库地址,默认本机
-          port:'3306',
-          dialect: 'mysql',
-          pool: {   //连接池设置
-            max: 5, //最大连接数
-            min: 0, //最小连接数
-            idle: 10000
-          },
-          dataSourceGroup: 'bb',
-          entities: [EntityA]
-        }
-      },
-    }
-
-    const instance = new CustomDataSourceFactory<keyof Config['dataSource']>();
+    const instance = new CustomDataSourceFactory<DataSourceName>();
     expect(instance.getName()).toEqual('test');
 
     await instance.init(config)
@@ -203,40 +178,6 @@ describe(filename, () => {
   });
 
   it('should test base data source without types', async () => {
-    class EntityA {}
-
-    class EntityB {}
-
-    type Config = DataSourceConfig
-
-    const config: Config = {
-      dataSource: {
-        default: {
-          host: 'localhost',    //数据库地址,默认本机
-          port:'3306',
-          dialect: 'mysql',
-          pool: {   //连接池设置
-            max: 5, //最大连接数
-            min: 0, //最小连接数
-            idle: 10000
-          },
-          entities: [EntityA, EntityB]
-        },
-        test: {
-          host: 'localhost',    //数据库地址,默认本机
-          port:'3306',
-          dialect: 'mysql',
-          pool: {   //连接池设置
-            max: 5, //最大连接数
-            min: 0, //最小连接数
-            idle: 10000
-          },
-          dataSourceGroup: 'bb',
-          entities: [EntityA]
-        }
-      },
-    }
-
     const instance = new CustomDataSourceFactory();
     expect(instance.getName()).toEqual('test');
 

--- a/packages/core/test/common/dataSourceManager-T-SourceName.test.ts
+++ b/packages/core/test/common/dataSourceManager-T-SourceName.test.ts
@@ -1,9 +1,13 @@
+import { relative } from 'node:path'
+
 import { DataSourceManager } from '../../src';
-import { DataSource, DataSourceConfig, DataSourceItem, globModels } from '../../src/common/dataSourceManager';
+import { DataSourceConfig, DataSourceItem, globModels } from '../../src/common/dataSourceManager';
 
-describe('test/common/dataSourceManager.test.ts', () => {
+const filename = relative(process.cwd(), __filename).replace(/\\/ug, '/')
 
-  const host = `schema://${Math.random().toString()}`;
+describe(filename, () => {
+
+  const host = 'foo';
   interface Dbh {
     host: string;
     entitiesLength: number;

--- a/packages/core/test/common/dataSourceManager-T-SourceName.test.ts
+++ b/packages/core/test/common/dataSourceManager-T-SourceName.test.ts
@@ -1,4 +1,4 @@
-import { relative } from 'node:path'
+import { relative } from 'path'
 
 import { DataSourceManager } from '../../src';
 import { DataSourceConfig, DataSourceItem, globModels } from '../../src/common/dataSourceManager';
@@ -79,10 +79,10 @@ describe(filename, () => {
     await instance.init(config)
     expect(instance.getDataSourceNames()).toEqual(['default', 'test']);
     expect(instance.hasDataSource('default')).toBeTruthy();
-    expect(instance.getDataSource('default')).toMatchSnapshot();
+    // expect(instance.getDataSource('default')).toMatchSnapshot();
     expect(instance.getDataSource('default').entitiesLength).toEqual(2);
     expect(instance.getDataSource('default').host).toEqual(host);
-    expect(instance.getDataSource('test')).toMatchSnapshot();
+    // expect(instance.getDataSource('test')).toMatchSnapshot();
     expect(instance.getDataSource('test').entitiesLength).toEqual(1);
     expect(instance.getDataSource('test').host).toEqual(host);
     // @ts-expect-error
@@ -129,7 +129,7 @@ describe(filename, () => {
 
     await instance.init(config)
     expect(instance.getDataSourceNames()).toEqual(['test']);
-    expect(instance.getDataSource('test')).toMatchSnapshot();
+    // expect(instance.getDataSource('test')).toMatchSnapshot();
   });
 
   it('should test will got error when no data source', async () => {
@@ -186,9 +186,9 @@ describe(filename, () => {
     await instance.init(config)
     expect(instance.getDataSourceNames()).toEqual(['default', 'test']);
     expect(instance.hasDataSource('default')).toBeTruthy();
-    expect(instance.getDataSource('default')).toMatchSnapshot();
+    // expect(instance.getDataSource('default')).toMatchSnapshot();
     expect(instance.getDataSource('default').entitiesLength).toEqual(2);
-    expect(instance.getDataSource('test')).toMatchSnapshot();
+    // expect(instance.getDataSource('test')).toMatchSnapshot();
     expect(instance.getDataSource('test').entitiesLength).toEqual(1);
     // @ts-expect-error
     expect(instance.getDataSource('fff')).not.toBeDefined();

--- a/packages/core/test/common/dataSourceManager-T-SourceName.test.ts
+++ b/packages/core/test/common/dataSourceManager-T-SourceName.test.ts
@@ -54,7 +54,7 @@ describe(filename, () => {
 
   class CustomDataSourceFactory<SourceName extends PropertyKey> extends DataSourceManager<Dbh, SourceName> {
     getName() {
-      return 'test';
+      return 'test' as SourceName;
     }
     async init(options: DataSourceConfig<SourceName>) {
       return super.initDataSource(options, __dirname);

--- a/packages/core/test/common/dataSourceManager.test.ts
+++ b/packages/core/test/common/dataSourceManager.test.ts
@@ -19,6 +19,10 @@ describe('test/common/dataSourceManager.test.ts', () => {
     protected async checkConnected(dataSource: any) {
       return false;
     }
+
+    protected async destroyDataSource(dataSource: any): Promise<void> {
+      return;
+    }
   }
 
   it('should test base data source', async () => {


### PR DESCRIPTION
- chore(core): change DataSourceManager.destroyDataSource() to abstract method   
   改为抽象方法，需要开发者实现
- feat(core): DataSourceManager accepts 2nd generic type SourceName (default string)   
  - `DataSourceManager ` 接收第二个泛型参数，为 DataSourceName 字面量类型，默认值为 `string` 和当前保持一致
  - usage: 
    - DataSourceManager<T> : keep current
    - DataSourceManager<T, 'db1' | 'db2'>
    - DataSourceManager<T, keyof typeof mysqlConfig.dataSource>