### PR TITLE
feat(core): add MidwayWebRouterService.deleteRouter() (availbale only before serverReady)

### DIFF
--- a/packages/core/src/common/webGenerator.ts
+++ b/packages/core/src/common/webGenerator.ts
@@ -134,6 +134,9 @@ export abstract class WebControllerGenerator<
 
       // add route
       const routes = routerTable.get(routerInfo.prefix);
+      if (!routes) {
+        throw new Error(`router table not found for ${routerInfo.prefix}`);
+      }
       for (const routeInfo of routes) {
         // get middleware
         const methodMiddlewares = [];

--- a/packages/core/src/common/webGenerator.ts
+++ b/packages/core/src/common/webGenerator.ts
@@ -16,7 +16,7 @@ import {
   MidwayWebRouterService,
   RouterInfo,
 } from '../service/webRouterService';
-import { httpError } from '../error';
+import { MidwayCommonError, httpError } from '../error';
 import { MidwayMiddlewareService } from '../service/middlewareService';
 
 const debug = util.debuglog('midway:debug');
@@ -135,8 +135,11 @@ export abstract class WebControllerGenerator<
       // add route
       const routes = routerTable.get(routerInfo.prefix);
       if (!routes) {
-        throw new Error(`router table not found for ${routerInfo.prefix}`);
+        throw new MidwayCommonError(
+          `router table not found for ${routerInfo.prefix}`
+        );
       }
+
       for (const routeInfo of routes) {
         // get middleware
         const methodMiddlewares = [];

--- a/packages/core/src/service/webRouterService.ts
+++ b/packages/core/src/service/webRouterService.ts
@@ -402,6 +402,21 @@ export class MidwayWebRouterService {
     this.sortPrefixAndRouter();
   }
 
+  public async deleteRouter(prefix: string) {
+    if (!prefix) {
+      return;
+    }
+    const routerTable = await this.getRouterTable();
+    routerTable.delete(prefix);
+
+    this.routesPriority = this.routesPriority.filter(item => {
+      if (prefix === item.prefix) {
+        return false;
+      }
+      return true;
+    });
+  }
+
   public sortRouter(urlMatchList: RouterInfo[]) {
     // 1. 绝对路径规则优先级最高如 /ab/cb/e
     // 2. 星号只能出现最后且必须在/后面，如 /ab/cb/**

--- a/packages/core/src/service/webRouterService.ts
+++ b/packages/core/src/service/webRouterService.ts
@@ -402,6 +402,9 @@ export class MidwayWebRouterService {
     this.sortPrefixAndRouter();
   }
 
+  /**
+   * @description 仅在 `serverReady` 之前调用有效
+   */
   public async deleteRouter(prefix: string) {
     if (!prefix) {
       return;

--- a/packages/core/test/service/webRouterService.test.ts
+++ b/packages/core/test/service/webRouterService.test.ts
@@ -36,7 +36,7 @@ describe('/test/service/webRouterService.test.ts', function () {
       url: '/abc/dddd/*',
       requestMethod: 'GET',
     });
-   
+
     let routeInfo = await collector.getMatchedRouterInfo('/api', 'get');
     expect(routeInfo).toBeUndefined();
 
@@ -204,6 +204,41 @@ describe('/test/service/webRouterService.test.ts', function () {
     const result1 = collector.sortRouter(require('./router').routerList6);
     expect(result1[0].url).toEqual('/hello');
     expect(result1[1].url).toEqual('/:slot');
+  });
+
+
+  it('should test delete router', async () => {
+    const collector = new MidwayWebRouterService();
+    const prefix = '/_abc'
+    collector.addRouter(async (ctx) => {
+      return 'hello world';
+    }, {
+      prefix,
+      url: prefix + '/dddd/efg',
+      requestMethod: 'GET',
+    });
+
+    const routerTable = await collector.getRouterTable();
+    expect(routerTable.has(prefix)).toEqual(true);
+
+    await collector.deleteRouter('fake_input')
+    expect(routerTable.has(prefix)).toEqual(true);
+
+    await collector.deleteRouter('')
+    expect(routerTable.has(prefix)).toEqual(true);
+
+    await collector.deleteRouter(prefix)
+    expect(routerTable.has(prefix)).toEqual(false);
+
+    const flattenTable = await collector.getFlattenRouterTable();
+    let exists = false;
+    flattenTable.forEach(item => {
+      if (item.prefix === prefix) {
+        exists = true;
+      }
+    });
+    expect(exists).toEqual(false);
+
   });
 
 });


### PR DESCRIPTION
增加动态删除路由方法

**此方法仅在 `serverReady` 之前调用有效**
