### PR TITLE
docs(awesome_midway.md): add @mwcp/paradedb

### DIFF
--- a/site/docs/awesome_midway.md
+++ b/site/docs/awesome_midway.md
@@ -13,6 +13,7 @@
 | [@mwcp/kmore][@mwcp/kmore]                           | waitingsong | midway 数据库组件 基于 [Knex]，通过 `Transactional` 装饰器支持声明式事务，支持自动分页、智能连表，集成 [OpenTelemetry] 链路追踪                                                                                                                              |
 | [@mwcp/otel][@mwcp/otel]                             | waitingsong | midway [OpenTelemetry] 增强组件 支持 [`Trace`][Trace], [`TraceLog`][TraceLog], [`TraceInit`][TraceInit] 装饰器  并支持[传入泛型参数获得方法入参类型][otel-generics-cn]                                                                                       |
 | [@mwcp/jwt][@mwcp/jwt]                               | waitingsong | midway JWT 增强组件 支持 [`Public`][jwt-public] 装饰器                                                                                                                                                                                                       |
+| [@mwcp/paradedb][@mwcp/paradedb]                     | waitingsong | midway [ParadeDb] 组件。首个基于 Postgres 的 Elasticsearch 开源替代，采用 Rust 编写, 旨在提供快速的全文检索、语义检索和混合检索能力，适用于搜索场景                                                                                                          |
 | [@mwcp/pgmq][@mwcp/pgmq]                             | waitingsong | midway [pqmg-js] 组件 支持 [`Consumer`][Consumer], [`PgmqListener`][PgmqListener] 装饰器， 支持事务以及事务保护的类似 MQ `Exchange` 概念的路由。  [PGMQ] 是一个基于 [PG] 数据库扩展的轻量级消息队列，原生支持消息持久化和延迟消息，类似 `AWS SQS` 或  `RSMQ` |
 | [midway-throttler][midway-throttler]                 | larryzhuo   | midway throttler 限流组件                                                                                                                                                                                                                                    |
 
@@ -77,6 +78,9 @@
 
 [@mwcp/jwt]: https://github.com/waitingsong/midway-components/tree/main/packages/jwt
 [jwt-public]: https://github.com/waitingsong/midway-components/blob/main/packages/jwt/README.md#public-decorator
+
+[@mwcp/paradedb]: https://github.com/waitingsong/paradedb/tree/main/packages/mwcp-paradedb
+[ParadeDB]: https://pigsty.cc/zh/blog/pg/paradedb/
 
 [@mwcp/pgmq]: https://github.com/waitingsong/pgmq-js/tree/main/packages/mwcp-pgmq-js
 [PGMQ]: https://tembo-io.github.io/pgmq/

--- a/site/docs/awesome_midway.md
+++ b/site/docs/awesome_midway.md
@@ -18,9 +18,9 @@
 
 ## 插件
 
-| 名称                                   | 作者  | 描述                  |
-| -------------------------------------- | ----- | --------------------- |
-| [邮件组件][mailer-zh]                   | MrDotYan    | midway 邮箱组件，基于nodemailer和midwayjs，以服务的形式注入控制器使用[文档（国内）][mailer-zh-doc]    [文档（国外）][mailer-en-doc]                                                                                                                  |
+| 名称                  | 作者     | 描述                                                                                                                                |
+| --------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| [邮件组件][mailer-zh] | MrDotYan | midway 邮箱组件，基于nodemailer和midwayjs，以服务的形式注入控制器使用[文档（国内）][mailer-zh-doc]    [文档（国外）][mailer-en-doc] |
 ## swagger
 
 | 名称                                   | 作者  | 描述                  |
@@ -42,7 +42,7 @@
 | [midway-boot][midway-boot]         | 码道功臣      | 一个比较完整的后端功能最佳实践，包含：增删改查及基类封装、数据库操作、缓存操作、用户安全认证及访问安全控制、JWT 访问凭证、分布式访问状态管理、密码加解密、统一返回结果封装、统一异常管理、Snowflake 主键生成、Swagger 集成及支持访问认证、环境变量的使用、Docker 镜像构建、Serverless 发布等 |
 | [midway-vue3-ssr][midway-vue3-ssr] | LiQingSong    | 基于 Midway、Vue 3 组装的 SSR 框架，简单、易学易用、方便扩展、集成 Midway 框架，您一直想要的 Vue SSR 框架。                                                                                                                                                                                  |
 | [midway-learn][midway-learn]       | hbsjmsjwj     | 一个学习midway的demo，包含 midway3 + egg + 官方的组件&扩展（consul, jwt, typeorm, prometheus, swagger, mysql2,grpc,rabbitmq）                                                                                                                                                                |
-| [midway-admin][midwayjs-admin]       | MrDotYan     | 一套GeekerAdmin+Midwayjs构建的后台管理框架                                                                                                                                                      |
+| [midway-admin][midwayjs-admin]     | MrDotYan      | 一套GeekerAdmin+Midwayjs构建的后台管理框架                                                                                                                                                                                                                                                   |
 
 ## 学习资料
 

--- a/site/i18n/en/docusaurus-plugin-content-docs/current/awesome_midway.md
+++ b/site/i18n/en/docusaurus-plugin-content-docs/current/awesome_midway.md
@@ -4,15 +4,18 @@ The following lists high-quality community projects related to Midwayjs
 
 ## Microservices
 
-| Name                                         | Author      | Description                                                                                                                                                                                                                                                       |
-| -------------------------------------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [@letscollab/midway-nacos][@lnulls]          | Nawbc       | midway nacos component                                                                                                                                                                                                                                            |
-| [midway-elasticsearch][midway-elasticsearch] | ddzyan      | Mi1dway elasticsearch component                                                                                                                                                                                                                                   |
-| [midway-apollo][midway-apollo]               | helloHT     | Midway Ctrip Asynchronous Dynamic Configuration apollo Components                                                                                                                                                                                                 |
-| [@mwcp/cache][@mwcp/cache]                   | waitingsong | midway Cache Component supports [`Cacheable`][Cacheable], [`CacheEvict`][CacheEvict], [`CachePut`][CachePut] decorators and supports generics for [obtaining method parameter type][cache-generics]                                                               |
-| [@mwcp/kmore][@mwcp/kmore]                   | waitingsong | midway Database QueryBuilder base on [Knex], declarative transaction via `Transactional` decorator, intergrated [OpenTelemetry] trace                                                                                                                             |
-| [@mwcp/otel][@mwcp/otel]                     | waitingsong | midway [OpenTelemetry] component supports [`Trace`][Trace], [`TraceLog`][TraceLog], [`TraceInit`][TraceInit] decorators and supports generics for [obtaining method parameter type][otel-generics]                                                                |
-| [@mwcp/jwt][@mwcp/jwt]                       | waitingsong | midway JWT component supports [`Public`][jwt-public] decorator                                                                                                                                                                                                    |
+| Name                                         | Author      | Description                                                                                                                                                                                         |
+| -------------------------------------------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [@letscollab/midway-nacos][@lnulls]          | Nawbc       | midway nacos component                                                                                                                                                                              |
+| [midway-elasticsearch][midway-elasticsearch] | ddzyan      | Mi1dway elasticsearch component                                                                                                                                                                     |
+| [midway-apollo][midway-apollo]               | helloHT     | Midway Ctrip Asynchronous Dynamic Configuration apollo Components                                                                                                                                   |
+| [@mwcp/cache][@mwcp/cache]                   | waitingsong | midway Cache Component supports [`Cacheable`][Cacheable], [`CacheEvict`][CacheEvict], [`CachePut`][CachePut] decorators and supports generics for [obtaining method parameter type][cache-generics] |
+| [@mwcp/kmore][@mwcp/kmore]                   | waitingsong | midway Database QueryBuilder base on [Knex], declarative transaction via `Transactional` decorator, intergrated [OpenTelemetry] trace                                                               |
+| [@mwcp/otel][@mwcp/otel]                     | waitingsong | midway [OpenTelemetry] component supports [`Trace`][Trace], [`TraceLog`][TraceLog], [`TraceInit`][TraceInit] decorators and supports generics for [obtaining method parameter type][otel-generics]  |
+| [@mwcp/jwt][@mwcp/jwt]                       | waitingsong | midway JWT component supports [`Public`][jwt-public] decorator                                                                                                                                      |
+
+
+|  [@mwcp/paradedb][@mwcp/paradedb]                    | waitingsong | midway [ParadeDb] component. Postgres for Search & Analytics —— Modern Elasticsearch Alternative built on Postgres  |
 | [@mwcp/pgmq][@mwcp/pgmq]                     | waitingsong | midway [pqmg-js] component supports [`Consumer`][Consumer], [`PgmqListener`][PgmqListener] decorators. [PGMQ] is a lightweight message queue based on [PG] database, with native support for message persistence and delayed messages, similar to AWS SQS or RSMQ |
 
 | [midway-throttler][midway-throttler]         | larryzhuo   | midway throttler current limiting component                                                                                                                                                         |
@@ -72,6 +75,9 @@ Welcome everyone to contribute to the community, edit this page and add your fav
 
 [@mwcp/jwt]: https://github.com/waitingsong/midway-components/tree/main/packages/jwt
 [jwt-public]: https://github.com/waitingsong/midway-components/blob/main/packages/jwt/README.md#public-decorator
+
+[@mwcp/paradedb]: https://github.com/waitingsong/paradedb/tree/main/packages/mwcp-paradedb
+[ParadeDB]: https://www.paradedb.com/
 
 [@mwcp/pgmq]: https://github.com/waitingsong/pgmq-js/tree/main/packages/mwcp-pgmq-js
 [PGMQ]: https://tembo-io.github.io/pgmq/


### PR DESCRIPTION
midway ParadeDb 组件。首个基于 Postgres 的 Elasticsearch 开源替代，采用 Rust 编写, 旨在提供快速的全文检索、语义检索和混合检索能力，适用于搜索场景     

official: https://www.paradedb.com/
link: https://pigsty.cc/zh/blog/pg/paradedb/            

