### PR TITLE
chore: upgrade bull to bull redis url config

### DIFF
--- a/packages/bull/package.json
+++ b/packages/bull/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@types/bull": "3.15.9",
-    "bull": "4.10.0"
+    "bull": "4.10.1"
   },
   "engines": {
     "node": ">=12"

--- a/site/docs/tool/sequelize_generator.md
+++ b/site/docs/tool/sequelize_generator.md
@@ -17,7 +17,7 @@ npm i sequelize-auto-midway
 ```shell
 # 推荐
 # 请替换配置信息
-npx sequelize-auto-midway -h localhost -d yourDBname -u root -x yourPassword -p 13306  --dialect mysql -o ./models -t task --noInitModels true --caseModel c --caseProp c --caseFile c --indentation 1 -a ./additional.json
+npx sequelize-auto-midway -h localhost -d yourDBname -u root -x yourPassword -p 13306  --dialect mysql -o ./models --noInitModels true --caseModel c --caseProp c --caseFile c --indentation 1 -a ./additional.json
 ```
 
 additional.json


### PR DESCRIPTION
模块包 bull 4.10.0版本不支持 redisurl 初始化配置，已经在 bull 仓库提交pr并且发布最新包，需要将依赖升级到4.10.1解决这个问题

![image](https://user-images.githubusercontent.com/9130123/195569163-ccec2e58-5d51-442f-b5b5-033a91553bf6.png)
