### PR TITLE
chore(bull): remove @types/bull

### DIFF
--- a/packages/bull/package.json
+++ b/packages/bull/package.json
@@ -28,7 +28,6 @@
     "@midwayjs/mock": "^3.6.0"
   },
   "dependencies": {
-    "@types/bull": "3.15.9",
     "bull": "4.10.1"
   },
   "engines": {


### PR DESCRIPTION
@types/bull: This is a stub types definition. bull provides its own type definitions, so you do not need this installed.

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
