### PR TITLE
docs(site): fix typo in container.md

### DIFF
--- a/site/docs/container.md
+++ b/site/docs/container.md
@@ -540,7 +540,7 @@ export class PaymentService {
   payService: IPay;         // 注意，这里的类型是接口，编译后类型信息会被移除
 
   async orderGood() {
-    await this.payService.payMonety();
+    await this.payService.payMoney();
   }
 
 }


### PR DESCRIPTION
the paymentservice example contains a typo in method call (payMoney, which is misspelld as  payMonety)

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
correct the method call typo in the paymentservice in container.md 