### PR TITLE
feat: add typeorm logger and logger lazy create

### DIFF
--- a/packages/core/src/interface.ts
+++ b/packages/core/src/interface.ts
@@ -346,7 +346,9 @@ export interface ILogger {
 }
 
 export interface MidwayCoreDefaultConfig {
-  midwayLogger?: ServiceFactoryConfigOption<LoggerOptions>;
+  midwayLogger?: ServiceFactoryConfigOption<LoggerOptions & {
+    lazyLoad?: boolean;
+  }>;
   debug?: {
     recordConfigMergeOrder?: boolean;
   };

--- a/packages/core/src/service/loggerService.ts
+++ b/packages/core/src/service/loggerService.ts
@@ -13,6 +13,8 @@ export class MidwayLoggerService extends ServiceFactory<ILogger> {
 
   private loggerFactory: LoggerFactory<any, any>;
 
+  private lazyLoggerConfigMap: Map<string, any> = new Map();
+
   constructor(
     readonly applicationContext: IMidwayContainer,
     readonly globalOptions = {}
@@ -32,7 +34,12 @@ export class MidwayLoggerService extends ServiceFactory<ILogger> {
   }
 
   protected createClient(config, name?: string) {
-    this.loggerFactory.createLogger(name, config);
+    if (!config.lazyLoad) {
+      this.loggerFactory.createLogger(name, config);
+    } else {
+      delete config['lazyLoad'];
+      this.lazyLoggerConfigMap.set(name, config);
+    }
   }
 
   getName() {
@@ -44,6 +51,16 @@ export class MidwayLoggerService extends ServiceFactory<ILogger> {
   }
 
   public getLogger(name: string) {
+    const logger = this.loggerFactory.getLogger(name);
+    if (logger) {
+      return logger;
+    }
+
+    if (this.lazyLoggerConfigMap.has(name)) {
+      // try to lazy init
+      this.createClient(this.lazyLoggerConfigMap.get(name), name);
+      this.lazyLoggerConfigMap.delete(name);
+    }
     return this.loggerFactory.getLogger(name);
   }
 

--- a/packages/core/src/service/loggerService.ts
+++ b/packages/core/src/service/loggerService.ts
@@ -21,9 +21,9 @@ export class MidwayLoggerService extends ServiceFactory<ILogger> {
   }
 
   @Init()
-  protected init() {
+  protected async init() {
     this.loggerFactory = this.globalOptions['loggerFactory'] || loggers;
-    this.initClients(this.configService.getConfiguration('midwayLogger'));
+    await this.initClients(this.configService.getConfiguration('midwayLogger'));
     // alias inject logger
     this.applicationContext?.registerObject(
       'logger',

--- a/packages/core/test/service/loggerService.test.ts
+++ b/packages/core/test/service/loggerService.test.ts
@@ -1,0 +1,75 @@
+import {
+  LoggerFactory,
+  MidwayConfigService,
+  MidwayContainer,
+  MidwayEnvironmentService,
+  MidwayInformationService,
+  MidwayLoggerService
+} from '../../src';
+
+class MockLoggerFactory extends LoggerFactory<any, any> {
+  maps = new Map();
+  close(loggerName: string | undefined) {
+    this.maps.clear();
+  }
+
+  createLogger(name: string, options: any): any {
+    this.maps.set(name, options);
+  }
+
+  getLogger(loggerName: string): any {
+    return this.maps.get(loggerName);
+  }
+
+  removeLogger(loggerName: string) {
+  }
+}
+
+describe('/test/service/loggerService.test.ts', () => {
+  it('should create loggerService', async () => {
+    const container = new MidwayContainer();
+    container.bindClass(MidwayEnvironmentService);
+    container.bindClass(MidwayInformationService);
+    container.bindClass(MidwayConfigService)
+    container.bindClass(MidwayLoggerService);
+
+    container.registerObject('baseDir', '');
+    container.registerObject('appDir', '');
+
+    const configService = await container.getAsync(MidwayConfigService);
+
+    configService.addObject({
+      midwayLogger: {
+        default: {
+          consoleLevel: 'DEBUG',
+        },
+        clients: {
+          customLoggerA: {
+            level: 'DEBUG',
+          },
+          customLoggerB: {
+            level: 'INFO',
+            lazyLoad: true,
+          },
+        }
+      }
+    });
+
+    configService.load();
+
+    const loggerService = await container.getAsync(MidwayLoggerService, [container, {
+      loggerFactory: new MockLoggerFactory(),
+    }]);
+
+    const customLoggerA = loggerService.getLogger('customLoggerA');
+    expect(customLoggerA).toBeDefined();
+
+    const loggerFactory = loggerService.getCurrentLoggerFactory();
+    const customLoggerB = loggerFactory.getLogger('customLoggerB');
+
+    expect(customLoggerB).toBeUndefined();
+
+    const customLogger = loggerService.getLogger('customLoggerB');
+    expect(customLogger).toBeDefined();
+  });
+});

--- a/packages/core/test/util.ts
+++ b/packages/core/test/util.ts
@@ -161,7 +161,7 @@ export async function createLightFramework(baseDir: string = '', globalConfig: a
     loggerFactory: new MidwayLoggerFactory(),
   });
 
-  return container.get(EmptyFramework);
+  return container.getAsync(EmptyFramework as any);
 }
 
 export async function createFramework(baseDir: string = '', globalConfig: any = {}): Promise<IMidwayContainer> {

--- a/packages/typeorm/src/configuration.ts
+++ b/packages/typeorm/src/configuration.ts
@@ -20,8 +20,9 @@ import { useContainer, EntityTarget } from 'typeorm';
         midwayLogger: {
           clients: {
             typeormLogger: {
-              fileLogName: 'typeorm.log',
+              fileLogName: 'midway-typeorm.log',
               enableError: false,
+              level: 'info',
             },
           },
         },

--- a/packages/typeorm/src/configuration.ts
+++ b/packages/typeorm/src/configuration.ts
@@ -17,6 +17,14 @@ import { useContainer, EntityTarget } from 'typeorm';
     {
       default: {
         typeorm: {},
+        midwayLogger: {
+          clients: {
+            typeormLogger: {
+              fileLogName: 'typeorm.log',
+              enableError: false,
+            },
+          },
+        },
       },
     },
   ],

--- a/packages/typeorm/src/configuration.ts
+++ b/packages/typeorm/src/configuration.ts
@@ -20,6 +20,7 @@ import { useContainer, EntityTarget } from 'typeorm';
         midwayLogger: {
           clients: {
             typeormLogger: {
+              lazyLoad: true,
               fileLogName: 'midway-typeorm.log',
               enableError: false,
               level: 'info',

--- a/packages/typeorm/src/dataSourceManager.ts
+++ b/packages/typeorm/src/dataSourceManager.ts
@@ -8,8 +8,10 @@ import {
   ApplicationContext,
   DataSourceManager,
   IMidwayContainer,
+  MidwayLoggerService,
 } from '@midwayjs/core';
 import { DataSource } from 'typeorm';
+import { TypeORMLogger } from './logger';
 
 @Provide()
 @Scope(ScopeEnum.Singleton)
@@ -22,6 +24,9 @@ export class TypeORMDataSourceManager extends DataSourceManager<DataSource> {
 
   @Inject()
   baseDir: string;
+
+  @Inject()
+  loggerService: MidwayLoggerService;
 
   @Init()
   async init() {
@@ -38,6 +43,11 @@ export class TypeORMDataSourceManager extends DataSourceManager<DataSource> {
   ): Promise<DataSource> {
     if (config['migrations']) {
       delete config['migrations'];
+    }
+    if (!config['logger']) {
+      config['logger'] = new TypeORMLogger(
+        this.loggerService.getLogger('typeormLogger')
+      );
     }
     const dataSource = new DataSource(config);
     await dataSource.initialize();

--- a/packages/typeorm/src/logger.ts
+++ b/packages/typeorm/src/logger.ts
@@ -1,0 +1,25 @@
+import { FileLogger, Logger, QueryRunner } from 'typeorm';
+
+export class TypeORMLogger extends FileLogger implements Logger {
+  constructor(readonly typeormLogger: any) {
+    super(true);
+  }
+
+  log(level: 'log' | 'info' | 'warn', message: any, queryRunner?: QueryRunner) {
+    switch (level) {
+      case 'log':
+        this.typeormLogger.debug(message);
+        break;
+      case 'info':
+        this.typeormLogger.info(message);
+        break;
+      case 'warn':
+        this.typeormLogger.warn(message);
+        break;
+    }
+  }
+
+  write(strings: string | string[]) {
+    this.typeormLogger.info(strings);
+  }
+}


### PR DESCRIPTION
- 1、当未配置 typeorm logger 时，默认添加了一个 typeormLogger，用于输出 sql 信息
- 2、loggerService 的配置，支持 lazyLoad，这样即使有配置，也会等到 getLogger 时才创建 logger