### PR TITLE
feat(rabbitmq): add msg into rabbitmq ctx

### DIFF
--- a/packages/rabbitmq/src/framework.ts
+++ b/packages/rabbitmq/src/framework.ts
@@ -85,6 +85,7 @@ export class MidwayRabbitMQFramework extends BaseFramework<
             listenerOptions,
             async (data: ConsumeMessage, channel, channelWrapper) => {
               const ctx = {
+                data,
                 channel,
                 queueName: listenerOptions.queueName,
                 ack: data => {

--- a/packages/rabbitmq/src/interface.ts
+++ b/packages/rabbitmq/src/interface.ts
@@ -11,20 +11,29 @@ import type { ConfirmChannel, Channel, Options as AmqpOptions } from 'amqplib';
 export interface IRabbitMQApplication {
   connect(...args): Promise<void>;
   createChannel(): Promise<Channel | ConfirmChannel>;
-  createConsumer(listenerOptions: RabbitMQListenerOptions, listenerCallback: (msg: ConsumeMessage | null, channel: Channel, channelWrapper) => Promise<void>): Promise<void>;
+  createConsumer(
+    listenerOptions: RabbitMQListenerOptions,
+    listenerCallback: (
+      msg: ConsumeMessage | null,
+      channel: Channel,
+      channelWrapper
+    ) => Promise<void>
+  ): Promise<void>;
   close(): Promise<void>;
 }
 
-export type IMidwayRabbitMQApplication = IMidwayApplication<IMidwayRabbitMQContext> & IRabbitMQApplication;
+export type IMidwayRabbitMQApplication =
+  IMidwayApplication<IMidwayRabbitMQContext> & IRabbitMQApplication;
 
 export interface IRabbitMQExchange {
-  name: string,
-  type: string,
-  options?: Options.AssertExchange
+  name: string;
+  type: string;
+  options?: Options.AssertExchange;
 }
 
-export interface IMidwayRabbitMQConfigurationOptions extends IConfigurationOptions {
-  url: string | Options.Connect,
+export interface IMidwayRabbitMQConfigurationOptions
+  extends IConfigurationOptions {
+  url: string | Options.Connect;
   socketOptions?: any;
   reconnectTime?: number;
   exchanges?: IRabbitMQExchange[];
@@ -32,6 +41,7 @@ export interface IMidwayRabbitMQConfigurationOptions extends IConfigurationOptio
 }
 
 export type IMidwayRabbitMQContext = IMidwayContext<{
+  data: ConsumeMessage;
   channel: Channel;
   queueName: string;
   ack: (data: any) => void;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines


> @midwayjs/rabbitmq@3.20.4 test
> node --require=ts-node/register ../../node_modules/.bin/jest --runInBand

2025-04-17 19:10:42.590 INFO 9332 Message Queue connected!
2025-04-17 19:10:43.741 INFO 9332 Rabbitmq server start success
2025-04-17 19:10:43.748 INFO 9332 test output => something to do
2025-04-17 19:10:48.189 INFO 9332 Message Queue connected!
2025-04-17 19:10:48.191 INFO 9332 Rabbitmq server start success
2025-04-17 19:10:50.810 INFO 9332 Message Queue connected!
2025-04-17 19:10:51.718 INFO 9332 Rabbitmq server start success
2025-04-17 19:11:00.700 INFO 9332 Message Queue connected!
2025-04-17 19:11:03.096 INFO 9332 Rabbitmq server start success
2025-04-17 19:11:03.283 INFO 9332 test output2 => Hello World!
2025-04-17 19:11:03.284 INFO 9332 test output1 => Hello World!
2025-04-17 19:11:11.548 INFO 9332 Message Queue connected!
2025-04-17 19:11:14.292 INFO 9332 Rabbitmq server start success
2025-04-17 19:11:14.473 INFO 9332 test output1 => Hello World!
 PASS  test/index.test.ts (43.98 s)
  /test/index.test.ts
    ✓ should test create channel with legacy method (6662 ms)
    ✓ should test create channel with new method (4221 ms)
    ✓ should test listen a not exist channel and channel will be close by server (8374 ms)
    ✓ should test fanout publish and subscribe (10834 ms)
    ✓ should test direct publish and subscribe (11271 ms)

Test Suites: 1 passed, 1 total
Tests:       5 passed, 5 total
Snapshots:   0 total
Time:        44.056 s
Ran all test suites.


##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->
@midwayjs/rabbitmq

##### Description of change
<!-- Provide a description of the change below this comment. -->
修改：
在 @midwayjs/rabbitmq 中将 data: ConsumeMessage 消息，挂载到 context 上

背景：
在分布式系统中，保持请求 traceid 在各个微服务间一致是一个强需求，有助于快速定位到一次请求的所有日志；因此 @midwayjs/rabbitmq， @midwayjs/grpc 等 framework 都有必要能够支持外部 traceid（主要是 http 服务中产生的 traceid）写入到各自 framework 的请求上下文中，这样才能够在 logger 中统一打印出所有 ctx.traceid。

@midwayjs/grpc 可以通过 grpc 本身的 metadata + middleware  在微服务公共库中实现 traceid 的传递；

@midwayjs/rabbitmq 则没有办法，因为传递 traceid 最好的方式是通过 rabbitmq 的 publish 方法中的 correlationId 传递， consume 侧读取则是通过 msg.properties.correlationId  读取； **但是 ctx 上没有挂载 data: ConsumeMessage， 导致在 middleware 中无法通过 msg.properties.correlationId  读取到 traceid， 必须在业务代码中编写这个逻辑，不是很灵活**。 