### PR TITLE
docs: change h in Github to uppercase in web page button

### DIFF
--- a/site/src/components/Splash.tsx
+++ b/site/src/components/Splash.tsx
@@ -163,7 +163,7 @@ export function Splash() {
         </Button>
         <Button type="secondary" href="https://github.com/midwayjs/midway" target="_blank">
           <Icon className="iconfont icon-github-fill" />
-          Github
+          GitHub
         </Button>
       </ButtonGroup>
       <StarContainer>


### PR DESCRIPTION
change h in Github to uppercase, Github should be GitHub since this is a proper noun..

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
