### PR TITLE
feat: add qs for parse query with array

### DIFF
--- a/packages/web-koa/package.json
+++ b/packages/web-koa/package.json
@@ -34,8 +34,10 @@
     "@midwayjs/core": "^3.15.6",
     "@midwayjs/session": "^3.15.6",
     "@types/koa": "2.15.0",
+    "@types/qs": "6.9.14",
     "koa": "2.15.2",
-    "koa-bodyparser": "4.4.1"
+    "koa-bodyparser": "4.4.1",
+    "qs": "6.11.2"
   },
   "author": "Harry Chen <czy88840616@gmail.com>",
   "repository": {

--- a/packages/web-koa/src/framework.ts
+++ b/packages/web-koa/src/framework.ts
@@ -27,6 +27,8 @@ import type { DefaultState, Middleware, Next } from 'koa';
 import * as koa from 'koa';
 import { Server } from 'http';
 import { setupOnError } from './onerror';
+import * as qs from 'qs';
+import * as querystring from 'querystring';
 
 const COOKIES = Symbol('context#cookies');
 
@@ -124,6 +126,51 @@ export class MidwayKoaFramework extends BaseFramework<
             throw new httpError.NotFoundError(`Forward url ${url} Not Found`);
           }
         };
+      },
+    });
+
+    const converter =
+      this.configurationOptions.queryParseMode === 'strict'
+        ? function (value) {
+            return !Array.isArray(value) ? [value] : value;
+          }
+        : this.configurationOptions.queryParseMode === 'first'
+        ? function (value) {
+            return Array.isArray(value) ? value[0] : value;
+          }
+        : undefined;
+
+    const self = this;
+    // fix query with array params
+    Object.defineProperty(this.app.request, 'query', {
+      get() {
+        const str = this.querystring;
+        const c = (this._querycache = this._querycache || {});
+
+        // find cache
+        if (c[str]) return c[str];
+
+        if (
+          self.configurationOptions.queryParseMode === 'extended' ||
+          self.configurationOptions.queryParseMode === 'simple'
+        ) {
+          // use qs module to parse query
+          c[str] = qs.parse(
+            str,
+            self.configurationOptions.queryParseOptions || {}
+          );
+        } else {
+          // use querystring to parse query by default
+          c[str] = querystring.parse(str);
+        }
+
+        if (converter) {
+          for (const key in c[str]) {
+            c[str][key] = converter(c[str][key]);
+          }
+        }
+
+        return c[str];
       },
     });
 

--- a/packages/web-koa/src/interface.ts
+++ b/packages/web-koa/src/interface.ts
@@ -2,6 +2,7 @@ import { IConfigurationOptions, IMidwayApplication, IMidwayContext } from '@midw
 import * as koa from 'koa';
 import { Context as KoaContext, DefaultState, Middleware, Next } from 'koa';
 import { RouterParamValue } from '@midwayjs/core';
+import * as qs from 'qs';
 
 export interface State extends DefaultState {}
 
@@ -82,6 +83,9 @@ export interface IMidwayKoaConfigurationOptions extends IConfigurationOptions {
    * @see https://nodejs.org/api/http.html#http_server_timeout
    */
   serverTimeout?: number;
+
+  queryParseMode?: 'extended' | 'simple' | 'strict' | 'first';
+  queryParseOptions?: qs.IParseOptions;
 }
 
 export type MiddlewareParamArray = Array<


### PR DESCRIPTION
## Objectives

Support parse array query parameter in koa. 

Koa use `querystring` will be set `a[]=1` to query by default.

`// GET /?a[0]=1&a[1]=2` will be got

```
{
    "a[0]": 1,
    "a[1]": 2,
}
```