### PR TITLE
fix: bootstrap close entry

### DIFF
--- a/packages/mock/src/creator.ts
+++ b/packages/mock/src/creator.ts
@@ -577,10 +577,15 @@ export async function createLightApp(
 export async function createBootstrap(
   entryFile: string,
   options: MockAppConfigurationOptions = {}
-): Promise<BootstrapAppStarter> {
+): Promise<{ close: (...args) => void }> {
   if (safeRequire('@midwayjs/faas')) {
     options.entryFile = entryFile;
-    return createFunctionApp(process.cwd(), options);
+    const app = await createFunctionApp(process.cwd(), options);
+    return {
+      close: async () => {
+        return close(app);
+      },
+    };
   } else {
     await create(undefined, {
       entryFile,

--- a/packages/mock/src/creator.ts
+++ b/packages/mock/src/creator.ts
@@ -228,7 +228,7 @@ export async function close(
   if (!app) return;
   if (
     app instanceof BootstrapAppStarter ||
-    typeof app['close'] === 'function'
+    (typeof app['close'] === 'function' && !app['getConfig'])
   ) {
     await app['close'](options);
   } else {

--- a/packages/mock/src/interface.ts
+++ b/packages/mock/src/interface.ts
@@ -1,4 +1,4 @@
-import { IMidwayBootstrapOptions } from '@midwayjs/core';
+import { IMidwayApplication, IMidwayBootstrapOptions, MidwayFrameworkType } from '@midwayjs/core';
 
 export interface MockAppConfigurationOptions extends IMidwayBootstrapOptions {
   cleanLogsDir?: boolean;
@@ -10,3 +10,8 @@ export interface MockAppConfigurationOptions extends IMidwayBootstrapOptions {
 export type ComponentModule = {
   Configuration: new () => any;
 };
+
+export interface IBootstrapAppStarter {
+  getApp?(type: MidwayFrameworkType | string): IMidwayApplication<any>;
+  close(options?: { sleep?: number }): Promise<void>;
+}


### PR DESCRIPTION
现在 mock 的 close 方法支持 bootstrap 和普通 app 两种，统一了 api