### PR TITLE
feat: inject ctx and app to leoric models

### DIFF
--- a/packages/leoric/package.json
+++ b/packages/leoric/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "@midwayjs/core": "^3.13.7",
+    "@midwayjs/koa": "^3.13.7",
     "@midwayjs/mock": "^3.13.7",
     "sqlite3": "5.1.6"
   },

--- a/packages/leoric/test/fixtures/logger/package.json
+++ b/packages/leoric/test/fixtures/logger/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "midwayjs-leoric-logger"
+}

--- a/packages/leoric/test/fixtures/logger/src/config/config.default.ts
+++ b/packages/leoric/test/fixtures/logger/src/config/config.default.ts
@@ -1,0 +1,28 @@
+import * as path from 'path';
+import { Bone } from '../../../../../src';
+import { Context } from '@midwayjs/core';
+
+export const keys = 'hakuna matata';
+
+export const leoric = {
+  dataSource: {
+    custom: {
+      dialect: 'sqlite',
+      database: path.join(__dirname, '../../', 'database.sqlite'),
+      models: ['**/model/*{.ts,.js}'],
+      sync: true,
+      logger: {
+        logQuery(
+          sql: string,
+          duration: number,
+          opts: { Model: typeof Bone & { ctx: Context }, command: string, connection: unknown }
+        ) {
+          const logger = opts.Model?.ctx?.logger;
+          if (!logger) return;
+          logger.info(`[leoric.${opts.command}]`, sql, { duration });
+        },
+      },
+    },
+  },
+  defaultDataSourceName: 'custom',
+}

--- a/packages/leoric/test/fixtures/logger/src/configuration.ts
+++ b/packages/leoric/test/fixtures/logger/src/configuration.ts
@@ -1,0 +1,24 @@
+import { Configuration } from "@midwayjs/core";
+import * as koa from '@midwayjs/koa';
+import * as leoric from '../../../../src';
+import * as path from 'path';
+
+const { InjectDataSource } = leoric;
+
+@Configuration({
+  imports: [koa, leoric],
+  conflictCheck: true,
+  importConfigs: [path.join(__dirname, 'config')],
+})
+export class ContainerLifeCycle {
+  @InjectDataSource()
+  defaultDataSource: leoric.Realm;
+
+  @InjectDataSource('custom')
+  namedDataSource: leoric.Realm;
+
+  async onReady() {
+    expect(this.defaultDataSource).toBeDefined();
+    expect(this.defaultDataSource).toEqual(this.namedDataSource);
+  }
+}

--- a/packages/leoric/test/fixtures/logger/src/controller/user.ts
+++ b/packages/leoric/test/fixtures/logger/src/controller/user.ts
@@ -1,0 +1,13 @@
+import { Controller, Get, Inject } from "@midwayjs/core";
+import { UserService } from '../service/user';
+
+@Controller('/api/users')
+export class UserController {
+  @Inject()
+  userService: UserService;
+
+  @Get('/')
+  async list() {
+    return await this.userService.list();
+  }
+}

--- a/packages/leoric/test/fixtures/logger/src/model/post.ts
+++ b/packages/leoric/test/fixtures/logger/src/model/post.ts
@@ -1,0 +1,18 @@
+import { Bone, Column, DataTypes } from '../../../../../src';
+
+export default class Post extends Bone {
+  @Column()
+  id: bigint;
+
+  @Column()
+  title: string;
+
+  @Column(DataTypes.TEXT)
+  content: string;
+
+  @Column()
+  createdAt: Date;
+
+  @Column()
+  updatedAt: Date;
+}

--- a/packages/leoric/test/fixtures/logger/src/model/user.ts
+++ b/packages/leoric/test/fixtures/logger/src/model/user.ts
@@ -1,0 +1,25 @@
+import { Bone, Column } from '../../../../../src';
+
+export default class User extends Bone {
+  @Column()
+  id: bigint;
+
+  @Column()
+  name: string;
+
+  @Column()
+  birthday: Date;
+
+  @Column()
+  createdAt: Date;
+
+  get age(): number {
+    const now = new Date();
+    const then = this.birthday;
+    const diff = now.getFullYear() - then.getFullYear();
+    if (now.getMonth() >= then.getMonth() && now.getDate() >= then.getDate()) {
+      return diff;
+    }
+    return diff - 1;
+  }
+}

--- a/packages/leoric/test/fixtures/logger/src/service/user.ts
+++ b/packages/leoric/test/fixtures/logger/src/service/user.ts
@@ -1,0 +1,21 @@
+import { Provide } from '@midwayjs/core';
+import User from '../model/user';
+import { InjectModel } from '../../../../../src';
+
+@Provide()
+export class UserService {
+  @InjectModel(User)
+  User: typeof User;
+
+  async list() {
+    return this.User.find();
+  }
+
+  async add(options) {
+    return this.User.create(options);
+  }
+
+  async delete() {
+    return this.User.remove({});
+  }
+}

--- a/packages/leoric/test/index.test.ts
+++ b/packages/leoric/test/index.test.ts
@@ -12,6 +12,7 @@ function cleanFile(file) {
 
 describe('test/index.test.ts', () => {
   let app: IMidwayApplication;
+
   beforeAll(async () => {
     cleanFile(join(__dirname, 'fixtures/basic', 'database.sqlite'));
     app = await createLightApp(join(__dirname, 'fixtures', 'basic'));
@@ -20,6 +21,7 @@ describe('test/index.test.ts', () => {
   afterAll(async () => {
     await close(app);
   });
+
   it('list user service ', async () => {
     const userService: UserService = await app
       .getApplicationContext()

--- a/packages/leoric/test/logger.test.ts
+++ b/packages/leoric/test/logger.test.ts
@@ -1,0 +1,48 @@
+import { close, createHttpRequest, createApp } from '@midwayjs/mock';
+import { join } from 'path';
+import { existsSync, unlinkSync } from 'fs';
+import { IMidwayApplication } from '@midwayjs/core';
+import { UserService } from './fixtures/logger/src/service/user';
+import { readFile } from 'fs/promises';
+
+function cleanFile(file) {
+  if (existsSync(file)) {
+    unlinkSync(file);
+  }
+}
+
+describe('test/logger.test.ts', () => {
+  let app: IMidwayApplication;
+  let userService: UserService;
+
+  beforeAll(async () => {
+    cleanFile(join(__dirname, 'fixtures/logger', 'database.sqlite'));
+    app = await createApp(join(__dirname, 'fixtures', 'logger'));
+    userService = await app
+      .getApplicationContext()
+      .getAsync(UserService);
+  });
+
+  afterAll(async () => {
+    await close(app);
+  });
+
+  beforeEach(async () => {
+    await userService.add({ name: 'Levi', birthday: new Date('2023-12-25') });
+  });
+
+  afterEach(async () => {
+    await userService.delete();
+  });
+
+  it('list user', async () => {
+    const res = await createHttpRequest(app)
+      .get('/api/users')
+      .expect(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body[0].name).toEqual('Levi');
+    const fpath = join(__dirname, 'fixtures/logger/logs/midwayjs-leoric-logger/midway-app.log');
+    expect(await readFile(fpath, 'utf-8')).toContain('SELECT * FROM "users"');
+  });
+
+});


### PR DESCRIPTION
enable `options.logger.logQuery()`

##### Checklist

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

- packages/leoric


##### Description of change

return subclass of models when accessing leoric models with InjectModel decorator, which enables the logQuery option

the subclassing implementation works like the one in egg-orm <https://github.com/eggjs/egg-orm/blob/master/lib/loader.js#L30>, just without the Proxy