### PR TITLE
fix: swagger组件中，ApiResponse 的 schema 参数的处理

### DIFF
--- a/packages/swagger/src/swaggerExplorer.ts
+++ b/packages/swagger/src/swaggerExplorer.ts
@@ -643,7 +643,35 @@ export class SwaggerExplorer {
       for (const k of keys) {
         // 这里是引用，赋值可以直接更改
         const tt = resp[k];
-        if (tt.type) {
+
+        /**
+         * 针对直接配置了scheme的写法 适用于统一的响应格式的情况
+         * 
+         * 例如以下例子，只需要配置data的类型即可
+         * ApiOkResponse({
+         *  description: '请求成功描述',
+         *  schema: {
+         *    title: `响应数据`,
+         *    allOf: [
+         *      {
+         *        $ref: getSchemaPath(ResponsOkDto),
+         *      },
+         *      {
+         *        properties: {
+         *          data: Data,
+         *        },
+         *      },
+         *    ],
+         *  },
+         * })
+         */
+        if (tt.schema) {
+          tt.content = {
+            'application/json': {
+              schema: tt.schema
+            }
+          }
+        } else if (tt.type) {
           if (Types.isClass(tt.type)) {
             this.parseClzz(tt.type);
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->

- @midway/swagger

##### Description of change
<!-- Provide a description of the change below this comment. -->

swagger组件中对直接配置了scheme 的写法做了一些兼容

起因是打算封装一个固定响应格式的装饰器，发现以下写法，直接使用schema不生效
```ts
import { ApiExtraModel, ApiOkResponse, getSchemaPath, ReferenceObject, SchemaObject, Type } from '@midwayjs/swagger';
import { ResponseVO } from '@/model/view/Basic';

export interface IResponseOptions<T extends Type<any>> {
  type: T;
  description?: string;
  isArray?: boolean;
  isPaginated?: boolean;
}

const baseTypeNames = ['String', 'Number', 'Boolean'];

export const ApiBasicResponse = <T extends Type<any>>(options: IResponseOptions<T>): MethodDecorator => {
  const { type } = options;
  const typeName = type?.name || 'null';
  let responseData: SchemaObject | ReferenceObject;
  if (options.isArray) {
    responseData = { type: 'array', items: { $ref: getSchemaPath(type) } };
  } else if (options.isPaginated) {
    responseData = {
      type: 'object',
      properties: {
        items: { type: 'array', items: { $ref: getSchemaPath(type) } },
        total: { type: 'number' },
        success: { type: 'boolean' },
      },
    };
  } else if (type) {
    if (baseTypeNames.includes(typeName)) {
      responseData = { type: typeName.toLocaleLowerCase() };
    } else {
      responseData = { $ref: getSchemaPath(type) };
    }
  } else {
    responseData = {
      type: 'null',
      nullable: true,
      default: null,
    };
  }

  const decorators: MethodDecorator[] = [
    ApiOkResponse({
      description: options.description || '请求成功响应',
      schema: {
        title: `响应数据 ${typeName}`,
        allOf: [
          {
            $ref: getSchemaPath(ResponseVO),
          },
          {
            properties: {
              data: responseData,
            },
          },
        ],
      },
    }),
  ];

  return (target, propertyKey, descriptor) => {
    ApiExtraModel([ResponseVO, type].filter(Boolean))(target.constructor);
    decorators.forEach(decorator => decorator(target, propertyKey, descriptor));
  };
};

```

> 另外还有一个Bug，使用`ApiExtraModels`绑定到`Method`也不生效，看源码貌似只对绑定到`Class`的数据进行了处理，因时间关系没有再行修复，而是直接改一下实现，手动绑定到类中

```ts
ApiExtraModel([ResponseVO, type].filter(Boolean))(target.constructor);
```


