### PR TITLE
fix: framework loaded by import sequence

### DIFF
--- a/packages/core/src/context/container.ts
+++ b/packages/core/src/context/container.ts
@@ -680,6 +680,10 @@ export class MidwayContainer implements IMidwayContainer, IModuleStore {
     return this.namespaceSet.has(ns);
   }
 
+  getNamespaceList() {
+    return Array.from(this.namespaceSet);
+  }
+
   hasDefinition(identifier: ObjectIdentifier) {
     return this.registry.hasDefinition(identifier);
   }

--- a/packages/core/src/interface.ts
+++ b/packages/core/src/interface.ts
@@ -304,6 +304,7 @@ export interface IMidwayContainer extends IObjectFactory, IObjectLifeCycle {
   registerObject(identifier: ObjectIdentifier, target: any);
   load(module?: any);
   hasNamespace(namespace: string): boolean;
+  getNamespaceList(): string[];
   hasDefinition(identifier: ObjectIdentifier);
   hasObject(identifier: ObjectIdentifier);
   bind<T>(target: T, options?: Partial<IObjectDefinition>): void;

--- a/packages/core/src/service/frameworkService.ts
+++ b/packages/core/src/service/frameworkService.ts
@@ -161,10 +161,21 @@ export class MidwayFrameworkService {
         this.globalFrameworkList.push(frameworkInstance);
       }
 
-      const nsSet = this.applicationContext['namespaceSet'] as Set<string>;
       let mainNs;
-      if (nsSet.size > 0) {
-        [mainNs] = nsSet;
+
+      /**
+       * 这里处理引入组件的顺序，在主框架之前是否包含其他的 framework
+       * 1、装饰器的顺序和 import 的写的顺序有关
+       * 2、主框架和 configuration 中的配置加载顺序有关
+       * 3、两者不符合的话，App 装饰器获取的 app 会不一致，导致中间件等无法正常使用
+       */
+      const namespaceList = this.applicationContext.getNamespaceList();
+      for (const namespace of namespaceList) {
+        const framework = this.applicationManager.getApplication(namespace);
+        if (framework) {
+          mainNs = namespace;
+          break;
+        }
       }
 
       global['MIDWAY_MAIN_FRAMEWORK'] = this.mainFramework =

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -35,7 +35,7 @@ const debug = util.debuglog('midway:debug');
  */
 export async function initializeGlobalApplicationContext(
   globalOptions: IMidwayBootstrapOptions
-) {
+): Promise<IMidwayContainer> {
   const applicationContext = prepareGlobalApplicationContext(globalOptions);
 
   // init logger

--- a/packages/core/test/baseFramework.test.ts
+++ b/packages/core/test/baseFramework.test.ts
@@ -16,7 +16,7 @@ import {
   MidwayFrameworkType,
   Provide
 } from '../src';
-import { createLightFramework } from './util';
+import { createFramework, createLightFramework } from './util';
 import sinon = require('sinon');
 import { IMidwayApplication } from '../src';
 import { NoopContextManager } from '../src/common/asyncContextManager';
@@ -700,5 +700,16 @@ describe('/test/baseFramework.test.ts', () => {
     const app = framework.getApplication() as IMidwayApplication;
     expect(app.getAttr('invokeResult')).toEqual(true);
     expect(app.getAttr('invoke2Result')).toEqual(false);
+  });
+
+  it('should test throw framework sequence error', async () => {
+    const applicationContext = await createFramework(path.join(
+      __dirname,
+      './fixtures/app-with-multi-framework-sequence-error/src'
+    ));
+
+    const midwayFrameworkService = applicationContext.get(MidwayFrameworkService);
+
+    console.log(midwayFrameworkService.getMainFramework());
   });
 });

--- a/packages/core/test/fixtures/app-with-multi-framework-sequence-error/package.json
+++ b/packages/core/test/fixtures/app-with-multi-framework-sequence-error/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "ali-demo"
+}

--- a/packages/core/test/fixtures/app-with-multi-framework-sequence-error/src/a.ts
+++ b/packages/core/test/fixtures/app-with-multi-framework-sequence-error/src/a.ts
@@ -1,0 +1,40 @@
+import {
+  Configuration as CoreConfiguration,
+  BaseFramework,
+  Framework,
+  IMidwayBootstrapOptions,
+  MidwayFrameworkType, IMidwayApplication, destroyGlobalApplicationContext
+} from '../../../../src';
+
+@Framework()
+export class AFramework extends BaseFramework<any, any, any> {
+  private isStopped = false;
+  getFrameworkType(): MidwayFrameworkType {
+    return MidwayFrameworkType.EMPTY;
+  }
+
+  async run(): Promise<void> {
+  }
+
+  async applicationInitialize(options: IMidwayBootstrapOptions) {
+    this.app = {} as IMidwayApplication;
+    this.defineApplicationProperties();
+  }
+
+  async beforeStop() {
+    if (!this.isStopped) {
+      this.isStopped = true;
+      await destroyGlobalApplicationContext(this.applicationContext);
+    }
+  }
+
+  configure() {
+    return {};
+  }
+}
+
+@CoreConfiguration({
+  namespace: 'a',
+})
+export class Configuration {
+}

--- a/packages/core/test/fixtures/app-with-multi-framework-sequence-error/src/b.ts
+++ b/packages/core/test/fixtures/app-with-multi-framework-sequence-error/src/b.ts
@@ -1,0 +1,40 @@
+import {
+  Configuration as CoreConfiguration,
+  BaseFramework,
+  Framework,
+  IMidwayBootstrapOptions,
+  MidwayFrameworkType, IMidwayApplication, destroyGlobalApplicationContext
+} from '../../../../src';
+
+@Framework()
+export class BFramework extends BaseFramework<any, any, any> {
+  private isStopped = false;
+  getFrameworkType(): MidwayFrameworkType {
+    return MidwayFrameworkType.EMPTY;
+  }
+
+  async run(): Promise<void> {
+  }
+
+  async applicationInitialize(options: IMidwayBootstrapOptions) {
+    this.app = {} as IMidwayApplication;
+    this.defineApplicationProperties();
+  }
+
+  async beforeStop() {
+    if (!this.isStopped) {
+      this.isStopped = true;
+      await destroyGlobalApplicationContext(this.applicationContext);
+    }
+  }
+
+  configure() {
+    return {};
+  }
+}
+
+@CoreConfiguration({
+  namespace: 'b',
+})
+export class Configuration {
+}

--- a/packages/core/test/fixtures/app-with-multi-framework-sequence-error/src/c.ts
+++ b/packages/core/test/fixtures/app-with-multi-framework-sequence-error/src/c.ts
@@ -1,0 +1,9 @@
+import {
+  Configuration as CoreConfiguration,
+} from '../../../../src';
+
+@CoreConfiguration({
+  namespace: 'c',
+})
+export class Configuration {
+}

--- a/packages/core/test/fixtures/app-with-multi-framework-sequence-error/src/configuration.ts
+++ b/packages/core/test/fixtures/app-with-multi-framework-sequence-error/src/configuration.ts
@@ -1,0 +1,14 @@
+import { Configuration } from '../../../../src'
+import * as c from './c';
+import * as b from './b';
+import * as a from './a';
+
+@Configuration({
+  imports: [
+    c,
+    a,
+    b
+  ]
+})
+export class MainConfiguration {
+}


### PR DESCRIPTION
修复 import 顺序不一致，导致主框架获取错误的情况。

比如：

```ts
import * as bull from '@midwayjs/bull';
import * as koa from '@midwayjs/koa';

@Configuration({
	imports: [koa, bull]
})
export class MainConfiguration {}
```

由于内部初始化是使用 require 的属性，即使 imports 的顺序固定，实际 bull 的 application 还是会变为 mainApp，这个时候去引入中间件，都会加到 bull 上，而不是 koa 上。