### PR TITLE
feat: config separated options for verify & decode and bug fixes

### DIFF
--- a/packages/jwt/index.d.ts
+++ b/packages/jwt/index.d.ts
@@ -1,10 +1,17 @@
-import { SignOptions } from 'jsonwebtoken';
+import { DecodeOptions, SignOptions, VerifyOptions } from 'jsonwebtoken';
 
 export * from './dist/index';
 
 declare module '@midwayjs/core/dist/interface' {
   interface MidwayConfig {
-    jwt?: SignOptions & {
+    jwt?: (
+      | SignOptions
+      | {
+          sign?: SignOptions;
+          verify?: VerifyOptions;
+          decode?: DecodeOptions;
+        }
+    ) & {
       secret?: string;
     };
   }

--- a/packages/jwt/package.json
+++ b/packages/jwt/package.json
@@ -19,6 +19,9 @@
     "jsonwebtoken",
     "jwt"
   ],
+  "engines": {
+    "node": ">=12"
+  },
   "author": "Nawbc",
   "license": "MIT",
   "devDependencies": {

--- a/packages/jwt/src/jwt.ts
+++ b/packages/jwt/src/jwt.ts
@@ -1,4 +1,5 @@
 import { Config, Provide, Scope, ScopeEnum } from '@midwayjs/core';
+import { KeyObject } from 'crypto';
 import type {
   DecodeOptions,
   GetPublicKeyOrSecret,
@@ -8,7 +9,6 @@ import type {
   VerifyOptions,
 } from 'jsonwebtoken';
 import * as jwt from 'jsonwebtoken';
-import { isKeyObject } from 'util/types';
 
 type JwtPayload = string | Buffer | Record<string, any>;
 
@@ -249,7 +249,7 @@ export class JwtService {
   isSecret(secret: any): secret is Secret {
     if (typeof secret === 'string') return true;
     if (Buffer.isBuffer(secret)) return true;
-    if (isKeyObject(secret)) return true;
+    if (secret instanceof KeyObject) return true;
     if (
       secret &&
       typeof secret === 'object' &&

--- a/packages/jwt/test/fixtures/base-app-2/package.json
+++ b/packages/jwt/test/fixtures/base-app-2/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "base-app-2",
+  "version": "1.0.0",
+  "dependencies": {
+  }
+}

--- a/packages/jwt/test/fixtures/base-app-2/src/configuration.ts
+++ b/packages/jwt/test/fixtures/base-app-2/src/configuration.ts
@@ -1,0 +1,28 @@
+import { Configuration } from '@midwayjs/core';
+
+@Configuration({
+  imports: [
+    require('../../../../src')
+  ],
+  importConfigs: [
+    {
+      default: {
+        jwt: {
+          sign: {
+            expiresIn: '200s',
+            algorithm: 'HS256',
+          },
+          verify: {
+            expiresIn: '200s',
+            algorithms: ['HS256'],
+            clockTolerance: 30,
+            ignoreExpiration: true,
+          },
+          secret: '123',
+        }
+      }
+    }
+  ]
+})
+export class AutoConfiguration {
+}

--- a/packages/jwt/test/index.test.ts
+++ b/packages/jwt/test/index.test.ts
@@ -38,4 +38,40 @@ describe('/test/index.test.ts', () => {
 
     await close(app);
   });
+
+  it('should test jwt with separated options', async () => {
+    const app = await createLightApp(join(__dirname, './fixtures/base-app-2'));
+    const jwtService = await  app.getApplicationContext().getAsync(JwtService);
+
+    // sign
+    const secret = 'shhhhhh';
+    const asyncToken = await jwtService.sign({ foo: 'bar' }, secret);
+    const syncToken = jwtService.signSync({ foo: 'bar' }, secret);
+    expect(typeof asyncToken).toEqual('string');
+    expect((asyncToken as string).split('.')).toHaveLength(3);
+    expect(asyncToken).toEqual(syncToken);
+
+    const asyncToken1 = await jwtService.sign({ foo: 'bar' });
+    const syncToken1 = jwtService.signSync({ foo: 'bar' });
+    expect(asyncToken1).toEqual(syncToken1);
+
+    // verify
+    const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIiLCJpYXQiOjE0MzcwMTg1ODIsImV4cCI6MTQzNzAxODU5Mn0.3aR3vocmgRpG05rsI9MpR6z2T_BGtMQaPq2YR6QaroU';
+    const key = 'key';
+
+    const payload = {foo: 'bar', iat: 1437018582, exp: 1437018592};
+    const p = await jwtService.verify(token, key);
+    expect(p).toEqual(payload);
+
+    const p1 = jwtService.verifySync(token, key);
+    expect(p1).toEqual(payload);
+
+    const decoded = jwtService.decode("null");
+    expect(decoded).toEqual(null);
+
+    const decoded1 = jwtService.decodeSync("null");
+    expect(decoded1).toEqual(null);
+
+    await close(app);
+  });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->
jwt

##### Description of change
<!-- Provide a description of the change below this comment. -->
这个Patch解决了JWT的几个问题：
1. 只识别`sign`的`expiresIn`参数，其它参数例，如`algorithm`，必须每次通过调用传入，而不能使用配置；
2. 原`verify`和`decode`不能提供默认配置，必须每次调用通过`options`参数指定；
3. 修复了`sign`和`verify`的参数识别问题，当提供了第二参数为密钥，且不提供第三个参数`options`时，原来的实现会错误地将密钥当作`options`，导致缺失密钥参数。

在兼容原有配置格式的基础上，新增以下配置方式:

```javascript
{
  jwt: {
    sign: {
      // 签名参数
    },
    verify: {
      // 验证参数
    },
    decode: {
      // 解码的参数
    },
    secret: '密钥' // 私钥/公钥，取决于仅用于验证还是同时验证和签名
  }
}
```