### PR TITLE
fix(leoric): keep multiple datasources from conflicting base model

### DIFF
--- a/packages/leoric/package.json
+++ b/packages/leoric/package.json
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "leoric": "2.13.1"
+    "leoric": "2.13.2"
   },
   "devDependencies": {
     "@midwayjs/core": "^3.19.0",

--- a/packages/leoric/src/dataSourceManager.ts
+++ b/packages/leoric/src/dataSourceManager.ts
@@ -29,6 +29,11 @@ export class LeoricDataSourceManager extends DataSourceManager<
 
   @Init()
   async init() {
+    if (Object.keys(this.leoricConfig.dataSource).length > 1) {
+      for (const dataSource of Object.values(this.leoricConfig.dataSource)) {
+        dataSource.subclass = true;
+      }
+    }
     await this.initDataSource(this.leoricConfig, {
       baseDir: this.baseDir,
       entitiesConfigKey: 'models',

--- a/packages/leoric/test/fixtures/multi/package.json
+++ b/packages/leoric/test/fixtures/multi/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "midwayjs-leoric-multi"
+}

--- a/packages/leoric/test/fixtures/multi/src/config/config.default.ts
+++ b/packages/leoric/test/fixtures/multi/src/config/config.default.ts
@@ -1,0 +1,21 @@
+import * as path from 'path';
+
+export const keys = 'hakuna matata';
+
+export const leoric = {
+  dataSource: {
+    custom: {
+      dialect: 'sqlite',
+      database: path.join(__dirname, '../../', 'database.sqlite'),
+      models: ['model/*{.ts,.js}'],
+      sync: true,
+    },
+    subsystem: {
+      dialect: 'sqlite',
+      database: path.join(__dirname, '../../', 'subsystem.sqlite'),
+      models: ['subsystem/model/*{.ts,.js}'],
+      sync: true,
+    }
+  },
+  defaultDataSourceName: 'custom',
+}

--- a/packages/leoric/test/fixtures/multi/src/configuration.ts
+++ b/packages/leoric/test/fixtures/multi/src/configuration.ts
@@ -1,0 +1,29 @@
+import { Configuration } from "@midwayjs/core";
+import * as koa from '@midwayjs/koa';
+import * as leoric from '../../../../src';
+import * as path from 'path';
+
+const { InjectDataSource } = leoric;
+
+@Configuration({
+  imports: [koa, leoric],
+  conflictCheck: true,
+  importConfigs: [path.join(__dirname, 'config')],
+})
+export class ContainerLifeCycle {
+  @InjectDataSource()
+  defaultDataSource: leoric.Realm;
+
+  @InjectDataSource('custom')
+  namedDataSource: leoric.Realm;
+
+  @InjectDataSource('subsystem')
+  subsystemDataSource: leoric.Realm;
+
+  async onReady() {
+    expect(this.defaultDataSource).toBeDefined();
+    expect(this.defaultDataSource).toEqual(this.namedDataSource);
+    expect(this.defaultDataSource).not.toEqual(this.subsystemDataSource);
+    
+  }
+}

--- a/packages/leoric/test/fixtures/multi/src/model/user.ts
+++ b/packages/leoric/test/fixtures/multi/src/model/user.ts
@@ -1,0 +1,25 @@
+import { Bone, Column } from '../../../../../src';
+
+export default class User extends Bone {
+  @Column()
+  id: bigint;
+
+  @Column()
+  name: string;
+
+  @Column()
+  birthday: Date;
+
+  @Column()
+  createdAt: Date;
+
+  get age(): number {
+    const now = new Date();
+    const then = this.birthday;
+    const diff = now.getFullYear() - then.getFullYear();
+    if (now.getMonth() >= then.getMonth() && now.getDate() >= then.getDate()) {
+      return diff;
+    }
+    return diff - 1;
+  }
+}

--- a/packages/leoric/test/fixtures/multi/src/service/user.ts
+++ b/packages/leoric/test/fixtures/multi/src/service/user.ts
@@ -1,0 +1,21 @@
+import { Provide } from '@midwayjs/core';
+import User from '../model/user';
+import { InjectModel } from '../../../../../src';
+
+@Provide()
+export class UserService {
+  @InjectModel(User)
+  User: typeof User;
+
+  async list() {
+    return this.User.find();
+  }
+
+  async add(options) {
+    return this.User.create(options);
+  }
+
+  async delete() {
+    return this.User.remove({});
+  }
+}

--- a/packages/leoric/test/fixtures/multi/src/subsystem/controller/post.ts
+++ b/packages/leoric/test/fixtures/multi/src/subsystem/controller/post.ts
@@ -1,0 +1,13 @@
+import { Controller, Get, Inject } from "@midwayjs/core";
+import { PostService } from "../service/post";
+
+@Controller('/api/posts')
+export class PostController {
+  @Inject()
+  postService: PostService;
+
+  @Get('')
+  async get() {
+    return await this.postService.get();
+  }
+}

--- a/packages/leoric/test/fixtures/multi/src/subsystem/model/post.ts
+++ b/packages/leoric/test/fixtures/multi/src/subsystem/model/post.ts
@@ -1,0 +1,18 @@
+import { Bone, Column, DataTypes } from '../../../../../../src';
+
+export default class Post extends Bone {
+  @Column()
+  id: bigint;
+
+  @Column()
+  title: string;
+
+  @Column(DataTypes.TEXT)
+  content: string;
+
+  @Column()
+  createdAt: Date;
+
+  @Column()
+  updatedAt: Date;
+}

--- a/packages/leoric/test/fixtures/multi/src/subsystem/service/post.ts
+++ b/packages/leoric/test/fixtures/multi/src/subsystem/service/post.ts
@@ -1,0 +1,22 @@
+import { Provide } from '@midwayjs/core';
+import { InjectModel, WhereConditions } from '../../../../../../src';
+import Post from '../model/post';
+
+
+@Provide()
+export class PostService {
+  @InjectModel(Post, 'subsystem')
+  Post: typeof Post;
+
+  async get(conditions?: WhereConditions<typeof Post>) {
+    return await this.Post.find(conditions || {});
+  }
+
+  async add(values) {
+    return await this.Post.create(values);
+  }
+
+  async delete(conditions?: WhereConditions<typeof Post>) {
+    return await this.Post.remove(conditions || {});
+  }
+}

--- a/packages/leoric/test/multi.test.ts
+++ b/packages/leoric/test/multi.test.ts
@@ -1,0 +1,61 @@
+import { close, createHttpRequest, createApp } from '@midwayjs/mock';
+import { join } from 'path';
+import { existsSync, unlinkSync } from 'fs';
+import { IMidwayApplication } from '@midwayjs/core';
+import { PostService } from './fixtures/multi/src/subsystem/service/post';
+import { Database } from 'sqlite3';
+import { Values } from 'leoric';
+import Post from './fixtures/multi/src/subsystem/model/post';
+
+function cleanFile(file) {
+  if (existsSync(file)) {
+    unlinkSync(file);
+  }
+}
+
+describe('test/multi.test.ts', () => {
+  let app: IMidwayApplication;
+  let postService: PostService;
+
+  beforeAll(async () => {
+    cleanFile(join(__dirname, 'fixtures/multi', 'database.sqlite'));
+    cleanFile(join(__dirname, 'fixtures/multi', 'subsystem.sqlite'));
+    app = await createApp(join(__dirname, 'fixtures', 'multi'));
+    postService = await app
+      .getApplicationContext()
+      .getAsync(PostService);
+  });
+
+  afterAll(async () => {
+    await close(app);
+  });
+
+  beforeEach(async () => {
+    await postService.add({ title: 'Levi' });
+  });
+
+  afterEach(async () => {
+    await postService.delete();
+  });
+
+  it('list post', async () => {
+    const res = await createHttpRequest(app)
+      .get('/api/posts')
+      .expect(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body[0].title).toEqual('Levi');
+  });
+
+  it('bound to specifc database', async () => {
+    const database = new Database(join(__dirname, 'fixtures/multi', 'subsystem.sqlite'));
+    const result = await new Promise<Values<Post>>((resolve, reject) => {
+      database.get('SELECT * FROM posts', (err, row) => {
+        if (err) reject(err);
+        else resolve(row as Values<Post>);
+      });
+    });
+    expect(result).not.toBe(null);
+    expect(result.title).toEqual('Levi');
+  });
+
+});


### PR DESCRIPTION

##### Checklist

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

- leoric


##### Description of change

- the base model of leoric (namely the `Bone` class) might be polluted if multiple datasources were configured. this pr fixes this issue.