### PR TITLE
fix(core): DataSourceManagerConfigOption generic OPTIONS now no changes by PowerPartial

### DIFF
--- a/packages/core/src/interface.ts
+++ b/packages/core/src/interface.ts
@@ -483,12 +483,12 @@ export type CreateDataSourceInstanceOptions = {
 }
 
 export type DataSourceManagerConfigOption<OPTIONS, ENTITY_CONFIG_KEY extends string = 'entities'> = {
-  default?: PowerPartial<OPTIONS>;
+  default?: OPTIONS;
   defaultDataSourceName?: string;
   dataSource?: {
     [key: string]: PowerPartial<{
       [keyName in ENTITY_CONFIG_KEY]: any[];
-    } & OPTIONS>;
+    }> & OPTIONS;
   };
 } & CreateDataSourceInstanceOptions;
 


### PR DESCRIPTION
数据源配置参数类型不应该作转换，否则在使用类似
```ts
  protected getDbConfigByDbId(dbId: string): DbConfig | undefined {
    const dbConfig = this.sourceConfig.dataSource?.[dbId]
    return dbConfig
  }
```
取值获得的类型是可能无法赋值给 `DbConfig` 类型