### PR TITLE
fix: passport missing ctx.setHeader

### DIFF
--- a/packages/passport/package.json
+++ b/packages/passport/package.json
@@ -32,6 +32,7 @@
     "express-session": "1.18.0",
     "passport-jwt": "4.0.1",
     "passport-local": "1.0.0",
-    "passport-openidconnect": "0.1.2"
+    "passport-openidconnect": "0.1.2",
+    "passport-http-bearer": "1.0.1"
   }
 }

--- a/packages/passport/src/passport/passport.service.ts
+++ b/packages/passport/src/passport/passport.service.ts
@@ -235,6 +235,9 @@ export function PassportMiddleware(
               redirect(url) {
                 ctx.redirect(url);
               },
+              setHeader(key, value) {
+                ctx.set(key, value);
+              },
             });
             return;
           }

--- a/packages/passport/test/fixtures/passport-koa-bearer-fail/package.json
+++ b/packages/passport/test/fixtures/passport-koa-bearer-fail/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "ali-demo"
+}

--- a/packages/passport/test/fixtures/passport-koa-bearer-fail/src/config/config.default.ts
+++ b/packages/passport/test/fixtures/passport-koa-bearer-fail/src/config/config.default.ts
@@ -1,0 +1,4 @@
+export const keys = ['1234'];
+export const passport = {
+  session: false,
+}

--- a/packages/passport/test/fixtures/passport-koa-bearer-fail/src/configuration.ts
+++ b/packages/passport/test/fixtures/passport-koa-bearer-fail/src/configuration.ts
@@ -1,0 +1,46 @@
+import { Configuration, App, Provide } from '@midwayjs/core';
+import * as path from 'path';
+import * as HttpBearerStrategy from 'passport-http-bearer';
+import {
+  PassportMiddleware,
+  PassportStrategy,
+  CustomStrategy as Strategy,
+  AuthenticateOptions,
+} from '../../../../src';
+import * as koa from '@midwayjs/koa';
+
+@Strategy()
+export class BearerStrategy extends PassportStrategy(
+  HttpBearerStrategy.Strategy,
+  'bearer'
+) {
+  getStrategyOptions(): any {
+    return this.validate.bind(this);
+  }
+
+  validate(token, done): any {
+    // return { username, password };
+    done(null);
+  }
+}
+
+@Provide()
+export class AuthMiddleware extends PassportMiddleware(BearerStrategy) {
+  getAuthenticateOptions(): Promise<AuthenticateOptions> | AuthenticateOptions {
+    return {};
+  }
+}
+
+@Configuration({
+  imports: [koa, require('../../../../src')],
+  conflictCheck: true,
+  importConfigs: [path.join(__dirname, 'config')],
+})
+export class ContainerLifeCycle {
+  @App()
+  app;
+
+  async onReady() {
+    this.app.useMiddleware(AuthMiddleware);
+  }
+}

--- a/packages/passport/test/fixtures/passport-koa-bearer-fail/src/controller/test.controller.ts
+++ b/packages/passport/test/fixtures/passport-koa-bearer-fail/src/controller/test.controller.ts
@@ -1,0 +1,20 @@
+import { Provide, Controller, Get, Inject } from '@midwayjs/core';
+
+@Provide()
+@Controller('/')
+export class TestPackagesController {
+  @Inject()
+  ctx;
+
+  @Get('/')
+  async localPassport() {
+    if (
+      this.ctx.state.user?.username === 'admin' &&
+      this.ctx.state.user?.password === '123'
+    ) {
+      return 'success';
+    }
+
+    return 'fail';
+  }
+}

--- a/packages/passport/test/index.test.ts
+++ b/packages/passport/test/index.test.ts
@@ -173,6 +173,21 @@ describe('/test/index.test.ts', () => {
       await close(app);
     });
 
+    it('should test passport all fail - http-bearer', async () => {
+      const app = await createApp(
+        join(__dirname, 'fixtures', 'passport-koa-bearer-fail'),
+        {},
+      );
+
+      const request = createHttpRequest(app);
+      let result = await request.get('/')
+
+      expect(result.status).toEqual(401);
+      expect(result.headers['www-authenticate']).toEqual('Bearer realm=\"Users\"')
+
+      await close(app);
+    });
+
     it('jwt passport with koa', async () => {
       let token;
       const app = await createApp(


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md
-->

passport.service 用了 ctx.setHeader, 但是 koa 版本的实现没有提供 setHeader

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
