### PR TITLE
fix: add default generic type to MikroConfigOptions

### DIFF
--- a/packages/mikro/src/interface.ts
+++ b/packages/mikro/src/interface.ts
@@ -1,4 +1,4 @@
 import { Options, Configuration, IDatabaseDriver } from '@mikro-orm/core';
 import { DataSourceManagerConfigOption } from '@midwayjs/core';
 
-export type MikroConfigOptions<D extends IDatabaseDriver> = DataSourceManagerConfigOption<Options<D> | Configuration<D>>;
+export type MikroConfigOptions<D extends IDatabaseDriver = IDatabaseDriver> = DataSourceManagerConfigOption<Options<D> | Configuration<D>>;


### PR DESCRIPTION
MidwayConfig 中没有指定 MikroConfigOptions 的泛型参数，所以需要给 MikroConfigOptions 加默认的泛型参数

https://github.com/midwayjs/midway/blob/ce6f5debcd9b10afbd2a8ab0dceb9ebc68b18414/packages/mikro/index.d.ts#L5-L9
