### PR TITLE
fix: ignore custom param decorator in swagger

### DIFF
--- a/packages/swagger/src/swaggerExplorer.ts
+++ b/packages/swagger/src/swaggerExplorer.ts
@@ -373,7 +373,9 @@ export class SwaggerExplorer {
      */
     // WEB_ROUTER_PARAM_KEY
     const args: any[] = routerArgs.filter(
-      item => item.key === WEB_ROUTER_PARAM_KEY
+      item =>
+        item.key === WEB_ROUTER_PARAM_KEY &&
+        item?.metadata?.type !== RouteParamTypes.CUSTOM
     );
     const types = getMethodParamTypes(target, webRouter.method);
     const params = metaForMethods.filter(

--- a/packages/swagger/test/parser.test.ts
+++ b/packages/swagger/test/parser.test.ts
@@ -10,7 +10,7 @@ import {
   SwaggerExplorer,
   Type
 } from '../src';
-import { Controller, Post, Get } from '@midwayjs/core';
+import { Controller, Post, Get, Query, createRequestParamDecorator } from '@midwayjs/core';
 
 class CustomSwaggerExplorer extends SwaggerExplorer {
   generatePath(target: Type) {
@@ -480,5 +480,25 @@ describe('/test/parser.test.ts', function () {
     expect(data.tags.length).toBe(2);
     expect(data.tags[0].name).toBe('tag1');
     expect(data.tags[1].name).toBe('tag2');
+  });
+
+  it("should ignore custom param decorator", () => {
+    function Test() {
+      return createRequestParamDecorator(ctx => {
+        return ctx.test;
+      });
+    }
+    @Controller('/api')
+    class APIController {
+      @Get('/get_user')
+      async getUser(@Test() param: any, @Query('data') data: any) {
+        // ...
+      }
+    }
+
+    const explorer = new CustomSwaggerExplorer();
+    explorer.generatePath(APIController);
+    const data = explorer.getData() as any;
+    expect(data.paths['/api/get_user'].get.parameters.length).toEqual(1);
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
