### PR TITLE
fix: use qs to replace querystring to solve #2162 issue

### DIFF
--- a/packages/web/app/extend/request.js
+++ b/packages/web/app/extend/request.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const _querycache = Symbol('_querycache');
-const qs = require('querystring');
+const qs = require('qs');
 
 function firstValue(value) {
   if (Array.isArray(value)) {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -49,7 +49,8 @@
     "egg": "^2.28.0",
     "egg-cluster": "^1.27.1",
     "find-up": "5.0.0",
-    "mkdirp": "1.0.4"
+    "mkdirp": "1.0.4",
+    "qs": "^6.11.2"
   },
   "author": "Harry Chen <czy88840616@gmail.com>",
   "repository": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -50,7 +50,7 @@
     "egg-cluster": "^1.27.1",
     "find-up": "5.0.0",
     "mkdirp": "1.0.4",
-    "qs": "^6.11.2"
+    "qs": "6.11.2"
   },
   "author": "Harry Chen <czy88840616@gmail.com>",
   "repository": {

--- a/packages/web/test/feature.test.ts
+++ b/packages/web/test/feature.test.ts
@@ -149,6 +149,21 @@ describe('/test/feature.test.ts', () => {
     await closeApp(app);
   });
 
+  it('should test query parser #2162 case 2', async () => {
+    const app = await creatApp('feature/base-app-query-parser');
+    let result = await createHttpRequest(app)
+      .get('/query_array?appId=31062&flowId=1330&mixFlowInstIds[]=108015365&flowInstIds[]=103137222');
+    expect(result.status).toEqual(200);
+    expect(result.text).toEqual(JSON.stringify({"appId":"31062","flowId":"1330","mixFlowInstIds":["108015365"],"flowInstIds":["103137222"]}));
+    
+    result = await createHttpRequest(app)
+      .get('/query_array_duplicate?appId=123&appId=456');
+
+    expect(result.status).toEqual(200);
+    expect(result.text).toEqual(JSON.stringify({"appId":["123","456"]}));
+    await closeApp(app);
+  });
+
   it('should test runInAgent decorator with egg', async () => {
     const resultFile = join(__dirname, 'fixtures/feature/base-app-run-in-agent', '.result');
     await remove(resultFile);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
use qs to replace querystring if config.egg.queryParseMode = 'simple'