### PR TITLE
fix: wrong object format for sse response

### DIFF
--- a/packages/core/src/response/sse.ts
+++ b/packages/core/src/response/sse.ts
@@ -52,9 +52,7 @@ export class ServerSendEventStream<
         this.ctx.req.socket.setTimeout(0);
         this.ctx.req.socket.setNoDelay(true);
         this.ctx.req.socket.setKeepAlive(true);
-        res.push({
-          data: ':ok',
-        });
+        res.push(': ok');
       }
 
       const senderObject = chunk;


### PR DESCRIPTION
按照 [whatwg](https://html.spec.whatwg.org/multipage/server-sent-events.html#parsing-an-event-stream) 规范 ，修复之前 sse 第一次传递对象的情况，改为正常的带冒号注释。