### PR TITLE
feat: support match and ignore property with array

### DIFF
--- a/packages/core/src/interface.ts
+++ b/packages/core/src/interface.ts
@@ -754,13 +754,15 @@ export type IMidwayContext<FrameworkContext = unknown> = Context &
   FrameworkContext;
 export type NextFunction = () => Promise<any>;
 
+export type IgnoreMatcher<CTX> = string | RegExp | ((ctx: CTX) => boolean);
+
 /**
  * Common middleware definition
  */
 export interface IMiddleware<CTX, R, N = unknown> {
   resolve: (app: IMidwayApplication) => FunctionMiddleware<CTX, R, N> | Promise<FunctionMiddleware<CTX, R, N>>;
-  match?: (ctx: CTX) => boolean;
-  ignore?: (ctx: CTX) => boolean;
+  match?: IgnoreMatcher<CTX> | IgnoreMatcher<CTX> [];
+  ignore?: IgnoreMatcher<CTX> | IgnoreMatcher<CTX> [];
 }
 export type FunctionMiddleware<CTX, R, N = unknown> = N extends true
   ? (req: CTX, res: R, next: N) => any

--- a/packages/core/src/service/middlewareService.ts
+++ b/packages/core/src/service/middlewareService.ts
@@ -57,9 +57,11 @@ export class MidwayMiddlewareService<T, R, N = unknown> {
           } else {
             // wrap ignore and match
             const mw = fn;
+
             const match = pathMatching({
-              match: classMiddleware.match?.bind(classMiddleware),
-              ignore: classMiddleware.ignore?.bind(classMiddleware),
+              match: classMiddleware.match,
+              ignore: classMiddleware.ignore,
+              thisResolver: classMiddleware,
             });
             (fn as any) = (ctx, next, options) => {
               if (!match(ctx)) return next();


### PR DESCRIPTION
支持中间件的 match /ignore 属性写为字符串，正则，函数回调形式，以及支持以上属性的数组和动态添加形式。

字符串

```ts
class TestMiddleware {
  // ...
  match = '/test';
}
```

正则

```ts
class TestMiddleware {
  // ...
  match = /^\/test/;
}
```

方法

```ts
class TestMiddleware {
  // ...
  match(ctx) {
    // ...
  }
}
```

混合

```ts
class TestMiddleware {
  // ...
  match = ['/123', /^\/test/, (ctx) => {})]
}
```

动态（一般用于组件中定义中间件，需要用户配置合并的情况）

```ts
class TestMiddleware {

  @Config('test.match')
  testMatchConfig: [];

  match = [];

  @Init()
  async init() {
     this.match.push('/123');
     this.match.push(...this.tesetMatchConfig);
  }
}
```
