### PR TITLE
fix: parsing array of size > 20 in query (#3447)

### DIFF
--- a/packages/web/app/extend/request.js
+++ b/packages/web/app/extend/request.js
@@ -15,7 +15,10 @@ module.exports = {
     if (this.app.config.egg.queryParseMode === 'simple') {
       const str = this.querystring;
       const c = (this._querycache = this._querycache || {});
-      return c[str] || (c[str] = qs.parse(str));
+      return (
+        c[str] ||
+        (c[str] = qs.parse(str, this.app.config.egg.queryParseOptions || {}))
+      );
     } else {
       return this._customQuery(_querycache, firstValue);
     }

--- a/packages/web/src/interface.ts
+++ b/packages/web/src/interface.ts
@@ -8,6 +8,7 @@ import {
 } from '@midwayjs/core';
 import { DefaultState, Middleware } from 'koa';
 import { ILogger, LoggerOptions } from '@midwayjs/logger';
+import { IParseOptions } from 'qs';
 
 export const RUN_IN_AGENT_KEY = 'egg:run_in_agent';
 export const EGG_AGENT_APP_KEY = 'egg_agent_app';
@@ -118,6 +119,10 @@ export interface IMidwayWebConfigurationOptions extends IConfigurationOptions {
    * http query parser mode, default is extended
    */
   queryParseMode?: 'simple' | 'extended';
+  /**
+   * http query parse options, used when 'simple' mode is used
+   */
+  queryParseOptions?: IParseOptions;
 }
 
 /**

--- a/packages/web/test/feature.test.ts
+++ b/packages/web/test/feature.test.ts
@@ -3,6 +3,7 @@ import { IMidwayWebApplication } from '../src';
 import { join } from 'path';
 import { remove, existsSync } from 'fs-extra';
 import { readFileSync } from 'fs';
+import * as qs from 'qs';
 
 describe('/test/feature.test.ts', () => {
   describe('test new decorator', () => {
@@ -155,12 +156,35 @@ describe('/test/feature.test.ts', () => {
       .get('/query_array?appId=31062&flowId=1330&mixFlowInstIds[]=108015365&flowInstIds[]=103137222');
     expect(result.status).toEqual(200);
     expect(result.text).toEqual(JSON.stringify({"appId":"31062","flowId":"1330","mixFlowInstIds":["108015365"],"flowInstIds":["103137222"]}));
-    
+
     result = await createHttpRequest(app)
       .get('/query_array_duplicate?appId=123&appId=456');
 
     expect(result.status).toEqual(200);
     expect(result.text).toEqual(JSON.stringify({"appId":["123","456"]}));
+    await closeApp(app);
+  });
+
+  it('should test query parser options', async () => {
+    const query5 = {
+      arr: ['1','2','3','4','5'],
+    };
+    const app = await creatApp('feature/base-app-query-parser');
+    let result = await createHttpRequest(app)
+      .get('/query_array')
+      .query(qs.stringify(query5));
+    expect(result.status).toEqual(200);
+    expect(result.text).toEqual(JSON.stringify(query5));
+
+    const query6 = {
+      arr: ['1','2','3','4','5','6'],
+    };
+    result = await createHttpRequest(app)
+      .get('/query_array')
+      .query(qs.stringify(query6));
+
+    expect(result.status).toEqual(200);
+    expect(result.text).toEqual(JSON.stringify(qs.parse(qs.stringify(query6), { arrayLimit: 5 })));
     await closeApp(app);
   });
 

--- a/packages/web/test/fixtures/feature/base-app-query-parser/src/config/config.default.ts
+++ b/packages/web/test/fixtures/feature/base-app-query-parser/src/config/config.default.ts
@@ -10,4 +10,7 @@ export const hello = {
 
 export const egg = {
   queryParseMode: 'simple',
+  queryParseOptions: {
+    arrayLimit: 5,
+  },
 }

--- a/site/docs/extensions/egg.md
+++ b/site/docs/extensions/egg.md
@@ -620,6 +620,7 @@ export default {
 | hostname       | string           | 监听的 hostname，默认 127.1  |
 | http2          | boolean          | 可选，http2 支持，默认 false |
 | queryParseMode | simple\|extended | 默认为 extended              |
+| queryParseOptions | `qs.IParseOptions` | 解析选项，当使用'simple'模式解析时可用 |
 
 以上的属性，对本地和使用 `bootstrap.js` 部署的应用生效。
 
@@ -747,6 +748,9 @@ export default {
   egg: {
     // ...
     queryParseMode: 'simple',
+    queryParseOptions: {
+      arrayLimit: 100,
+    },
   },
 }
 ```

--- a/site/i18n/en/docusaurus-plugin-content-docs/current/extensions/egg.md
+++ b/site/i18n/en/docusaurus-plugin-content-docs/current/extensions/egg.md
@@ -622,6 +622,7 @@ All parameters of `@midwayjs/web` are as follows:
 | hostname | string | The hostname of the listener, the default 127.1 |
 | http2 | boolean | Optional, supported by http2, default false |
 | queryParseMode | simple\|extended | The default is extended |
+| queryParseOptions | `qs.IParseOptions` | Parse options when 'simple' mode is used |
 
 The above attributes are valid for applications deployed locally and using `bootstrap.js`.
 
@@ -749,6 +750,9 @@ export default {
   egg: {
     // ...
     queryParseMode: 'simple',
+    queryParseOptions: {
+      arrayLimit: 100,
+    },
   },
 }
 ```


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->
web

##### Description of change
<!-- Provide a description of the change below this comment. -->
通过增加simple模式的解析参数，修复 #3447 。

例如：在`config.default.ts`中，设置：
```typescript
export default {
  web: {
    queryParseMode: 'simple', // 指定使用qs作为解析器
    queryParseOptions: {
      arrayLimit: 100, // 设置将array的解析元素上限为100
    }
  }，
  // ... 其它参数
}
```