### PR TITLE
fix: swagger query object

### DIFF
--- a/packages/swagger/src/swaggerExplorer.ts
+++ b/packages/swagger/src/swaggerExplorer.ts
@@ -333,7 +333,7 @@ export class SwaggerExplorer {
         if (p.in === 'query') {
           // 如果@Query()装饰的 是一个对象，则把该对象的子属性作为多个@Query参数
           const schema = this.documentBuilder.getSchema(currentType.name);
-          for (const pName in schema.properties) {
+          Object.keys(schema.properties).forEach(pName => {
             const ppt: any = schema.properties[pName];
             const pp = {
               name: pName,
@@ -341,7 +341,7 @@ export class SwaggerExplorer {
             };
             this.parseFromParamsToP({ metadata: ppt }, pp);
             parameters.push(pp);
-          }
+          });
           continue;
         } else {
           p.schema = {

--- a/packages/swagger/src/swaggerExplorer.ts
+++ b/packages/swagger/src/swaggerExplorer.ts
@@ -330,9 +330,24 @@ export class SwaggerExplorer {
       if (Types.isClass(currentType)) {
         this.parseClzz(currentType);
 
-        p.schema = {
-          $ref: '#/components/schemas/' + currentType.name,
-        };
+        if (p.in === 'query') {
+          // 如果@Query()装饰的 是一个对象，则把该对象的子属性作为多个@Query参数
+          const schema = this.documentBuilder.getSchema(currentType.name);
+          for (const pName in schema.properties) {
+            const ppt: any = schema.properties[pName];
+            const pp = {
+              name: pName,
+              in: p.in,
+            };
+            this.parseFromParamsToP({ metadata: ppt }, pp);
+            parameters.push(pp);
+          }
+          continue;
+        } else {
+          p.schema = {
+            $ref: '#/components/schemas/' + currentType.name,
+          };
+        }
       } else {
         p.schema = {
           type: convertSchemaType(currentType?.name ?? currentType),


### PR DESCRIPTION
遇到和下面issue同样的问题，跟了一下源码，改好顺便提个pr。
https://github.com/midwayjs/midway/issues/2521

修改后效果：如果@Query装饰的是一个对象，则把这个对象的所有子属性作为多个query参数。