### PR TITLE
fix: core error filter process empty error issue

### DIFF
--- a/packages/core/src/common/filterManager.ts
+++ b/packages/core/src/common/filterManager.ts
@@ -100,7 +100,7 @@ export class FilterManager<
   }> {
     let result, error;
     let matched = false;
-    if (this.exceptionMap.has((err as any).constructor)) {
+    if (err && this.exceptionMap.has((err as any).constructor)) {
       matched = true;
       const filterData = this.exceptionMap.get((err as any).constructor);
       result = await filterData.filter.catch(err, ctx, res, next);


### PR DESCRIPTION
runErrorFilter will throw an unexpected error when the upper throws an empty error, making it impossible to locate the real error, and the filter can’t continue processing the response result:

```
TypeError: Cannot read properties of undefined (reading 'constructor') at FilterManager.runErrorFilter
```

The reason is that the upper does not fully comply with eslint rules:

- no-throw-literal
- prefer-promise-reject-errors

When the following error is thrown, it prevents the `err.constructor`:

```js
Promise.reject();
throw undefined;
throw null;
```

This pull request fixes the filter to handle various scenarios correctly.