### PR TITLE
feat(code-dye): outputType-html support show not end async call

### DIFF
--- a/packages/code-dye/src/html.ts
+++ b/packages/code-dye/src/html.ts
@@ -1,5 +1,25 @@
+function getInfoResult(info) {
+  if (info.end) {
+    return `<div class="infoBtn">返回值<div class="infoCard"><pre>${JSON.stringify(
+      info.end.result,
+      null,
+      2
+    )}</pre></div></div>`;
+  } else {
+    return '<div class="infoBtn">未结束</div>';
+  }
+}
+
+function getInfoTimeUse(info) {
+  if (info.end) {
+    return info.end.time - info.start.time;
+  } else {
+    return new Date().getTime() - info.start.time;
+  }
+}
+
 export const foreach = (info, start, pi, level) => {
-  const timeUse = info.end.time - info.start.time;
+  const timeUse = getInfoTimeUse(info);
   const timeDiff = info.start.time - start;
   const paths = info.paths.filter(path => {
     return !path.startsWith('/');
@@ -14,19 +34,15 @@ export const foreach = (info, start, pi, level) => {
             null,
             2
           )}</pre></div></div>
-          <div class="infoBtn">返回值<div class="infoCard"><pre>${JSON.stringify(
-            info.end.result,
-            null,
-            2
-          )}</pre></div></div>
+          ${getInfoResult(info)}
         </div>
       </div>
       <div class="timeContainer">
-        <div class="time" style="width:${timeUse / pi}px;left: ${
-    timeDiff / pi
-  }px"><div class="timeValue">${timeUse} ms</div></div>
+        <div class="time ${info.end ? 'end' : 'not-end'}" style="width:${
+    timeUse / pi
+  }px;left: ${timeDiff / pi}px"><div class="timeValue">${timeUse} ms</div></div>
       </div>
-      
+
     </div>
     <div class="child">
       <div class="childLine" style="left: ${(level - 1) * 24 + 12}px"></div>
@@ -39,12 +55,27 @@ export const foreach = (info, start, pi, level) => {
   `;
 };
 
-export const toHTML = info => {
-  const timeDiff = info.end.time - info.start.time;
+export const callChain = call => {
+  const timeDiff = call.end.time - call.start.time;
   let pi = timeDiff / 600;
   if (pi < 1) {
     pi = 1;
   }
+  return `
+  <div>
+    <div>调用链路总耗时 ${timeDiff}ms<div>
+    <div>调用结果:<br /><pre>${JSON.stringify(
+      call.end.result,
+      null,
+      2
+    )}</pre></div>
+    <hr />
+    <div style="padding: 12px;">${foreach(call, call.start.time, pi, 1)}</div>
+  </div>
+  `;
+};
+
+export const toHTML = info => {
   return `
   <title>Midway CodeDye</title>
   <meta charset="utf-8" />
@@ -89,7 +120,10 @@ export const toHTML = info => {
     background-color: #66c;
     border-radius: 3px;
   }
-  
+  .time.not-end {
+    background-color: #ddd;
+  }
+
   .timeValue {
     position: absolute;
     line-height: 16px;
@@ -131,15 +165,7 @@ export const toHTML = info => {
   }
   </style>
   <h1>Midway CodeDye</h1><hr />
-  <div>调用链路总耗时 ${timeDiff}ms<div>
-  <div>调用结果:<br /><pre>${JSON.stringify(
-    info.end.result,
-    null,
-    2
-  )}</pre></div>
-  <hr />
-  <div style="padding: 12px;">
-  ${foreach(info, info.start.time, pi, 1)}</div>
+  ${info.map(call => callChain(call)).join('')}
   <hr /><a href="https://www.midwayjs.org/">Powered by Midway.js</a>
   `;
 };

--- a/packages/code-dye/src/middleware.ts
+++ b/packages/code-dye/src/middleware.ts
@@ -63,7 +63,7 @@ export class CodeDyeMW {
         console.log(reqInfoJSON);
       } else if (outputType === 'html') {
         response.set('Content-Type', 'text/html');
-        return toHTML(reqInfo.call[0]);
+        return toHTML(reqInfo.call);
       } else if (outputType === 'json') {
         return reqInfoJSON;
       }

--- a/packages/code-dye/test/fixtures/koa/src/index.ts
+++ b/packages/code-dye/test/fixtures/koa/src/index.ts
@@ -1,24 +1,36 @@
 import { Controller, Get } from '@midwayjs/core';
+
 @Controller('/')
 export class HomeController {
-
   @Get('/*')
   async test() {
+    this.log('begin');
     await new Promise(resolve => {
-      setTimeout(resolve, 1234)
-    })
-    return { test: 123, name: await this.name(), first: await this.firstName() }
+      setTimeout(resolve, 1234);
+    });
+    this.log('end');
+    return {
+      test: 123,
+      name: await this.name(),
+      first: await this.firstName(),
+    };
   }
 
-
   async name() {
-    return 'name'
+    return 'name';
   }
 
   async firstName() {
     await new Promise(resolve => {
-      setTimeout(resolve, 1234)
-    })
-    return 'test'
+      setTimeout(resolve, 1234);
+    });
+    return 'test';
+  }
+
+  async log(content) {
+    await new Promise(resolve => {
+      setTimeout(resolve, 2345);
+    });
+    return 'log ' + content;
   }
 }

--- a/packages/code-dye/test/koa.test.ts
+++ b/packages/code-dye/test/koa.test.ts
@@ -8,7 +8,7 @@ describe('test/koa.test.ts', function () {
     try {
       app = await createApp(appDir);
     } catch (e) {
-      console.log("e", e);
+      console.log('e', e);
     }
   });
 
@@ -18,9 +18,15 @@ describe('test/koa.test.ts', function () {
 
   it('json', async () => {
     const request = await createHttpRequest(app);
-    const res = await request.get('/test?codeDye=json').then(res => res.text)
+    const res = await request.get('/test?codeDye=json').then(res => res.text);
     const json = JSON.parse(res);
-    assert(json.call[0].call[1].paths[2] === '[async func] firstName')
-    assert(json.call[0].call[1].end.result === 'test')
+    assert(json.call[0].call[3].paths[2] === '[async func] firstName');
+    assert(json.call[0].call[3].end.result === 'test');
+  });
+
+  it('html', async () => {
+    const request = await createHttpRequest(app);
+    const res = await request.get('/test?codeDye=html').then(res => res.text);
+    assert(res && res.length > 0);
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
codeDye在使用html模式输出的时候，如果一个异步函数未执行完成，在渲染html的时候会因找不到call.end而报错。

本次修改：
1. 判断了end是否存在，如果不存在则在函数返回值位置展示一个【未结束】的说明。
2. 将只输出第一个call修改为遍历输出所有call的callchain图像

测试用例截图：
![image](https://github.com/midwayjs/midway/assets/3841747/3e32ba99-5e79-41ec-8084-72495c2521b7)

