### PR TITLE
feat: expose more APIs from axios

### DIFF
--- a/packages/axios/src/interface.ts
+++ b/packages/axios/src/interface.ts
@@ -10,38 +10,53 @@ export interface AxiosHttpService {
     response: AxiosInterceptorManager<AxiosResponse>;
   };
   getUri(config?: AxiosRequestConfig): string;
-  request<T = any, R = AxiosResponse<T>>(
-    config: AxiosRequestConfig
+  request<T = any, R = AxiosResponse<T>, D = any>(
+    config: AxiosRequestConfig<D>
   ): Promise<R>;
-  get<T = any, R = AxiosResponse<T>>(
+  get<T = any, R = AxiosResponse<T>, D = any>(
     url: string,
-    config?: AxiosRequestConfig
+    config?: AxiosRequestConfig<D>
   ): Promise<R>;
-  delete<T = any, R = AxiosResponse<T>>(
+  delete<T = any, R = AxiosResponse<T>, D = any>(
     url: string,
-    config?: AxiosRequestConfig
+    config?: AxiosRequestConfig<D>
   ): Promise<R>;
-  head<T = any, R = AxiosResponse<T>>(
+  head<T = any, R = AxiosResponse<T>, D = any>(
     url: string,
-    config?: AxiosRequestConfig
+    config?: AxiosRequestConfig<D>
   ): Promise<R>;
-  options<T = any, R = AxiosResponse<T>>(
+  options<T = any, R = AxiosResponse<T>, D = any>(
     url: string,
-    config?: AxiosRequestConfig
+    config?: AxiosRequestConfig<D>
   ): Promise<R>;
-  post<T = any, R = AxiosResponse<T>>(
+  post<T = any, R = AxiosResponse<T>, D = any>(
     url: string,
-    data?: any,
-    config?: AxiosRequestConfig
+    data?: D,
+    config?: AxiosRequestConfig<D>
   ): Promise<R>;
-  put<T = any, R = AxiosResponse<T>>(
+  put<T = any, R = AxiosResponse<T>, D = any>(
     url: string,
-    data?: any,
-    config?: AxiosRequestConfig
+    data?: D,
+    config?: AxiosRequestConfig<D>
   ): Promise<R>;
-  patch<T = any, R = AxiosResponse<T>>(
+  patch<T = any, R = AxiosResponse<T>, D = any>(
     url: string,
-    data?: any,
-    config?: AxiosRequestConfig
+    data?: D,
+    config?: AxiosRequestConfig<D>
+  ): Promise<R>;
+  postForm<T = any, R = AxiosResponse<T>, D = any>(
+    url: string,
+    data?: D,
+    config?: AxiosRequestConfig<D>
+  ): Promise<R>;
+  putForm<T = any, R = AxiosResponse<T>, D = any>(
+    url: string,
+    data?: D,
+    config?: AxiosRequestConfig<D>
+  ): Promise<R>;
+  patchForm<T = any, R = AxiosResponse<T>, D = any>(
+    url: string,
+    data?: D,
+    config?: AxiosRequestConfig<D>
   ): Promise<R>;
 }

--- a/packages/axios/src/interface.ts
+++ b/packages/axios/src/interface.ts
@@ -2,9 +2,11 @@ import {
   AxiosRequestConfig,
   AxiosResponse,
   AxiosInterceptorManager,
+  AxiosDefaults,
 } from 'axios';
 
 export interface AxiosHttpService {
+  defaults: AxiosDefaults;
   interceptors: {
     request: AxiosInterceptorManager<AxiosRequestConfig>;
     response: AxiosInterceptorManager<AxiosResponse>;

--- a/packages/axios/src/interface.ts
+++ b/packages/axios/src/interface.ts
@@ -1,9 +1,12 @@
-import {
+import type {
   AxiosRequestConfig,
   AxiosResponse,
   AxiosInterceptorManager,
   AxiosDefaults,
 } from 'axios';
+import axios from 'axios';
+
+export { axios };
 
 export interface AxiosHttpService {
   defaults: AxiosDefaults;

--- a/packages/axios/src/serviceManager.ts
+++ b/packages/axios/src/serviceManager.ts
@@ -57,6 +57,10 @@ export class HttpService implements AxiosHttpService {
   @Inject()
   private serviceFactory: HttpServiceFactory;
 
+  get defaults() {
+    return this.instance.defaults;
+  }
+
   get interceptors() {
     return this.instance.interceptors;
   }

--- a/packages/axios/src/serviceManager.ts
+++ b/packages/axios/src/serviceManager.ts
@@ -1,5 +1,10 @@
-import type { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
-import * as axios from 'axios';
+import type {
+  AxiosInstance,
+  AxiosRequestConfig,
+  AxiosResponse,
+  CreateAxiosDefaults,
+} from 'axios';
+import axios from 'axios';
 import {
   Config,
   Init,
@@ -33,10 +38,10 @@ export class HttpServiceFactory extends ServiceFactory<AxiosInstance> {
   }
 
   protected async createClient(
-    config: AxiosRequestConfig,
+    config: CreateAxiosDefaults,
     clientName: any
   ): Promise<AxiosInstance> {
-    return (axios as any).create(config);
+    return axios.create(config);
   }
 
   getName(): string {
@@ -70,61 +75,85 @@ export class HttpService implements AxiosHttpService {
     return this.instance.getUri(config);
   }
 
-  request<T = any, R = AxiosResponse<T>>(
-    config: AxiosRequestConfig
+  request<T = any, R = AxiosResponse<T>, D = any>(
+    config: AxiosRequestConfig<D>
   ): Promise<R> {
     return this.instance.request(config);
   }
 
-  get<T = any, R = AxiosResponse<T>>(
+  get<T = any, R = AxiosResponse<T>, D = any>(
     url: string,
-    config?: AxiosRequestConfig
+    config?: AxiosRequestConfig<D>
   ): Promise<R> {
     return this.instance.get(url, config);
   }
 
-  delete<T = any, R = AxiosResponse<T>>(
+  delete<T = any, R = AxiosResponse<T>, D = any>(
     url: string,
-    config?: AxiosRequestConfig
+    config?: AxiosRequestConfig<D>
   ): Promise<R> {
     return this.instance.delete(url, config);
   }
 
-  head<T = any, R = AxiosResponse<T>>(
+  head<T = any, R = AxiosResponse<T>, D = any>(
     url: string,
-    config?: AxiosRequestConfig
+    config?: AxiosRequestConfig<D>
   ): Promise<R> {
     return this.instance.head(url, config);
   }
 
-  options<T = any, R = AxiosResponse<T>>(
+  options<T = any, R = AxiosResponse<T>, D = any>(
     url: string,
-    config?: AxiosRequestConfig
+    config?: AxiosRequestConfig<D>
   ): Promise<R> {
     return this.instance.options(url, config);
   }
 
-  post<T = any, R = AxiosResponse<T>>(
+  post<T = any, R = AxiosResponse<T>, D = any>(
     url: string,
-    data?: any,
-    config?: AxiosRequestConfig
+    data?: D,
+    config?: AxiosRequestConfig<D>
   ): Promise<R> {
     return this.instance.post(url, data, config);
   }
 
-  put<T = any, R = AxiosResponse<T>>(
+  put<T = any, R = AxiosResponse<T>, D = any>(
     url: string,
-    data?: any,
-    config?: AxiosRequestConfig
+    data?: D,
+    config?: AxiosRequestConfig<D>
   ): Promise<R> {
     return this.instance.put(url, data, config);
   }
 
-  patch<T = any, R = AxiosResponse<T>>(
+  patch<T = any, R = AxiosResponse<T>, D = any>(
     url: string,
-    data?: any,
-    config?: AxiosRequestConfig
+    data?: D,
+    config?: AxiosRequestConfig<D>
   ): Promise<R> {
     return this.instance.patch(url, data, config);
+  }
+
+  postForm<T = any, R = AxiosResponse<T>, D = any>(
+    url: string,
+    data?: D,
+    config?: AxiosRequestConfig<D>
+  ): Promise<R> {
+    return this.instance.postForm(url, data, config);
+  }
+
+  putForm<T = any, R = AxiosResponse<T>, D = any>(
+    url: string,
+    data?: D,
+    config?: AxiosRequestConfig<D>
+  ): Promise<R> {
+    return this.instance.putForm(url, data, config);
+  }
+
+  patchForm<T = any, R = AxiosResponse<T>, D = any>(
+    url: string,
+    data?: D,
+    config?: AxiosRequestConfig<D>
+  ): Promise<R> {
+    return this.instance.patchForm(url, data, config);
   }
 }

--- a/packages/axios/test/index.test.ts
+++ b/packages/axios/test/index.test.ts
@@ -1,5 +1,5 @@
 import { join } from 'path';
-import { HttpService } from '../src';
+import { HttpService, axios } from '../src';
 import { createLightApp } from '@midwayjs/mock';
 import * as nock from 'nock';
 
@@ -39,7 +39,7 @@ describe('/test/index.test.ts', () => {
     expect(httpServiceWithRequest).toEqual(httpService);
   });
 
-  it('should test proxy method', function () {
+  it('should test proxy method', () => {
     const proxyMethods = [
       'getUri',
       'request',
@@ -50,11 +50,14 @@ describe('/test/index.test.ts', () => {
       'post',
       'put',
       'patch',
+      'postForm',
+      'putForm',
+      'patchForm',
     ];
 
     for (const method of proxyMethods) {
       const fn = jest
-        .spyOn(httpService['instance'], method)
+        .spyOn(httpService.instance, method)
         .mockImplementation(() => {
           return 'hello world';
         });
@@ -62,6 +65,11 @@ describe('/test/index.test.ts', () => {
       expect(fn).toHaveBeenCalled();
       jest.restoreAllMocks();
     }
+  });
+
+  it('should test defaults and intercepters', () => {
+    expect(httpService.defaults).toStrictEqual(axios.defaults);
+    expect(httpService.interceptors).toStrictEqual(axios.interceptors);
   });
 
   it('should test get method', async () => {

--- a/site/docs/extensions/axios.md
+++ b/site/docs/extensions/axios.md
@@ -242,6 +242,9 @@ axios.options(url[, config])
 axios.post(url[, data[, config]])
 axios.put(url[, data[, config]])
 axios.patch(url[, data[, config]])
+axios.postForm(url[, data[, config]])
+axios.putForm(url[, data[, config]])
+axios.patchForm(url[, data[, config]])
 ```
 
 
@@ -413,3 +416,22 @@ export class MainConfiguration {
 }
 ```
 
+### 直接使用Axios
+
+`@midayjs/axios`导出了原始的`axios`实例，在非应用环境中可以直接使用。
+
+```typescript
+import { axios } from '@midwayjs/axios';
+import { ReadStream, createWriteStream } from 'fs';
+import { finished } from 'stream/promises';
+
+async function download(url: string, filename: string) {
+  const writer = await createWriteStream(filename);
+  const res = axios.get<ReadStream>(url, {
+    responseType: 'stream',
+  });
+  res.data.pipe(writer);
+  await finished(writer);
+  return res;
+}
+```

--- a/site/i18n/en/docusaurus-plugin-content-docs/current/extensions/axios.md
+++ b/site/i18n/en/docusaurus-plugin-content-docs/current/extensions/axios.md
@@ -242,6 +242,9 @@ axios.options(url[, config])
 axios.post(url[, data[, config]])
 axios.put(url[, data[, config]])
 axios.patch(url[, data[, config]])
+axios.postForm(url[, data[, config]])
+axios.putForm(url[, data[, config]])
+axios.patchForm(url[, data[, config]])
 ```
 
 
@@ -413,3 +416,21 @@ export class MainConfiguration {
 }
 ```
 
+### Use Axios directly
+
+`@midayjs/axios` also exported the original instance of `axios`, which could be useful in helper functions.
+
+```typescript
+import { axios } from '@midwayjs/axios';
+import { ReadStream, createWriteStream } from 'fs';
+import { finished } from 'stream/promises';
+
+async function download(url: string, filename: string) {
+  const writer = await createWriteStream(filename);
+  const res = axios.get<ReadStream>(url, {
+    responseType: 'stream',
+  });
+  res.data.pipe(writer);
+  await finished(writer);
+  return res;
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `npm test` passes
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->
axios

##### Description of change
<!-- Provide a description of the change below this comment. -->

导出更多的`axios`的API：
* `httpService.defaults` => `axios.defaults`
* `httpService.postForm` => `axios.postForm`
* `httpService.putForm` => `axios.putForm`
* `httpService.patchForm` => `axios.patchForm`

在工具函数的编程中无法获取`HttpService`，此时可以直接使用`import { axios } from '@midwayjs/axios'`直接调用`axios`。在使用类似`pnpm`这样的包管理器时，可以避免额外引入一个`axios`依赖。