### PR TITLE
feat: support app enable ssl custom certificate in dev mode

### DIFF
--- a/packages-legacy/serverless-app/src/framework.ts
+++ b/packages-legacy/serverless-app/src/framework.ts
@@ -4,6 +4,7 @@ import {
   IMidwayContext,
   MidwayCommonError,
   MidwayFrameworkType,
+  PathFileUtil,
 } from '@midwayjs/core';
 import { Application, IServerlessAppOptions } from './interface';
 import { Server } from 'net';
@@ -304,11 +305,26 @@ export class ServerlessAppFramework extends BaseFramework<
       process.env.MIDWAY_HTTP_PORT ?? this.configurationOptions.port;
     if (customPort) {
       if (this.configurationOptions.ssl) {
+        let key = readFileSync(join(__dirname, '../ssl/ssl.key'), 'utf8');
+        let cert = readFileSync(join(__dirname, '../ssl/ssl.pem'), 'utf8');
+
+        if (
+          this.configurationOptions.https &&
+          this.configurationOptions.https.key &&
+          this.configurationOptions.https.cert
+        ) {
+          key = PathFileUtil.getFileContentSync(
+            this.configurationOptions.https.key,
+            'utf8'
+          );
+          cert = PathFileUtil.getFileContentSync(
+            this.configurationOptions.https.cert,
+            'utf8'
+          );
+        }
+
         this.server = require('https').createServer(
-          {
-            key: readFileSync(join(__dirname, '../ssl/ssl.key'), 'utf8'),
-            cert: readFileSync(join(__dirname, '../ssl/ssl.pem'), 'utf8'),
-          },
+          { key, cert },
           this.httpServerApp
         );
       } else {

--- a/packages-legacy/serverless-app/src/interface.ts
+++ b/packages-legacy/serverless-app/src/interface.ts
@@ -11,6 +11,7 @@ export interface Application extends FaaSApplication {
 export interface IServerlessAppOptions extends IConfigurationOptions {
   port?: string | number;
   ssl?: boolean;
+  https?: { key: string; cert: string };
   initContext?: any;
   bodyParserLimit?: string;
 }


### PR DESCRIPTION
在 ```midway-bin dev``` 下，应用在本地开发时也可以快速使用 ```--ssl --https.key=./ssl/key.pem --https.cert=./ssl/cert.pem ```指定私钥及证书文件来启动 https 服务 #2900 