### PR TITLE
docs: update global prefix descriptions

### DIFF
--- a/site/docs/controller.md
+++ b/site/docs/controller.md
@@ -914,15 +914,26 @@ export class HomeController {
 
 ## 全局路由前缀
 
-需要在配置中设置。
-
-比如：
+需要在`src/config/config.default`配置中设置。
+针对不同组件时,需添加在对应配置里。
+如使用egg作为上层时：
+```typescript
+// src/config/config.default.ts
+export default (appInfo: MidwayAppInfo) => {
+  return {
+    egg: { globalPrefix: '/v1' }
+  }
+});
+```
+使用koa作为上层时：
 
 ```typescript
 // src/config/config.default.ts
-export const koa = {
-  globalPrefix: '/v1'
-}
+export default (appInfo: MidwayAppInfo) => {
+  return {
+    koa: { globalPrefix: '/v1' }
+  }
+});
 ```
 
 配置后，所有的路由都会自动增加该前缀。


### PR DESCRIPTION
目的: 完善说明和代码模块,添加了egg声明方式的代码,修改了koa的代码
背景: 原代码写的不够清晰,是按照 export cosnt koa写出来的, 容易导致误会,感觉只有koa才有globalPrefix,并且没有说明不同组件时,要声明在对应组件config下,cli创建的模板都是按照函数 export default export default (appInfo: MidwayAppInfo) => {}),所以更改为函数式的config,比较贴合大部分用户理解

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->
没有任何影响,只是丰富文档

##### Description of change
<!-- Provide a description of the change below this comment. -->
1.添加了egg声明globalPrefix方式的代码,
2.修改了koa添加globalPrefix的代码
