### PR TITLE
feat: add @injectClient for service factory

### DIFF
--- a/packages/core/src/common/serviceFactory.ts
+++ b/packages/core/src/common/serviceFactory.ts
@@ -1,9 +1,10 @@
 import { extend } from '../util/extend';
+import { IServiceFactory } from '../interface';
 
 /**
  * 多客户端工厂实现
  */
-export abstract class ServiceFactory<T> {
+export abstract class ServiceFactory<T> implements IServiceFactory<T> {
   protected clients: Map<string, T> = new Map();
   protected options = {};
 
@@ -33,7 +34,7 @@ export abstract class ServiceFactory<T> {
     return this.clients.has(id);
   }
 
-  public async createInstance(config, clientName?): Promise<T | void> {
+  public async createInstance(config, clientName?): Promise<T | undefined> {
     // options.default will be merge in to options.clients[id]
     config = extend(true, {}, this.options['default'], config);
     const client = await this.createClient(config, clientName);

--- a/packages/core/src/decorator/common/inject.ts
+++ b/packages/core/src/decorator/common/inject.ts
@@ -1,8 +1,23 @@
-import { savePropertyInject } from '../decoratorManager';
+import {
+  createCustomPropertyDecorator,
+  savePropertyInject,
+} from '../decoratorManager';
 import { ObjectIdentifier } from '../interface';
+import { IServiceFactory } from '../../interface';
+import { FACTORY_SERVICE_CLIENT_KEY } from '../constant';
 
 export function Inject(identifier?: ObjectIdentifier) {
   return function (target: any, targetKey: string): void {
     savePropertyInject({ target, targetKey, identifier });
   };
+}
+
+export function InjectClient(
+  serviceFactoryClz: new (...args) => IServiceFactory<unknown>,
+  clientName?: string
+) {
+  return createCustomPropertyDecorator(FACTORY_SERVICE_CLIENT_KEY, {
+    serviceFactoryClz,
+    clientName,
+  });
 }

--- a/packages/core/src/decorator/constant.ts
+++ b/packages/core/src/decorator/constant.ts
@@ -9,6 +9,7 @@ export const ASPECT_KEY = 'common:aspect';
 export const CATCH_KEY = 'common:catch';
 export const MATCH_KEY = 'common:match';
 export const GUARD_KEY = 'common:guard';
+export const FACTORY_SERVICE_CLIENT_KEY = 'common:service_factory:client';
 
 // faas
 export const FUNC_KEY = 'faas:func';

--- a/packages/core/src/interface.ts
+++ b/packages/core/src/interface.ts
@@ -674,8 +674,6 @@ export interface IMidwayFramework<
   runGuard(ctx: CTX, supplierClz: new (...args) => any, methodName: string): Promise<boolean>;
 }
 
-
-
 export interface MidwayAppInfo {
   pkg: Record<string, any>;
   name: string;
@@ -691,4 +689,13 @@ export interface MidwayAppInfo {
  */
 export interface MidwayConfig extends FileConfigOption<MidwayCoreDefaultConfig> {
   [customConfigKey: string]: unknown;
+}
+
+export interface IServiceFactory<Client> {
+  get(clientId: string): Client;
+  has(clientId: string): boolean;
+  createInstance(config: any, clientId?: string): Promise<Client | undefined>;
+  getName(): string;
+  stop(): Promise<void>;
+  getDefaultClientName(): string;
 }

--- a/packages/core/test/baseFramework.test.ts
+++ b/packages/core/test/baseFramework.test.ts
@@ -712,4 +712,23 @@ describe('/test/baseFramework.test.ts', () => {
 
     console.log(midwayFrameworkService.getMainFramework());
   });
+
+  it('should test injectClient for serviceFactory', async () => {
+    const applicationContext = await createFramework(path.join(
+      __dirname,
+      './fixtures/base-app-service-factory-inject/src'
+    ));
+
+    const a = await applicationContext.getAsync<any>('a');
+    expect(() => {
+      a.invokeA();
+    }).toThrow(/Please set clientName/);
+
+    expect(a.invokeB()['data']).toEqual('default1');
+    expect(a.invokeC()['data']).toEqual('default2');
+
+    expect(() => {
+      a.invokeD();
+    }).toThrow(/custom1 not found/);
+  });
 });

--- a/packages/core/test/fixtures/base-app-service-factory-inject/package.json
+++ b/packages/core/test/fixtures/base-app-service-factory-inject/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "ali-demo"
+}

--- a/packages/core/test/fixtures/base-app-service-factory-inject/src/configuration.ts
+++ b/packages/core/test/fixtures/base-app-service-factory-inject/src/configuration.ts
@@ -1,0 +1,104 @@
+import { App, Configuration, InjectClient, Provide, ServiceFactory, IMidwayApplication, Init } from '../../../../src';
+
+@Provide()
+export class ServiceFactoryA extends ServiceFactory<any> {
+  protected createClient(config, clientName): any {
+  }
+
+  getName(): string {
+    return '';
+  }
+}
+
+@Provide()
+export class ServiceFactoryB extends ServiceFactory<any> {
+
+  @Init()
+  async init() {
+    await this.initClients({
+      clients: {
+        default1: {}
+      }
+    })
+  }
+
+  protected createClient(config, clientName): any {
+    return {
+      data: clientName,
+    }
+  }
+
+  getName(): string {
+    return '';
+  }
+}
+
+@Provide()
+export class ServiceFactoryC extends ServiceFactory<any> {
+
+  @Init()
+  async init() {
+    await this.initClients({
+      clients: {
+        default1: {},
+        default2: {}
+      },
+      defaultClientName: 'default2'
+    })
+  }
+
+  protected createClient(config, clientName): any {
+    return {
+      data: clientName,
+    }
+  }
+
+  getName(): string {
+    return '';
+  }
+}
+
+@Provide()
+export class A {
+  @InjectClient(ServiceFactoryA)
+  clientA;
+
+  @InjectClient(ServiceFactoryB, 'default1')
+  clientB;
+
+  @InjectClient(ServiceFactoryC)
+  clientC;
+
+  @InjectClient(ServiceFactoryA, 'custom1')
+  clientD;
+
+  invokeA() {
+    return this.clientA;
+  }
+
+  invokeB() {
+    return this.clientB;
+  }
+
+  invokeC() {
+    return this.clientC;
+  }
+
+  invokeD() {
+    return this.clientD;
+  }
+}
+
+
+@Configuration()
+export class AutoConfiguration {
+
+  @App()
+  app: IMidwayApplication;
+
+  async onReady(container) {
+    await container.getAsync(ServiceFactoryA);
+    await container.getAsync(ServiceFactoryB);
+    await container.getAsync(ServiceFactoryC);
+  }
+}


### PR DESCRIPTION
为 ServiceFactory 类型添加一个 @InjectClient 装饰器，方便客户端的选择注入。

比如 redis

原来：

```ts
import { RedisServiceFactory } from '@midwayjs/redis';
import { join } from 'path';

@Provide()
export class UserService {

  @Inject()
  redisServiceFactory: RedisServiceFactory;

  async save() {
    const redis1 = this.redisServiceFactory.get('instance1');
    const redis2 = this.redisServiceFactory.get('instance3');

    //...

  }
}
```

现在

```ts
import { RedisServiceFactory } from '@midwayjs/redis';
import { join } from 'path';

@Provide()
export class UserService {

  @InjectClient(RedisServiceFactory, 'instance1')
  redisClient1: RedisService;

  async save() {


  }
}

```