### PR TITLE
fix(core): declaration of type ILifeCycle

### DIFF
--- a/packages/core/src/interface.ts
+++ b/packages/core/src/interface.ts
@@ -418,7 +418,28 @@ export type Writable<T> = {
  * Lifecycle Definition
  * 生命周期定义
  */
-export interface ILifeCycle extends Partial<IObjectLifeCycle> {
+export interface ILifeCycle {
+  onBeforeBind?(
+    Clzz: any,
+    options: ObjectBeforeBindOptions
+  ): Promise<void>;
+  onBeforeObjectCreated?(
+    Clzz: any,
+    options: ObjectBeforeCreatedOptions
+  ): Promise<void>;
+  onObjectCreated?<T>(
+    ins: T,
+    options: ObjectCreatedOptions<T>
+  ): Promise<void>;
+  onObjectInit?(
+    ins: any,
+    options: ObjectInitOptions
+  ): Promise<void>;
+  onBeforeObjectDestroy?(
+    ins: any,
+    options: ObjectBeforeDestroyOptions
+  ): Promise<void>;
+
   onConfigLoad?(
     container: IMidwayContainer,
     mainApp?: IMidwayApplication


### PR DESCRIPTION
Do not extends Partial<IObjectLifeCycle>, define methods with correct parameter instead:
- onBeforeBind
- onBeforeObjectCreated
- onObjectCreated
- onObjectInit
- onBeforeObjectDestroy

`IObjectLifeCycle` 定义方法的形参类型并非实际 `ILifeCycle` 运行时相应方法的真正入参类型
