### PR TITLE
chore: change level for default logger level

### DIFF
--- a/packages/core/src/config/config.default.ts
+++ b/packages/core/src/config/config.default.ts
@@ -13,12 +13,13 @@ export default (appInfo: MidwayAppInfo): MidwayCoreDefaultConfig => {
     midwayLogger: {
       default: {
         dir: join(logRoot, 'logs', appInfo.name),
-        level: isDevelopment ? 'info' : 'warn',
+        level: 'info',
         consoleLevel: isDevelopment ? 'info' : 'warn',
         auditFileDir: '.audit',
       },
       clients: {
         coreLogger: {
+          level: isDevelopment ? 'info' : 'warn',
           fileLogName: 'midway-core.log',
         },
         appLogger: {


### PR DESCRIPTION
- 1、调整默认 logger level 为 info（原来开发环境 info，服务器 warn）
- 2、调整 coreLogger level，开发环境 info，服务器 warn