### PR TITLE
chore(decorator): opt code in serverlessTrigger

### DIFF
--- a/packages/core/src/decorator/faas/serverlessTrigger.ts
+++ b/packages/core/src/decorator/faas/serverlessTrigger.ts
@@ -84,7 +84,7 @@ export function ServerlessTrigger(
         methodName: functionName,
         metadata,
       },
-      target.constructor
+      target
     );
   };
 }


### PR DESCRIPTION
```target.constructor``` is not required because ```target``` is compatible with function ```attachClassMetadata```

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
