### PR TITLE
chore(core): add type DecoratorMetaData for custom decorator

### DIFF
--- a/packages/core/src/interface.ts
+++ b/packages/core/src/interface.ts
@@ -333,7 +333,7 @@ export interface DecoratorMetaData<T = any> {
   /** decorator key */
   key: string;
   metadata: T;
-  options: MethodDecoratorOptions;
+  options: MethodDecoratorOptions | undefined;
 }
 export interface MethodDecoratorOptions {
   impl?: boolean;

--- a/packages/core/src/interface.ts
+++ b/packages/core/src/interface.ts
@@ -328,6 +328,13 @@ export type PipeTransformFunction<T = any, R = any> = (value: T) => R;
 
 export type PipeUnionTransform<T = any, R = any> = PipeTransform<T, R> | (new (...args) => PipeTransform<T, R>) | PipeTransformFunction<T, R>;
 
+export interface DecoratorMetaData<T = any> {
+  propertyName: string
+  /** decorator key */
+  key: string
+  metadata: T
+  options: MethodDecoratorOptions
+}
 export interface MethodDecoratorOptions {
   impl?: boolean;
 }

--- a/packages/core/src/interface.ts
+++ b/packages/core/src/interface.ts
@@ -329,11 +329,11 @@ export type PipeTransformFunction<T = any, R = any> = (value: T) => R;
 export type PipeUnionTransform<T = any, R = any> = PipeTransform<T, R> | (new (...args) => PipeTransform<T, R>) | PipeTransformFunction<T, R>;
 
 export interface DecoratorMetaData<T = any> {
-  propertyName: string
+  propertyName: string;
   /** decorator key */
-  key: string
-  metadata: T
-  options: MethodDecoratorOptions
+  key: string;
+  metadata: T;
+  options: MethodDecoratorOptions;
 }
 export interface MethodDecoratorOptions {
   impl?: boolean;

--- a/packages/core/src/service/decoratorService.ts
+++ b/packages/core/src/service/decoratorService.ts
@@ -11,6 +11,7 @@ import {
   transformTypeFromTSDesign,
 } from '../decorator';
 import {
+  DecoratorMetaData,
   HandlerFunction,
   IMidwayContainer,
   MethodHandlerFunction,
@@ -18,7 +19,6 @@ import {
   JoinPoint,
   ScopeEnum,
   ParamDecoratorOptions,
-  MethodDecoratorOptions,
   PipeUnionTransform,
   PipeTransform,
 } from '../interface';
@@ -48,12 +48,10 @@ export class MidwayDecoratorService {
     // add custom method decorator listener
     this.applicationContext.onBeforeBind(Clzz => {
       // find custom method decorator metadata, include method decorator information array
-      const methodDecoratorMetadataList: Array<{
-        propertyName: string;
-        key: string;
-        metadata: any;
-        options: MethodDecoratorOptions;
-      }> = getClassMetadata(INJECT_CUSTOM_METHOD, Clzz);
+      const methodDecoratorMetadataList: DecoratorMetaData[] = getClassMetadata(
+        INJECT_CUSTOM_METHOD,
+        Clzz
+      );
 
       if (methodDecoratorMetadataList) {
         // loop it, save this order for decorator run


### PR DESCRIPTION
增加一个类型 `DecoratorMetaData`。
自己项目就不用重复定义了，也避免 metadata 存储类型变化导致的关联问题