### PR TITLE
fix: IMiddleware interface

### DIFF
--- a/packages/core/src/interface.ts
+++ b/packages/core/src/interface.ts
@@ -398,9 +398,9 @@ export type NextFunction = () => Promise<any>;
  * Common middleware definition
  */
 export interface IMiddleware<CTX, R, N = unknown> {
-  resolve: (app?: IMidwayApplication) => FunctionMiddleware<CTX, R, N> | Promise<FunctionMiddleware<CTX, R, N>>;
-  match?: (ctx?: CTX) => boolean;
-  ignore?: (ctx?: CTX) => boolean;
+  resolve: (app: IMidwayApplication) => FunctionMiddleware<CTX, R, N> | Promise<FunctionMiddleware<CTX, R, N>>;
+  match?: (ctx: CTX) => boolean;
+  ignore?: (ctx: CTX) => boolean;
 }
 export type FunctionMiddleware<CTX, R, N = unknown> = N extends true
   ? (req: CTX, res: R, next: N) => any


### PR DESCRIPTION
fixes #2241

tsconfig 开启 `strictFunctionTypes` 时，方法参数必须逆变。以下为一示例：

```ts
interface Obj {
  f: (n: number) => any;
  g: (n?: number) => any;
}

class O1 implements Obj {
  f: () => 1; // Ok
  g: () => 1; // Ok
}

class O2 implements Obj {
  f: (n: number) => 1; // Ok
  g: (n: number) => 1; // Error, 类型“O2”中的属性“g”不可分配给基类型“Obj”中的同一属性
}
```