### PR TITLE
feat(swagger): check route prefix exists in routeTable

### DIFF
--- a/packages/swagger/src/configuration.ts
+++ b/packages/swagger/src/configuration.ts
@@ -1,10 +1,11 @@
 import {
+  Configuration,
   ILifeCycle,
+  Inject,
   IMidwayContainer,
   MidwayApplicationManager,
   MidwayConfigService,
-  Inject,
-  Configuration,
+  MidwayWebRouterService,
 } from '@midwayjs/core';
 import { SwaggerExplorer, SwaggerMiddleware } from '.';
 import * as DefaultConfig from './config/config.default';
@@ -24,6 +25,9 @@ export class SwaggerConfiguration implements ILifeCycle {
   @Inject()
   configService: MidwayConfigService;
 
+  @Inject()
+  readonly webRouterService: MidwayWebRouterService;
+
   async onReady(container: IMidwayContainer) {
     const apps = this.applicationManager.getApplications([
       'express',
@@ -34,7 +38,8 @@ export class SwaggerConfiguration implements ILifeCycle {
 
     if (apps.length) {
       const explorer = await container.getAsync(SwaggerExplorer);
-      explorer.scanApp();
+      const routerTable = await this.webRouterService.getRouterTable();
+      explorer.scanApp(routerTable);
 
       // 添加统一前缀
       let globalPrefix =

--- a/packages/swagger/src/configuration.ts
+++ b/packages/swagger/src/configuration.ts
@@ -28,7 +28,7 @@ export class SwaggerConfiguration implements ILifeCycle {
   @Inject()
   readonly webRouterService: MidwayWebRouterService;
 
-  async onReady(container: IMidwayContainer) {
+  async onServerReady(container: IMidwayContainer) {
     const apps = this.applicationManager.getApplications([
       'express',
       'koa',

--- a/packages/swagger/src/swaggerExplorer.ts
+++ b/packages/swagger/src/swaggerExplorer.ts
@@ -20,6 +20,7 @@ import {
   getPropertyType,
   RequestMethod,
   getClassExtendedMetadata,
+  RouterInfo,
 } from '@midwayjs/core';
 import { PathItemObject, Type } from './interfaces';
 import { DECORATORS } from './constants';
@@ -131,11 +132,11 @@ export class SwaggerExplorer {
     this.documentBuilder.setPaths(newPaths);
   }
 
-  public scanApp() {
+  public scanApp(routerTable: Map<string, RouterInfo[]>) {
     const routes = listModule(CONTROLLER_KEY);
 
     for (const route of routes) {
-      this.generatePath(route);
+      this.generatePath(route, routerTable);
     }
 
     if (this.swaggerConfig?.tagSortable) {
@@ -147,7 +148,7 @@ export class SwaggerExplorer {
     return this.documentBuilder.build();
   }
 
-  protected generatePath(target: Type) {
+  protected generatePath(target: Type, routerTable: Map<string, RouterInfo[]>) {
     this.parseExtraModel(target);
 
     const metaForMethods: any[] =
@@ -168,6 +169,10 @@ export class SwaggerExplorer {
     );
 
     const prefix = controllerOption.prefix;
+    if (routerTable && routerTable.size > 0 && !routerTable.has(prefix)) {
+      return;
+    }
+
     const tags = metaForMethods.filter(
       item => item.key === DECORATORS.API_TAGS
     );


### PR DESCRIPTION
- 扫描路由时检测 prefix 是否存在于路由表中
- 初始化时机从 `onReady` 改为 `onServerReady`  以便其它中间件可以在 `onReady` 阶段更新路由表
- 