### PR TITLE
docs: fix serverless_yml link path

### DIFF
--- a/site/docs/serverless/serverless_dev.md
+++ b/site/docs/serverless/serverless_dev.md
@@ -123,7 +123,7 @@ custom:
 `@ServerlessTrigger` 装饰器用于定义不同的触发器，它的参数为每个触发器信息，以及通用触发器参数。
 
 
-触发器和 [f.yml 的定义](/docs/serverless_yml#YoMeC)保持一致，当前的定义请参考每个触发器的 [interface](https://github.com/midwayjs/midway/blob/2.x/packages/decorator/src/interface.ts#L141)。
+触发器和 [f.yml 的定义](/docs/serverless/serverless_yml)保持一致，当前的定义请参考每个触发器的 [interface](https://github.com/midwayjs/midway/blob/2.x/packages/decorator/src/interface.ts#L141)。
 
 比如触发器的名称修改为 abc。
 
@@ -140,7 +140,7 @@ custom:
 `@ServerlessFunction` 装饰器用于定义函数，通过它可以修改函数名。
 
 
-函数触发器和 [f.yml 的定义](/docs/serverless_yml#f1568472) 保持一致，当前的定义请参考每个触发器的 [interface](https://github.com/midwayjs/midway/blob/2.x/packages/decorator/src/interface.ts#L141)。
+函数触发器和 [f.yml 的定义](/docs/serverless/serverless_yml) 保持一致，当前的定义请参考每个触发器的 [interface](https://github.com/midwayjs/midway/blob/2.x/packages/decorator/src/interface.ts#L141)。
 
 
 比如：


### PR DESCRIPTION
修复 [Serverless - 基础 - 开发函数](https://www.midwayjs.org/docs/serverless/serverless_dev) 文档中 `[f.yml 的定义](https://www.midwayjs.org/docs/serverless_yml#YoMeC)` 链接失效问题。