### PR TITLE
feat(bull-board): save the result of createBullBoard

### DIFF
--- a/packages/bull-board/src/board.middleware.ts
+++ b/packages/bull-board/src/board.middleware.ts
@@ -48,6 +48,8 @@ export class BoardMiddleware
   @Config('bullBoard')
   bullBoardConfig: BullBoardOption;
 
+  bullBoard: ReturnType<typeof createBullBoard>;
+
   private basePath: string;
   private serverAdapter: MidwayAdapter;
 
@@ -58,7 +60,7 @@ export class BoardMiddleware
     this.basePath = this.bullBoardConfig.basePath;
 
     this.serverAdapter = new MidwayAdapter();
-    createBullBoard({
+    this.bullBoard = createBullBoard({
       queues: wrapQueues,
       serverAdapter: this.serverAdapter,
       options: {


### PR DESCRIPTION
改动点：保存 createBullBoard 的返回值，供项目内使用。

原因：主要为了解决 bull board 在动态创建队列的情况下不更新的问题，参考这个 [issue](https://github.com/felixmosh/bull-board/issues/368#issuecomment-1017291532)，需要使用 createBullBoard 返回值的 addQueue 进行手动增加队列