### PR TITLE
fix: remove typings from the cron module since it includes its own types

### DIFF
--- a/packages/cron/package.json
+++ b/packages/cron/package.json
@@ -26,7 +26,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@types/cron": "2.4.0",
     "cron": "2.4.4"
   },
   "devDependencies": {


### PR DESCRIPTION
We try to remove @types/cron.

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
