### PR TITLE
docs: update static_file.md for static directory not found

### DIFF
--- a/site/i18n/en/docusaurus-plugin-content-docs/current/extensions/static_file.md
+++ b/site/i18n/en/docusaurus-plugin-content-docs/current/extensions/static_file.md
@@ -222,3 +222,7 @@ export default {
    static: false,
 } as EggPlugin;
 ```
+
+### 4.Internal Server Error, real status: 500
+
+If the static directory configured with staticFile does not exist, the server may throw a 500 error. Please ensure that the static directory you configured has been properly created.


### PR DESCRIPTION
If the configured static directory does not exist, the server will return a 500 error without any warning, and the request will not reach the routing layer. Documentation has been updated to include a reminder.

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ x] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

### 4.Internal Server Error, real status: 500

If the static directory configured with staticFile does not exist, the server may throw a 500 error. Please ensure that the static directory you configured has been properly created.
