### PR TITLE
fix(swagger): swagger-UI not show exception after fixing global configuration

### DIFF
--- a/packages/swagger/src/configuration.ts
+++ b/packages/swagger/src/configuration.ts
@@ -33,12 +33,15 @@ export class SwaggerConfiguration implements ILifeCycle {
     ]);
 
     if (apps.length) {
+      const explorer = await container.getAsync(SwaggerExplorer);
+      explorer.scanApp();
+
+      // 添加统一前缀
       let globalPrefix =
         this.configService.getConfiguration('globalPrefix') ||
         this.configService.getConfiguration('koa.globalPrefix') ||
         this.configService.getConfiguration('express.globalPrefix') ||
         this.configService.getConfiguration('egg.globalPrefix');
-      const explorer = await container.getAsync(SwaggerExplorer);
 
       if (globalPrefix) {
         if (!/^\//.test(globalPrefix)) {
@@ -47,8 +50,6 @@ export class SwaggerConfiguration implements ILifeCycle {
 
         explorer.addGlobalPrefix(globalPrefix);
       }
-
-      explorer.scanApp();
 
       apps.forEach(app => {
         app.useMiddleware(SwaggerMiddleware);

--- a/packages/swagger/src/documentBuilder.ts
+++ b/packages/swagger/src/documentBuilder.ts
@@ -7,6 +7,7 @@ import {
   PathItemObject,
   SchemaObject,
   TagObject,
+  PathsObject,
 } from './interfaces';
 
 export class DocumentBuilder {
@@ -71,6 +72,10 @@ export class DocumentBuilder {
   public addPaths(paths: Record<string, PathItemObject>) {
     Object.assign(this.document.paths, paths);
     return this;
+  }
+
+  public getPaths(): PathsObject {
+    return this.document.paths;
   }
 
   public addSchema(schema: Record<string, SchemaObject>) {

--- a/packages/swagger/src/swaggerExplorer.ts
+++ b/packages/swagger/src/swaggerExplorer.ts
@@ -112,11 +112,23 @@ export class SwaggerExplorer {
     }
   }
 
-  public addGlobalPrefix(prefix: string) {
-    if (!prefix) {
+  public addGlobalPrefix(globalPrefix: string) {
+    if (!globalPrefix) {
       return;
     }
-    this.documentBuilder.addServer(prefix);
+    const paths = this.documentBuilder.getPaths();
+
+    // 添加统一前缀后的接口地址
+    const newPaths: Record<string, PathItemObject> = {};
+    for (const [routerUrl, value] of Object.entries(paths)) {
+      // 处理路由
+      if (!/^\//.test(routerUrl)) {
+        newPaths[`${globalPrefix}/${routerUrl}`] = value;
+      } else {
+        newPaths[`${globalPrefix}${routerUrl}`] = value;
+      }
+    }
+    this.documentBuilder.addPaths(newPaths);
   }
 
   public scanApp() {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

- 使用midway/swagger模块，配置globalPrefix参数，支持在swagger-UI 中正常显示


##### Description of change

修复前，使用globalPrefix参数，无法在UI中显示，前端对接时候不知道具体路由

例如：配置globalPrefix参数为api/v1，修复后可以正常显示
![image](https://github.com/midwayjs/midway/assets/40396940/35c00951-7115-4600-ab34-4a26eace3d45)


同时：

- swagger-UI中的addServer方法使用不对，swagger的server参数是用来配置多环境，即：区分不同环境的api地址，类似host+post
- swagger应该是先扫描路由，原来在没有扫面前就去设置globalPrefix存在异常





