### PR TITLE
feat: add InjectEntityManager decorator for MikroORM and upgrade document

### DIFF
--- a/packages/mikro/src/configuration.ts
+++ b/packages/mikro/src/configuration.ts
@@ -9,7 +9,11 @@ import {
   Init,
   Inject,
 } from '@midwayjs/core';
-import { DATA_SOURCE_KEY, ENTITY_MODEL_KEY } from './decorator';
+import {
+  DATA_SOURCE_KEY,
+  ENTITY_MANAGER_KEY,
+  ENTITY_MODEL_KEY,
+} from './decorator';
 import { MikroDataSourceManager } from './dataSourceManager';
 import { EntityName, RequestContext } from '@mikro-orm/core';
 
@@ -58,6 +62,20 @@ export class MikroConfiguration implements ILifeCycle {
                 this.dataSourceManager.getDefaultDataSourceName()
             )
             .em.getRepository(meta.modelKey);
+        }
+      }
+    );
+
+    this.decoratorService.registerPropertyHandler(
+      ENTITY_MANAGER_KEY,
+      (propertyName, meta: { connectionName?: string }) => {
+        if (RequestContext.getEntityManager()) {
+          return RequestContext.getEntityManager();
+        } else {
+          return this.dataSourceManager.getDataSource(
+            meta.connectionName ||
+              this.dataSourceManager.getDefaultDataSourceName()
+          ).em;
         }
       }
     );

--- a/packages/mikro/src/decorator.ts
+++ b/packages/mikro/src/decorator.ts
@@ -2,6 +2,7 @@ import { createCustomPropertyDecorator } from '@midwayjs/core';
 import { EntityName } from '@mikro-orm/core';
 
 export const ENTITY_MODEL_KEY = 'mikro:entity_model_key';
+export const ENTITY_MANAGER_KEY = 'mikro:entity_manager_key';
 export const DATA_SOURCE_KEY = 'mikro:data_source_key';
 
 export function InjectRepository(
@@ -10,6 +11,12 @@ export function InjectRepository(
 ) {
   return createCustomPropertyDecorator(ENTITY_MODEL_KEY, {
     modelKey,
+    connectionName,
+  });
+}
+
+export function InjectEntityManager(connectionName?: string) {
+  return createCustomPropertyDecorator(ENTITY_MANAGER_KEY, {
     connectionName,
   });
 }

--- a/packages/mikro/test/fixtures/base-fn-origin/src/configuration.ts
+++ b/packages/mikro/test/fixtures/base-fn-origin/src/configuration.ts
@@ -9,8 +9,8 @@ import {
 } from '../../../../src';
 import { IMidwayApplication } from '@midwayjs/core';
 import { Book } from './entity';
-import { EntityManager, EntityRepository, QueryOrder } from '@mikro-orm/core';
-import { MikroORM, IDatabaseDriver, Connection } from '@mikro-orm/core';
+import { EntityManager, EntityRepository } from '@mikro-orm/sqlite';
+import { MikroORM, IDatabaseDriver, Connection, QueryOrder } from '@mikro-orm/core';
 
 @Configuration({
   imports: [mikro],
@@ -39,9 +39,8 @@ export class ContainerConfiguration {
     expect(this.defaultDataSource).toBeDefined();
     expect(this.defaultDataSource).toEqual(this.namedDataSource);
 
-    const orm = this.mikroDataSourceManager.getDataSource('default');
-    const connection = orm.em.getConnection();
-    await (connection as any).loadFile(join(__dirname, '../sqlite-schema.sql'));
+    const connection = this.em.getConnection();
+    await connection.loadFile(join(__dirname, '../sqlite-schema.sql'));
 
     const book = this.bookRepository.create({
       title: 'b1',


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `npm test` passes
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->
mikro

##### Description of change
<!-- Provide a description of the change below this comment. -->
由于MikroORM从5.7开始，开始废弃`Repository`上的`persist`, `flush`等接口，[v6计划彻底删除这些接口](https://github.com/mikro-orm/mikro-orm/discussions/3989)，导致要保存到数据库的时候要这样写：

```typescript
class BookService {
  @InjectRepository(Book)
  bookRepository: EntityRepository<Book>;

  async create() {
    const book = new Book(/** 初始化 **/);
    await this.bookRepository.getEntityManager().persistAndFlush(book);
  }
}
```

增加`InjectEntityManager`直接注入`EntityManager`后，写法如下：

```typescript
class BookService {
  @InjectEntityManager()
  em: EntityManager;

  async create() {
    const book = new Book(/** 初始化 **/);
    await this.em.persistAndFlush(book);
  }
}
```
