### PR TITLE
feat: support add locals and add case

### DIFF
--- a/packages/i18n/src/config/config.default.ts
+++ b/packages/i18n/src/config/config.default.ts
@@ -19,4 +19,5 @@ export const i18n: I18nOptions = {
       cookieMaxAge: FORMAT.MS.ONE_YEAR,
     },
   },
+  localsField: 'i18n',
 };

--- a/packages/i18n/src/interface.ts
+++ b/packages/i18n/src/interface.ts
@@ -19,6 +19,7 @@ export interface I18nOptions {
   fallbacks: Record<string, any>;
   writeCookie: boolean;
   resolver:  RequestResolver | false,
+  localsField: string;
 }
 
 export const I18N_ATTR_KEY = 'i18n:locale';

--- a/packages/i18n/src/middleware.ts
+++ b/packages/i18n/src/middleware.ts
@@ -98,6 +98,15 @@ export class I18nMiddleware implements IMiddleware<any, any> {
           i18nService.saveRequestLocale();
         }
 
+        res.locals[this.i18nConfig.localsField] = (
+          message: string,
+          data: any
+        ) => {
+          return i18nService.translate(message, {
+            args: data,
+          });
+        };
+
         return next();
       };
     } else {
@@ -142,6 +151,15 @@ export class I18nMiddleware implements IMiddleware<any, any> {
           } else {
             i18nService.saveRequestLocale();
           }
+
+          ctx.locals[this.i18nConfig.localsField] = (
+            message: string,
+            data: any
+          ) => {
+            return i18nService.translate(message, {
+              args: data,
+            });
+          };
         }
 
         // run next middleware and controller

--- a/packages/i18n/test/fixtures/base-app-express-req-locals/package.json
+++ b/packages/i18n/test/fixtures/base-app-express-req-locals/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "ali-demo"
+}

--- a/packages/i18n/test/fixtures/base-app-express-req-locals/src/configuration.ts
+++ b/packages/i18n/test/fixtures/base-app-express-req-locals/src/configuration.ts
@@ -1,0 +1,34 @@
+import { Configuration, Inject } from '@midwayjs/decorator';
+import * as express from '@midwayjs/express';
+
+@Configuration({
+  imports: [
+    express,
+    require('../../../../src')
+  ],
+  importConfigs: [
+    {
+      default: {
+        keys: '12345',
+        i18n: {
+          defaultLocale: 'en_US',
+          localeTable: {
+            en_US: {
+              "HELLO_MESSAGE": "Hello {username}",
+            },
+            zh_CN: {
+              "HELLO_MESSAGE": "你好 {username}",
+            }
+          }
+        },
+      }
+    }
+  ]
+})
+export class AutoConfiguration {
+  @Inject()
+  framework: express.Framework;
+
+  async onReady() {
+  }
+}

--- a/packages/i18n/test/fixtures/base-app-express-req-locals/src/user.ts
+++ b/packages/i18n/test/fixtures/base-app-express-req-locals/src/user.ts
@@ -1,0 +1,21 @@
+import { Controller, Get, Inject, Query } from '@midwayjs/decorator';
+import { MidwayI18nService } from '../../../../src';
+
+@Controller('/')
+export class UserController {
+
+  @Inject()
+  i18nService: MidwayI18nService;
+
+  @Inject()
+  res;
+
+  @Get('/')
+  async index(@Query('username') username: string) {
+    const i18n = this.res.locals['i18n'];
+
+    return i18n('HELLO_MESSAGE', {
+      username
+    });
+  }
+}

--- a/packages/i18n/test/fixtures/base-app-koa-ctx-locals/package.json
+++ b/packages/i18n/test/fixtures/base-app-koa-ctx-locals/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "ali-demo"
+}

--- a/packages/i18n/test/fixtures/base-app-koa-ctx-locals/src/configuration.ts
+++ b/packages/i18n/test/fixtures/base-app-koa-ctx-locals/src/configuration.ts
@@ -1,0 +1,34 @@
+import { Configuration, Inject } from '@midwayjs/decorator';
+import * as koa from '@midwayjs/koa';
+
+@Configuration({
+  imports: [
+    koa,
+    require('../../../../src')
+  ],
+  importConfigs: [
+    {
+      default: {
+        keys: '12345',
+        i18n: {
+          defaultLocale: 'en_US',
+          localeTable: {
+            en_US: {
+              "HELLO_MESSAGE": "Hello {username}",
+            },
+            zh_CN: {
+              "HELLO_MESSAGE": "你好 {username}",
+            }
+          }
+        },
+      }
+    }
+  ]
+})
+export class AutoConfiguration {
+  @Inject()
+  framework: koa.Framework;
+
+  async onReady() {
+  }
+}

--- a/packages/i18n/test/fixtures/base-app-koa-ctx-locals/src/user.ts
+++ b/packages/i18n/test/fixtures/base-app-koa-ctx-locals/src/user.ts
@@ -1,0 +1,17 @@
+import { Controller, Get, Inject, Query } from '@midwayjs/decorator';
+
+@Controller('/')
+export class UserController {
+
+  @Inject()
+  ctx;
+
+  @Get('/')
+  async index(@Query('username') username: string) {
+    const i18n = this.ctx.locals['i18n'];
+
+    return i18n('HELLO_MESSAGE', {
+      username
+    });
+  }
+}

--- a/packages/i18n/test/index.test.ts
+++ b/packages/i18n/test/index.test.ts
@@ -297,6 +297,22 @@ describe('test/index.test.ts', () => {
       expect(result.headers['set-cookie']).toBeUndefined();
       await close(app);
     });
+
+    it('should test with request ctx.locals', async () => {
+      const app = await createApp(join(
+        __dirname,
+        './fixtures/base-app-koa-ctx-locals'
+      ));
+
+      const result = await createHttpRequest(app).get('/').query({
+        locale: 'zh_CN',
+        username: '世界',
+      });
+
+      expect(result.text).toEqual('你好 世界');
+
+      await close(app);
+    });
   });
 
   describe('i18n in express', function () {
@@ -391,6 +407,22 @@ describe('test/index.test.ts', () => {
 
       expect(result.text).toEqual('Hello 世界');
       expect(result.headers['set-cookie']).toBeUndefined();
+      await close(app);
+    });
+
+    it('should test with request req.locals', async () => {
+      const app = await createApp(join(
+        __dirname,
+        './fixtures/base-app-express-req-locals'
+      ));
+
+      const result = await createHttpRequest(app).get('/').query({
+        locale: 'zh_CN',
+        username: '世界',
+      });
+
+      expect(result.text).toEqual('你好 世界');
+
       await close(app);
     });
   });

--- a/packages/view/src/contextView.ts
+++ b/packages/view/src/contextView.ts
@@ -38,7 +38,7 @@ export class ContextView implements IViewEngine {
     let viewEngineName = options.viewEngine;
     if (!viewEngineName) {
       const ext = extname(filename);
-      viewEngineName = this.viewManager.extMap.get(ext);
+      viewEngineName = this.viewManager.findEngine(ext);
     }
     // use the default view engine that is configured if no matching above
     if (!viewEngineName) {
@@ -85,6 +85,7 @@ export class ContextView implements IViewEngine {
 
   private setLocals(locals) {
     return Object.assign(
+      this.viewManager.getLocals(),
       {
         ctx: this.ctx,
         request: this.ctx.request,

--- a/packages/view/src/viewManager.ts
+++ b/packages/view/src/viewManager.ts
@@ -15,18 +15,19 @@ import { IViewEngine } from './interface';
 @Scope(ScopeEnum.Singleton)
 export class ViewManager extends Map {
   @App()
-  app;
+  protected app;
 
   @Config('view')
-  viewConfig;
+  protected viewConfig;
 
-  config;
+  protected config;
 
-  extMap = new Map();
-  fileMap = new Map();
+  protected extMap = new Map();
+  protected fileMap = new Map();
+  protected localsMap = {};
 
   @Init()
-  init() {
+  protected init() {
     this.config = this.viewConfig;
     const rootSet: Set<string> = new Set(Object.values(this.config.rootDir));
     if (this.config.root) {
@@ -59,7 +60,7 @@ export class ViewManager extends Map {
    * @param {String} name - the name of view engine
    * @param {Object} viewEngine - the class of view engine
    */
-  use(name: string, viewEngine: new (...args) => IViewEngine): void {
+  public use(name: string, viewEngine: new (...args) => IViewEngine): void {
     assert(name, 'name is required');
     assert(!this.has(name), `${name} has been registered`);
 
@@ -83,7 +84,7 @@ export class ViewManager extends Map {
    * @param {String} name - the given path name, it's relative to config.root
    * @return {String} filename - the full path
    */
-  async resolve(name: string): Promise<string> {
+  public async resolve(name: string): Promise<string> {
     const config = this.config;
 
     // check cache
@@ -100,6 +101,26 @@ export class ViewManager extends Map {
     // set cache
     this.fileMap.set(name, filename);
     return filename;
+  }
+
+  /**
+   * add a global data for all views
+   * @param key
+   * @param localValue
+   */
+  public addLocals(key, localValue) {
+    this.localsMap[key] = localValue;
+  }
+
+  /**
+   * get global locals data
+   */
+  public getLocals() {
+    return this.localsMap;
+  }
+
+  public findEngine(ext: string): string {
+    return this.extMap.get(ext);
   }
 }
 

--- a/packages/view/test/index.test.ts
+++ b/packages/view/test/index.test.ts
@@ -1,6 +1,7 @@
 import { createApp, close, createHttpRequest } from '@midwayjs/mock';
-import { Framework } from '@midwayjs/koa'
+import { Framework } from '@midwayjs/koa';
 import { join } from 'path';
+import { ContextView, ViewManager } from '../src';
 
 describe('/test/index.test.ts', () => {
 
@@ -24,5 +25,42 @@ describe('/test/index.test.ts', () => {
     expect(result.status).toEqual(200);
     expect(result.text).toEqual(join(__dirname, 'fixtures', 'base-app-default/view/a.html'));
     await close(app);
+  });
+
+  it('should test context view', async () => {
+    class CustomView {
+      async render(name: string,
+                   locals?: Record<string, any>,
+                   options?: any) {
+        return name;
+      }
+      async renderString(tpl: string,
+                         locals?: Record<string, any>,
+                         options?: any) {
+        const text = locals.b();
+        return tpl.replace('{{b}}', text);
+      }
+    }
+    const manager = new ViewManager();
+    manager.use('custom', CustomView);
+    manager.addLocals('b', () => {
+      return 'harry';
+    });
+
+    const view = new ContextView();
+    view.viewManager = manager;
+    view.ctx = {
+      requestContext: {
+        async getAsync() {
+          return new CustomView();
+        }
+      }
+    };
+
+    const result = await view.renderString('hello {{b}}', {}, {
+      viewEngine: 'custom'
+    });
+
+    expect(result).toEqual('hello harry');
   });
 });

--- a/packages/web-koa/src/framework.ts
+++ b/packages/web-koa/src/framework.ts
@@ -88,6 +88,12 @@ export class MidwayKoaFramework extends BaseFramework<
       enumerable: true,
     });
 
+    Object.defineProperty(this.app.context, 'locals', {
+      get() {
+        return this.state;
+      },
+    });
+
     const onerrorConfig = this.configService.getConfiguration('onerror');
     setupOnError(this.app, onerrorConfig, this.logger);
 

--- a/packages/web-koa/src/framework.ts
+++ b/packages/web-koa/src/framework.ts
@@ -92,6 +92,9 @@ export class MidwayKoaFramework extends BaseFramework<
       get() {
         return this.state;
       },
+      set(value) {
+        this.state = value;
+      },
     });
 
     const onerrorConfig = this.configService.getConfiguration('onerror');

--- a/packages/web-koa/test/fixtures/base-app-state-locals/package.json
+++ b/packages/web-koa/test/fixtures/base-app-state-locals/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "ali-demo"
+}

--- a/packages/web-koa/test/fixtures/base-app-state-locals/src/config/config.default.ts
+++ b/packages/web-koa/test/fixtures/base-app-state-locals/src/config/config.default.ts
@@ -1,0 +1,9 @@
+'use strict';
+
+export const keys = 'key';
+
+export const hello = {
+  a: 1,
+  b: 2,
+  d: [1, 2, 3],
+};

--- a/packages/web-koa/test/fixtures/base-app-state-locals/src/config/config.unittest.ts
+++ b/packages/web-koa/test/fixtures/base-app-state-locals/src/config/config.unittest.ts
@@ -1,0 +1,5 @@
+
+exports.hello = {
+  b: 4,
+  c: 3,
+};

--- a/packages/web-koa/test/fixtures/base-app-state-locals/src/configuration.ts
+++ b/packages/web-koa/test/fixtures/base-app-state-locals/src/configuration.ts
@@ -1,0 +1,16 @@
+import { Configuration, App } from '@midwayjs/decorator';
+import { join } from 'path';
+
+@Configuration({
+  importConfigs: [
+    join(__dirname, './config'),
+  ]
+})
+export class ContainerConfiguration {
+
+  @App()
+  app;
+
+  async onReady() {
+  }
+}

--- a/packages/web-koa/test/fixtures/base-app-state-locals/src/controller/home.ts
+++ b/packages/web-koa/test/fixtures/base-app-state-locals/src/controller/home.ts
@@ -1,0 +1,24 @@
+import {
+  Controller,
+  Get,
+  Inject,
+} from '@midwayjs/decorator';
+import { IMidwayKoaContext } from '../../../../../src';
+
+@Controller('/')
+export class APIController {
+  @Inject()
+  ctx: IMidwayKoaContext;
+
+  @Get('/')
+  async home() {
+    this.ctx.state['a'] = 1;
+    this.ctx.locals['b'] = 2;
+
+    return {
+      locals: this.ctx.locals,
+      state: this.ctx.state,
+    }
+  }
+
+}

--- a/packages/web-koa/test/fixtures/base-app-state-locals/src/controller/home.ts
+++ b/packages/web-koa/test/fixtures/base-app-state-locals/src/controller/home.ts
@@ -12,8 +12,10 @@ export class APIController {
 
   @Get('/')
   async home() {
+    this.ctx.locals = {
+      b: 2,
+    }
     this.ctx.state['a'] = 1;
-    this.ctx.locals['b'] = 2;
 
     return {
       locals: this.ctx.locals,

--- a/packages/web-koa/test/index.test.ts
+++ b/packages/web-koa/test/index.test.ts
@@ -404,6 +404,7 @@ describe('/test/feature.test.ts', () => {
       .get('/api/user');
     expect(result.status).toEqual(200);
     expect(result.text).toEqual('hello world123');
+    await closeApp(app);
   });
 
   it('should test query parser', async () => {
@@ -424,5 +425,16 @@ describe('/test/feature.test.ts', () => {
 
     expect(result.status).toEqual(200);
     expect(result.text).toEqual(JSON.stringify({"appId":["123","456"]}));
+    await closeApp(app);
+  });
+
+  it('should test locals proxy state', async () => {
+    const app = await creatApp('base-app-state-locals');
+    let result = await createHttpRequest(app)
+      .get('/');
+    expect(result.status).toEqual(200);
+    expect(result.text).toEqual('{"locals":{"a":1,"b":2},"state":{"a":1,"b":2}}');
+
+    await closeApp(app);
   });
 });

--- a/packages/web-koa/test/index.test.ts
+++ b/packages/web-koa/test/index.test.ts
@@ -433,7 +433,7 @@ describe('/test/feature.test.ts', () => {
     let result = await createHttpRequest(app)
       .get('/');
     expect(result.status).toEqual(200);
-    expect(result.text).toEqual('{"locals":{"a":1,"b":2},"state":{"a":1,"b":2}}');
+    expect(result.text).toEqual('{"locals":{"b":2,"a":1},"state":{"b":2,"a":1}}');
 
     await closeApp(app);
   });


### PR DESCRIPTION
related: #2287

调整了下，locals 里加了 i18n 函数，模板里可以直接用

```
 {{ i18n('hello', user) }}
```