### PR TITLE
fix(web): default app logger name error  in cluster mode

### DIFF
--- a/packages/web/src/config/config.default.ts
+++ b/packages/web/src/config/config.default.ts
@@ -3,7 +3,6 @@ import * as mkdirp from 'mkdirp';
 import * as os from 'os';
 import * as fs from 'fs';
 import * as loggerModule from '@midwayjs/logger';
-import { extend } from '@midwayjs/core';
 
 export default appInfo => {
   const exports = {} as any;
@@ -47,12 +46,7 @@ export default appInfo => {
   }
 
   // 修改默认的日志名
-  exports.midwayLogger = extend(
-    true,
-    {},
-    loggerModule.loggers.getDefaultMidwayLoggerConfig(appInfo)['midwayLogger'],
-    defaultLoggerConfig
-  );
+  exports.midwayLogger = defaultLoggerConfig;
 
   exports.egg = {
     dumpConfig: true,

--- a/packages/web/src/config/config.default.ts
+++ b/packages/web/src/config/config.default.ts
@@ -3,6 +3,7 @@ import * as mkdirp from 'mkdirp';
 import * as os from 'os';
 import * as fs from 'fs';
 import * as loggerModule from '@midwayjs/logger';
+import { extend } from '@midwayjs/core';
 
 export default appInfo => {
   const exports = {} as any;
@@ -46,7 +47,12 @@ export default appInfo => {
   }
 
   // 修改默认的日志名
-  exports.midwayLogger = defaultLoggerConfig;
+  exports.midwayLogger = extend(
+    true,
+    {},
+    loggerModule.loggers.getDefaultMidwayLoggerConfig(appInfo)['midwayLogger'],
+    defaultLoggerConfig
+  );
 
   exports.egg = {
     dumpConfig: true,

--- a/packages/web/src/logger.ts
+++ b/packages/web/src/logger.ts
@@ -104,7 +104,8 @@ class MidwayLoggers extends Map<string, ILogger> {
     // 这里属于 hack 了，cluster 模式下会先走这里，找不到默认值
     // 先合并一遍默认配置
     configService.addObject(
-      loggers.getDefaultMidwayLoggerConfig(configService.getAppInfo())
+      loggers.getDefaultMidwayLoggerConfig(configService.getAppInfo()),
+      true
     );
     loggerConfig = configService.getConfiguration('midwayLogger');
 

--- a/site/docs/logger.md
+++ b/site/docs/logger.md
@@ -34,6 +34,8 @@ Midway 为不同场景提供了一套统一的日志接入方式。通过 `@midw
 
 在大部分场景下，两个版本是兼容的，但是在配置中，会有一定的差异性，为此我们提供了一些方法来尽可能兼容老逻辑，完整的 Breaking Change 变化，请查看 [变更文档](https://github.com/midwayjs/logger/blob/main/BREAKING-3.md)。
 
+如果你的配置文件中有老的日志配置，可以参考 **常见问题** 进行转换。
+
 
 
 ## 日志路径和文件
@@ -936,3 +938,25 @@ const newLoggerConfig = formatLegacyLoggerOptions({
 注意，这个方法只能转换老的配置，如果配置中包含新老配置则新配置不会生效。
 
 :::
+
+比如，你的 `src/config/config.default.ts` 中如果有日志使用的是老配置，可以使用这个方法做兼容。
+
+```typescript
+import { MidwayConfig, MidwayAppInfo } from '@midwayjs/core';
+import { formatLegacyLoggerOptions } from '@midwayjs/logger';
+
+export default (appInfo: MidwayAppInfo) => {
+  return {
+    midwayLogger: {
+      clients: {
+        abc: logger.formatLegacyLoggerOptions({
+          fileLogName: 'abc.log',
+        }),
+      }
+    },
+    // ...
+  } as MidwayConfig;
+};
+
+```
+

--- a/site/i18n/en/docusaurus-plugin-content-docs/current/logger.md
+++ b/site/i18n/en/docusaurus-plugin-content-docs/current/logger.md
@@ -34,6 +34,8 @@ Upgrade the dependency versions in `package.json`, pay attention to the `depende
 
 In most scenarios, the two versions are compatible, but there will be certain differences in configuration. For this reason, we have provided some methods to be as compatible with the old logic as possible. For complete Breaking Change changes, please view [the change document](https://github.com/midwayjs/logger/blob/main/BREAKING-3.md).
 
+If you have old log configuration in your configuration file, you can refer to **Common Problem** to convert it.
+
 
 
 ## Logger path and file
@@ -897,7 +899,7 @@ export class MainConfiguration {
 
 
 
-## Common problem
+## Common Problem
 
 
 
@@ -918,3 +920,47 @@ Generally speaking, the server console log (console) is closed and will only be 
 ### 3. Some Docker environments fail to start
 
 Check whether the user who started the current application in the directory where the log is written has permissions.
+
+
+
+### 4. How to convert if there is an old configuration?
+
+The log library provides a conversion method to assist users in converting old configurations into new configurations.
+
+```typescript
+import { formatLegacyLoggerOptions } from '@midwayjs/logger';
+
+const newLoggerConfig = formatLegacyLoggerOptions({
+   level: 'info',
+   enableFile: false,
+   disableConsole: true,
+   enableJSON: true,
+});
+```
+
+:::caution
+
+Note that this method can only convert the old configuration. If the configuration contains the old and new configurations, the new configuration will not take effect.
+
+:::
+
+For example, if there are logs in your `src/config/config.default.ts` that use old configurations, you can use this method for compatibility.
+
+```typescript
+import { MidwayConfig, MidwayAppInfo } from '@midwayjs/core';
+import { formatLegacyLoggerOptions } from '@midwayjs/logger';
+
+export default (appInfo: MidwayAppInfo) => {
+   return {
+     midwayLogger: {
+       clients: {
+         abc: logger.formatLegacyLoggerOptions({
+           fileLogName: 'abc.log',
+         }),
+       }
+     },
+     // ...
+   } as MidwayConfig;
+};
+
+```


### PR DESCRIPTION
在使用 v2 版本的 logger 时，如果使用 egg cluster 模式，midway-web.log 会变成 midway-app.log !!!!!!