### PR TITLE
fix: repair the impact of JSONP on normal requests(#2692)

### DIFF
--- a/packages/cross-domain/src/jsonp.ts
+++ b/packages/cross-domain/src/jsonp.ts
@@ -12,28 +12,31 @@ export class JSONPService {
   res;
 
   jsonp(body: any, config?: JSONPOptions) {
-    this.ctx.type = 'js';
-    // https://developer.mozilla.org/zh-CN/docs/Web/HTTP/Headers/X-Content-Type-Options
-    if (this.ctx.set) {
-      this.ctx.set('x-content-type-options', 'nosniff');
-    } else if (this.res.set) {
-      this.res.set('x-content-type-options', 'nosniff');
-    }
-
     const { callback, limit } = Object.assign({}, this.jsonpConfig, config);
+    const name = this.ctx.query[callback] || this.ctx.query['callback'];
+    if (name) {
+      this.ctx.type = 'js';
+      // https://developer.mozilla.org/zh-CN/docs/Web/HTTP/Headers/X-Content-Type-Options
+      if (this.ctx.set) {
+        this.ctx.set('x-content-type-options', 'nosniff');
+      } else if (this.res.set) {
+        this.res.set('x-content-type-options', 'nosniff');
+      }
 
-    // Only allow "[","]","a-zA-Z0123456789_", "$" and "." characters.
-    let cb = (this.ctx.query[callback] || 'callback').replace(
-      /[^[\]\w$.]+/g,
-      ''
-    );
+      // Only allow "[","]","a-zA-Z0123456789_", "$" and "." characters.
+      let cb = (this.ctx.query[callback] || 'callback').replace(
+        /[^[\]\w$.]+/g,
+        ''
+      );
 
-    if (cb.length > limit) {
-      cb = cb.substring(0, limit);
+      if (cb.length > limit) {
+        cb = cb.substring(0, limit);
+      }
+
+      const str = JSON.stringify(body === undefined ? null : body);
+      // protect from jsonp xss
+      return `/**/ typeof ${cb} === 'function' && ${cb}(${str});`;
     }
-
-    const str = JSON.stringify(body === undefined ? null : body);
-    // protect from jsonp xss
-    return `/**/ typeof ${cb} === 'function' && ${cb}(${str});`;
+    return body;
   }
 }

--- a/packages/cross-domain/test/express.test.ts
+++ b/packages/cross-domain/test/express.test.ts
@@ -42,7 +42,7 @@ describe('test/express.test.ts', function () {
       .expect(res => {
         assert(!res.headers['access-control-allow-origin']);
       })
-      .expect(200)
+      .expect(200);
   });
 
   it('jsonp callback', async () => {
@@ -51,6 +51,11 @@ describe('test/express.test.ts', function () {
       .post('/jsonp?callback=fn')
       .expect(200)
       .expect('x-content-type-options', 'nosniff')
-      .expect(`/**/ typeof callback === 'function' && callback({"test":123});`)
+      .expect(`/**/ typeof callback === 'function' && callback({"test":123});`);
+  });
+
+  it('jsonp callback ignore', async () => {
+    const request = await createHttpRequest(app);
+    await request.post('/jsonp').expect(200).expect({ test: 123 });
   });
 });

--- a/packages/cross-domain/test/koa.test.ts
+++ b/packages/cross-domain/test/koa.test.ts
@@ -8,7 +8,7 @@ describe('test/koa.test.ts', function () {
     try {
       app = await createApp(appDir);
     } catch (e) {
-      console.log("e", e);
+      console.log('e', e);
     }
   });
 
@@ -49,14 +49,17 @@ describe('test/koa.test.ts', function () {
       .expect(200);
   });
 
-
   it('jsonp callback', async () => {
     const request = await createHttpRequest(app);
     await request
       .post('/jsonp?callback=fn')
       .expect(200)
       .expect('x-content-type-options', 'nosniff')
-      .expect(`/**/ typeof callback === 'function' && callback({"test":123});`)
+      .expect(`/**/ typeof callback === 'function' && callback({"test":123});`);
+  });
 
+  it('jsonp callback ignore', async () => {
+    const request = await createHttpRequest(app);
+    await request.post('/jsonp').expect(200).expect({ test: 123 });
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->
```
import { JSONPMiddleware } from '@midwayjs/cross-domain';
Impact scope: JSONPMiddleware
```

##### Description of change
<!-- Provide a description of the change below this comment. -->
Determine if a callback exists before performing JSONP content conversion, return original content if it doesn't exist 