### PR TITLE
fix: default is used by default for typeorm multiple data sources

### DIFF
--- a/packages/typeorm/src/decorator.ts
+++ b/packages/typeorm/src/decorator.ts
@@ -12,7 +12,7 @@ export const ORM_MODEL_KEY = 'typeorm:orm_model_key';
 
 export function InjectEntityModel(
   modelKey: EntityTarget<unknown>,
-  connectionName?: string
+  connectionName: string = 'default'
 ) {
   return createCustomPropertyDecorator(ORM_MODEL_KEY, {
     modelKey,


### PR DESCRIPTION
[上一版本改动](https://github.com/midwayjs/midway/commit/5c9c90c550e04dbcbe975701e98b62bb04c9c03b)
本次改动: typeorm 多数据源默认使用default配置