### PR TITLE
the dosc fix of extension casbin

### DIFF
--- a/site/docs/extensions/casbin.md
+++ b/site/docs/extensions/casbin.md
@@ -126,11 +126,11 @@ g, alice, superuser
 g, bob, guest
 g, tom, manager
 
-g, users_list, user
-g, user_roles, user
-g, user_permissions, user
-g, roles_list, role
-g, role_permissions, role
+g2, users_list, user
+g2, user_roles, user
+g2, user_permissions, user
+g2, roles_list, role
+g2, role_permissions, role
 ```
 
 将其保存在项目根目录的 `basic_policy.csv` 文件中。

--- a/site/i18n/en/docusaurus-plugin-content-docs/current/extensions/casbin.md
+++ b/site/i18n/en/docusaurus-plugin-content-docs/current/extensions/casbin.md
@@ -126,11 +126,11 @@ g, alice, superuser
 g, bob, guest
 g, tom, manager
 
-g, users_list, user
-g, user_roles, user
-g, user_permissions, user
-g, roles_list, role
-g, role_permissions, role
+g2, users_list, user
+g2, user_roles, user
+g2, user_permissions, user
+g2, roles_list, role
+g2, role_permissions, role
 ```
 
 Save it in the `basic_policy.csv` file in the project root directory.


### PR DESCRIPTION
in the path: site-docs-extension-casbin. the basic_policy.csv file content error fixed.
