### PR TITLE
chore(mock): check process.env.MIDWAY_HTTP_PORT

### DIFF
--- a/packages/mock/app.js
+++ b/packages/mock/app.js
@@ -21,9 +21,14 @@ const { join } = require('path');
     ...args,
   });
 
+  const port = process.env.MIDWAY_HTTP_PORT
+  if (! port) {
+    throw new Error('MIDWAY_HTTP_PORT is not defined');
+  }
+
   process.send({
     title: 'server-ready',
-    port: process.env.MIDWAY_HTTP_PORT,
+    port,
     ssl: args.ssl,
   });
 


### PR DESCRIPTION
检查 `process.env.MIDWAY_HTTP_PORT` 变量是否设置。

有时卡着一直启动不了，不出现 `➜  Local:    http://127.0.0.1:7001/ ` 的信息，也没有日志可以判断。