### PR TITLE
feat(bull): Add a config to make Bull create jobs without processing …

### DIFF
--- a/packages/bull/src/decorator.ts
+++ b/packages/bull/src/decorator.ts
@@ -6,7 +6,8 @@ import {
   Scope,
   ScopeEnum,
 } from '@midwayjs/core';
-import { JobOptions, QueueOptions } from 'bull';
+import { QueueOptions } from 'bull';
+import { JobOptions } from './interface';
 import { BULL_PROCESSOR_KEY, BULL_QUEUE_KEY } from './constants';
 
 export function Processor(

--- a/packages/bull/src/interface.ts
+++ b/packages/bull/src/interface.ts
@@ -1,5 +1,9 @@
 import { IMidwayApplication, IMidwayContext, NextFunction as BaseNextFunction } from '@midwayjs/core';
-import { JobId, Job } from 'bull';
+import { JobId, Job, JobOptions as JobOptionsBase } from 'bull';
+
+export interface JobOptions extends JobOptionsBase {
+  enabledEnvironment?: string[];
+}
 
 export interface IProcessor {
   execute(data: any);

--- a/packages/bull/test/fixtures/base-app-only-create/package.json
+++ b/packages/bull/test/fixtures/base-app-only-create/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "ali-demo"
+}

--- a/packages/bull/test/fixtures/base-app-only-create/src/configuration.ts
+++ b/packages/bull/test/fixtures/base-app-only-create/src/configuration.ts
@@ -1,0 +1,14 @@
+import { Configuration } from '@midwayjs/core';
+import * as bull from '../../../../src';
+
+@Configuration({
+  imports: [
+    bull
+  ],
+})
+export class ContainerConfiguration {
+
+  async onReady() {
+
+  }
+}

--- a/packages/bull/test/fixtures/base-app-only-create/src/task/queue.task.ts
+++ b/packages/bull/test/fixtures/base-app-only-create/src/task/queue.task.ts
@@ -1,0 +1,18 @@
+import { App, Inject } from '@midwayjs/core';
+import { Processor, Application } from '../../../../../src';
+
+@Processor('test', {
+  enabledEnvironment: ['prod'],
+})
+export class QueueTask {
+  @App()
+  app: Application;
+
+  @Inject()
+  logger;
+
+  async execute(params) {
+    this.logger.info(`====>QueueTask execute`);
+    this.app.setAttr(`queueConfig`, JSON.stringify(params));
+  }
+}

--- a/packages/bull/test/index.test.ts
+++ b/packages/bull/test/index.test.ts
@@ -47,6 +47,27 @@ describe(`/test/index.test.ts`, () => {
     await close(app);
   });
 
+  it('test processor only create, not execute', async () => {
+    const app = await createApp(join(__dirname, 'fixtures', 'base-app-only-create'), {}, bull);
+
+    await sleep(5 * 1000);
+
+    // run job
+    const bullFramework = app.getApplicationContext().get(bull.Framework);
+    expect(bullFramework.getCoreLogger()).toBeDefined();
+    const testQueue = bullFramework.getQueue('test');
+    expect(testQueue).toBeDefined();
+
+    const params = {
+      name: 'stone-jin',
+    };
+    const job = await testQueue?.runJob(params, { delay: 1000 });
+    expect(await job?.getState()).toEqual('delayed');
+    await sleep(1200);
+    expect(await job?.getState()).toEqual('delayed');
+
+    await close(app);
+  });
 });
 
 // describe('test another duplicated error', function () {

--- a/site/docs/extensions/bull.md
+++ b/site/docs/extensions/bull.md
@@ -338,6 +338,7 @@ export class TestProcessor implements IProcessor {
 | removeOnComplete | boolean \| number     | 如果为 true，则在成功完成后删除任务。如果设置数字，则为指定要保留的任务数量。默认行为是任务信息保留在已完成列表中。 |
 | removeOnFail     | boolean \| number     | 如果为 true，则在所有尝试后都失败时删除任务。如果设置数字，指定要保留的任务数量。默认行为是将任务信息保留在失败列表中。 |
 | stackTraceLimit  | number                | 限制将在堆栈跟踪中记录的堆栈跟踪行的数量。                   |
+| enableEnvironment | string[]             | 执行任务的环境变量列表, 若不指定该参数，则默认在所有的环境中执行 |
 
 
 
@@ -818,7 +819,7 @@ export class MainConfiguration {
 
   @Inject()
   bullFramework: bull.Framework;
-  
+
   @Inject()
   bullBoardManager: bullBoard.BullBoardManager;
 


### PR DESCRIPTION
…on startup.

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->

* bull 组件


##### Description of change
<!-- Provide a description of the change below this comment. -->

在装饰器中新增 `enabledEnvironment` 参数，用于实现生产者与消费者之间的环境隔离。

假设主项目的运行环境为 `prod`，而消费者的运行环境为 `prod_consumer`。通过以下方式配置装饰器：

```ts
@Processor('test', {
  enabledEnvironment: ['prod_consumer'], // 指定任务允许执行的环境
})
export class TestProcessor implements IProcessor {
  async execute(params) {
    // 示例：params.aaa => 1
  }
}
```

### 使用示例

1. **任务生产**  
   调用 `runJob` 方法向队列添加任务：
   ```ts
   const testQueue = this.bullFramework.getQueue('test');
   await testQueue?.runJob({
     aaa: 1,
     bbb: 2,
   });
   ```
   > 注意：任务仅会在 `prod_consumer` 环境下被消费者处理。

2. **任务消费**  
   当消费者运行于 `prod_consumer` 环境时，`TestProcessor` 中的 `execute` 方法会被触发执行。
