### PR TITLE
fix: makeHttpRequest failed when post with custom headers

### DIFF
--- a/packages/core/src/util/httpclient.ts
+++ b/packages/core/src/util/httpclient.ts
@@ -50,12 +50,13 @@ export async function makeHttpRequest<ResType>(
     dataType,
     method,
     timeout = 5000,
+    headers: customHeaders,
     ...otherOptions
   } = options;
 
   const headers = {
     Accept: mimeMap[dataType] || mimeMap.octet,
-    ...options.headers,
+    ...customHeaders,
   };
 
   let data;

--- a/packages/core/test/util/httpclient.test.ts
+++ b/packages/core/test/util/httpclient.test.ts
@@ -62,6 +62,20 @@ describe('/test/util/httpclient.test.ts', function () {
     manager.close();
   });
 
+  it('should test base http request with post and headers', async () => {
+    const manager = await createHttpServer();
+    const httpclient = new HttpClient();
+    const result = await httpclient.request(`http://127.1:${manager.getPort()}/`, {
+      method: 'POST',
+      headers: {},
+      data: {},
+      dataType: 'json',
+      contentType: 'json',
+    });
+    expect(result.data.headers['content-type']).toEqual('application/json');
+    manager.close();
+  });
+
   it('should test base http request and timeout', async () => {
     const manager = await createHttpServer({
       timeout: 1000,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
如果 makeHttpRequest 发送post 请求时，包含自定义header, 比如
```js
makeHttpRequest(url, {
  method: 'POST',
  header: { token },
})
```
这样计算得来的 Content-Type, Content-Length 等 header 都将失败，导致 body 数据无法正常发送

修复：将 headers 从 otherOptions 中拿出