### PR TITLE
chore(core): add boolean property JoinPoint['proceedIsAsyncFunction']

### DIFF
--- a/packages/core/src/interface.ts
+++ b/packages/core/src/interface.ts
@@ -279,7 +279,7 @@ export interface JoinPoint {
   target: any;
   args: any[];
   proceed?(...args: any[]): any;
-  proceedIsAsyncFunction?: boolean | undefined;
+  proceedIsAsyncFunction?: boolean;
 }
 
 export interface AspectMetadata {

--- a/packages/core/src/interface.ts
+++ b/packages/core/src/interface.ts
@@ -279,6 +279,7 @@ export interface JoinPoint {
   target: any;
   args: any[];
   proceed?(...args: any[]): any;
+  proceedIsAsyncFunction?: boolean | undefined;
 }
 
 export interface AspectMetadata {

--- a/packages/core/src/service/aspectService.ts
+++ b/packages/core/src/service/aspectService.ts
@@ -97,6 +97,7 @@ export class MidwayAspectService {
           target: this,
           args: args,
           proceed: newProceed,
+          proceedIsAsyncFunction: true,
         } as JoinPoint;
 
         if (typeof aspectObject === 'function') {
@@ -140,6 +141,7 @@ export class MidwayAspectService {
           target: this,
           args: args,
           proceed: newProceed,
+          proceedIsAsyncFunction: false,
         } as JoinPoint;
 
         if (typeof aspectObject === 'function') {

--- a/packages/core/test/service/aspectService.test.ts
+++ b/packages/core/test/service/aspectService.test.ts
@@ -1,3 +1,5 @@
+import * as assert from 'assert';
+
 import { MidwayAspectService, MidwayContainer } from '../../src';
 
 describe('/test/service/aspectService.test.ts', () => {
@@ -31,6 +33,7 @@ describe('/test/service/aspectService.test.ts', () => {
     aspectService.interceptPrototypeMethod(A, 'invokeAsyncMethod', {
       around: async (joinPoint) => {
         console.log('before1');
+        assert(joinPoint.proceedIsAsyncFunction === true, 'proceedIsAsyncFunction should be true')
         const result = await joinPoint.proceed(...joinPoint.args);
         console.log('after1');
         return result + ' midway 2.0';
@@ -40,6 +43,7 @@ describe('/test/service/aspectService.test.ts', () => {
     aspectService.interceptPrototypeMethod(A, 'invokeAsyncMethod', {
       around: async (joinPoint) => {
         console.log('before2');
+        assert(joinPoint.proceedIsAsyncFunction === true, 'proceedIsAsyncFunction should be true')
         const result = await joinPoint.proceed(...joinPoint.args);
         console.log('after2');
         return result + ' midway 3.0';
@@ -49,6 +53,7 @@ describe('/test/service/aspectService.test.ts', () => {
     // test before
     aspectService.interceptPrototypeMethod(A, 'invokeMethod', {
       before: (joinPoint) => {
+        assert(joinPoint.proceedIsAsyncFunction === false, 'proceedIsAsyncFunction should be false')
         joinPoint.args = [3, 4];
       }
     });
@@ -56,6 +61,7 @@ describe('/test/service/aspectService.test.ts', () => {
     let err;
     aspectService.interceptPrototypeMethod(A, 'gotError', {
       afterThrow: (joinPoint, error) => {
+        assert(joinPoint.proceedIsAsyncFunction === false, 'proceedIsAsyncFunction should be false')
         err = error;
       }
     });


### PR DESCRIPTION
indicate aop proceed whether AsyncFunction or not

判断 经过aop 包裹后的方法是否异步函数比较麻烦，添加一个属性来表明方法异步性