### PR TITLE
fix(swagger): Updated test cases to fix duplicate interface addresses…

### DIFF
--- a/packages/swagger/src/documentBuilder.ts
+++ b/packages/swagger/src/documentBuilder.ts
@@ -78,6 +78,11 @@ export class DocumentBuilder {
     return this.document.paths;
   }
 
+  public setPaths(paths: Record<string, PathItemObject>){
+    this.document.paths=paths
+    return this;
+  }
+
   public addSchema(schema: Record<string, SchemaObject>) {
     if (!this.document.components.schemas) {
       this.document.components.schemas = {};

--- a/packages/swagger/src/documentBuilder.ts
+++ b/packages/swagger/src/documentBuilder.ts
@@ -78,8 +78,8 @@ export class DocumentBuilder {
     return this.document.paths;
   }
 
-  public setPaths(paths: Record<string, PathItemObject>){
-    this.document.paths=paths
+  public setPaths(paths: Record<string, PathItemObject>) {
+    this.document.paths = paths;
     return this;
   }
 

--- a/packages/swagger/src/swaggerExplorer.ts
+++ b/packages/swagger/src/swaggerExplorer.ts
@@ -128,7 +128,7 @@ export class SwaggerExplorer {
         newPaths[`${globalPrefix}${routerUrl}`] = value;
       }
     }
-    this.documentBuilder.addPaths(newPaths);
+    this.documentBuilder.setPaths(newPaths);
   }
 
   public scanApp() {

--- a/packages/swagger/test/index.test.ts
+++ b/packages/swagger/test/index.test.ts
@@ -84,7 +84,7 @@ describe('/test/index.test.ts', () => {
       expect(body.components.schemas.Cat.properties.father).toEqual({
         $ref: '#/components/schemas/Cat',
       });
-      expect(body.paths['/cats/{id}']).toMatchSnapshot();
+      expect(body.paths['/helloworld/vvvv01/cats/{id}']).toMatchSnapshot();
     });
   });
 


### PR DESCRIPTION
swagger配置globalPrefix后，由于setPaths函数使用错误，导致出现同一接口多次显示，并且无法正常调用

![image](https://github.com/midwayjs/midway/assets/40396940/dca6edf3-9198-42ff-9c84-72cce41c8029)

从上面看，API的URL会多次显示，为解决这个问题，做如下的逻辑修改：

- 避免setPaths函数对paths的污染
- 配置globalPrefix后，对应的单元测试用例也需要修改


这个fix是针对先前的[PR3578](https://github.com/midwayjs/midway/pull/3578)改出的错误，实在抱歉。这里做一个修复!