### PR TITLE
feat: add one-shot component

### DIFF
--- a/packages/one-shot/index.d.ts
+++ b/packages/one-shot/index.d.ts
@@ -1,0 +1,9 @@
+import { OneShotConfigOptions } from './dist/index';
+
+export * from './dist/index';
+
+declare module '@midwayjs/core/dist/interface' {
+  interface MidwayConfig {
+    oneShot?: Partial<OneShotConfigOptions>;
+  }
+}

--- a/packages/one-shot/jest.config.js
+++ b/packages/one-shot/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testPathIgnorePatterns: ['<rootDir>/test/fixtures'],
+  coveragePathIgnorePatterns: ['<rootDir>/test/'],
+};

--- a/packages/one-shot/package.json
+++ b/packages/one-shot/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@midwayjs/one-shot",
+  "version": "4.0.0-beta.2",
+  "description": "Midway One-shot Framework",
+  "main": "dist/index.js",
+  "typings": "index.d.ts",
+  "keywords": [
+    "midway",
+    "component",
+    "one-shot"
+  ],
+  "author": "czy88840616@gmail.com",
+  "files": [
+    "dist/**/*.js",
+    "dist/**/*.d.ts",
+    "index.d.ts"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "node -r ts-node/register ../../node_modules/jest/bin/jest.js --runInBand",
+    "cov": "node -r ts-node/register ../../node_modules/jest/bin/jest.js --runInBand --coverage --forceExit",
+    "ci": "npm run test",
+    "lint": "mwts check"
+  },
+  "dependencies": {
+    "@midwayjs/core": "workspace:^"
+  },
+  "devDependencies": {
+    "@midwayjs/mock": "workspace:^"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "license": "MIT"
+}

--- a/packages/one-shot/src/configuration.ts
+++ b/packages/one-shot/src/configuration.ts
@@ -1,0 +1,22 @@
+import { Configuration } from '@midwayjs/core';
+
+/**
+ * One-shot component configuration.
+ */
+@Configuration({
+  namespace: 'oneShot',
+  importConfigs: [
+    {
+      default: {
+        midwayLogger: {
+          clients: {
+            oneShotLogger: {
+              fileLogName: 'midway-one-shot.log',
+            },
+          },
+        },
+      },
+    },
+  ],
+})
+export class OneShotConfiguration {}

--- a/packages/one-shot/src/framework.ts
+++ b/packages/one-shot/src/framework.ts
@@ -1,0 +1,63 @@
+import {
+  BaseFramework,
+  Framework,
+  IMidwayBootstrapOptions,
+  MidwayCommonError,
+} from '@midwayjs/core';
+import {
+  IMidwayOneShotApplication,
+  IMidwayOneShotContext,
+  OneShotConfigOptions,
+  OneShotRunner,
+} from './interface';
+
+/**
+ * Framework for one-shot scripts.
+ */
+@Framework()
+export class MidwayOneShotFramework extends BaseFramework<
+  IMidwayOneShotApplication,
+  IMidwayOneShotContext,
+  OneShotConfigOptions
+> {
+  protected frameworkLoggerName = 'oneShotLogger';
+
+  configure(): OneShotConfigOptions {
+    return this.configService.getConfiguration('oneShot');
+  }
+
+  async applicationInitialize(_options: IMidwayBootstrapOptions) {
+    void _options;
+    this.app = {} as IMidwayOneShotApplication;
+  }
+
+  public async run(): Promise<void> {
+    // one-shot framework runs on demand
+  }
+
+  /**
+   * Execute a one-shot runner class once.
+   */
+  public async runScript<T = unknown, R = unknown>(
+    Runner: new (...args: unknown[]) => OneShotRunner<T, R>,
+    payload?: T,
+    ctxData: Partial<IMidwayOneShotContext> = {}
+  ): Promise<R> {
+    const ctx = this.app.createAnonymousContext({
+      ...ctxData,
+      payload,
+    });
+
+    const fn = await this.applyMiddleware(async ctx => {
+      const instance = (await ctx.requestContext.getAsync(
+        Runner
+      )) as OneShotRunner<T, R>;
+      if (!instance?.run) {
+        throw new MidwayCommonError('One-shot runner must implement run().');
+      }
+      return await instance.run(payload, ctx);
+    });
+
+    return (await fn(ctx)) as R;
+  }
+}

--- a/packages/one-shot/src/index.ts
+++ b/packages/one-shot/src/index.ts
@@ -1,0 +1,3 @@
+export * from './interface';
+export { MidwayOneShotFramework as Framework } from './framework';
+export { OneShotConfiguration as Configuration } from './configuration';

--- a/packages/one-shot/src/interface.ts
+++ b/packages/one-shot/src/interface.ts
@@ -1,0 +1,28 @@
+import {
+  IConfigurationOptions,
+  IMidwayApplication,
+  IMidwayContext,
+} from '@midwayjs/core';
+
+export interface OneShotConfigOptions extends IConfigurationOptions {
+  // global config
+}
+
+/**
+ * One-shot execution context.
+ */
+export interface IMidwayOneShotContext extends IMidwayContext {
+  payload?: unknown;
+}
+
+export type IMidwayOneShotApplication = IMidwayApplication<IMidwayOneShotContext>;
+
+export type Application = IMidwayOneShotApplication;
+export type Context = IMidwayOneShotContext;
+
+/**
+ * One-shot runner contract.
+ */
+export interface OneShotRunner<T = unknown, R = unknown> {
+  run(payload?: T, ctx?: IMidwayOneShotContext): R | Promise<R>;
+}

--- a/packages/one-shot/test/index.test.ts
+++ b/packages/one-shot/test/index.test.ts
@@ -1,0 +1,33 @@
+import { Inject, Provide } from '@midwayjs/core';
+import { close, createLightApp } from '@midwayjs/mock';
+import {
+  Context,
+  Framework,
+  OneShotRunner,
+} from '../src';
+
+@Provide()
+class SampleScript implements OneShotRunner<{ id: number }, string> {
+  @Inject()
+  ctx: Context;
+
+  async run(payload?: { id: number }): Promise<string> {
+    return `${payload?.id}:${(this.ctx.payload as { id?: number })?.id}`;
+  }
+}
+
+describe('one-shot framework', () => {
+  it('should run script with payload and context', async () => {
+    const app = await createLightApp({
+      imports: [require('../src')],
+      preloadModules: [SampleScript],
+    });
+
+    const framework = app.getFramework() as Framework;
+    const result = await framework.runScript(SampleScript, { id: 42 });
+
+    expect(result).toEqual('42:42');
+
+    await close(app);
+  });
+});

--- a/packages/one-shot/tsconfig.json
+++ b/packages/one-shot/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compileOnSave": true,
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": [
+    "./src/**/*.ts"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -894,6 +894,16 @@ importers:
         specifier: ^18
         version: 18.3.1(react@18.3.1)
 
+  packages/one-shot:
+    dependencies:
+      '@midwayjs/core':
+        specifier: workspace:^
+        version: link:../core
+    devDependencies:
+      '@midwayjs/mock':
+        specifier: workspace:^
+        version: link:../mock
+
   packages/oss:
     dependencies:
       '@types/ali-oss':

--- a/site/docs/extensions/commander.md
+++ b/site/docs/extensions/commander.md
@@ -48,7 +48,22 @@ export class MainConfiguration {}
 
 ## 编写命令
 
+目录结构示例：
+
+```bash
+.
+├── src
+│   ├── commands
+│   │   ├── hello.command.ts
+│   │   └── status.command.ts
+│   ├── configuration.ts
+│   └── ...
+├── bootstrap.js
+└── package.json
+```
+
 一个命令对应一个 Class，使用 `@Command()` 修饰，并实现 `CommandRunner` 接口的 `run()` 方法。
+
 
 ```typescript
 // src/commands/hello.command.ts

--- a/site/docs/extensions/commander.md
+++ b/site/docs/extensions/commander.md
@@ -1,4 +1,4 @@
-# Commander（命令行）
+# 命令行
 
 `@midwayjs/commander` 是一个基于 Midway IoC 容器的命令行组件，底层使用 [commander.js](https://github.com/tj/commander.js#readme) 做参数解析与 help 输出。你可以用 Midway 熟悉的依赖注入方式组织命令、选项解析与业务逻辑，并将命令拆分为多个 Class。
 

--- a/site/docs/extensions/one-shot.md
+++ b/site/docs/extensions/one-shot.md
@@ -1,0 +1,142 @@
+# One-shot
+
+`@midwayjs/one-shot` 是一个只提供 Framework 的一次性脚本执行组件，适合用 IoC 容器组织依赖，并在应用内触发一次性的任务逻辑。
+
+相关信息：
+
+| 描述              |      |
+| ----------------- | ---- |
+| 可用于标准项目    | ❌    |
+| 可用于 Serverless | ❌    |
+| 可用于一体化      | ❌   |
+| 包含独立主框架    | ✅    |
+| 包含独立日志      | ✅    |
+
+## 安装依赖
+
+在现有项目中安装 one-shot 组件依赖。
+
+```bash
+$ npm i @midwayjs/one-shot@4  --save
+```
+
+或者在 `package.json` 中增加如下依赖后，重新安装。
+
+```json
+{
+  "dependencies": {
+    "@midwayjs/one-shot": "^4.0.0"
+  }
+}
+```
+
+## 开启组件
+
+在入口配置中引入组件。
+
+```typescript
+// src/configuration.ts
+import { Configuration } from '@midwayjs/core';
+import * as oneShot from '@midwayjs/one-shot';
+
+@Configuration({
+  imports: [oneShot],
+})
+export class MainConfiguration {}
+```
+
+## 在生命周期执行
+
+该组件不要求编写额外 Runner，推荐在 `onServerReady` 生命周期里直接执行一次性脚本逻辑。
+
+```typescript
+// src/configuration.ts
+import { Configuration, Inject } from '@midwayjs/core';
+import * as oneShot from '@midwayjs/one-shot';
+import { ScriptService } from './service/script';
+
+@Configuration({
+  imports: [oneShot],
+})
+export class MainConfiguration {
+  @Inject()
+  scriptService: ScriptService;
+
+  async onServerReady() {
+    await this.scriptService.runOnce();
+  }
+}
+```
+
+## 需要请求作用域时
+
+如果脚本逻辑需要依赖请求作用域（request scope），可以通过 framework 的 `runScript` 执行一个固定格式的 service 类，框架会为本次执行创建上下文并走中间件/过滤器链。
+
+```typescript
+// src/script/syncUser.ts
+import { Provide } from '@midwayjs/core';
+import { OneShotRunner, Context } from '@midwayjs/one-shot';
+
+@Provide()
+export class SyncUserScript implements OneShotRunner<{ id: number }, void> {
+  async run(payload?: { id: number }, ctx?: Context) {
+    // use payload / ctx
+    void payload;
+    void ctx;
+  }
+}
+```
+
+```typescript
+// src/configuration.ts
+import { Configuration, Inject } from '@midwayjs/core';
+import * as oneShot from '@midwayjs/one-shot';
+import { Framework } from '@midwayjs/one-shot';
+import { SyncUserScript } from './script/syncUser';
+
+@Configuration({
+  imports: [oneShot],
+})
+export class MainConfiguration {
+  @Inject()
+  framework: Framework;
+
+  async onServerReady() {
+    await this.framework.runScript(SyncUserScript, { id: 42 });
+  }
+}
+```
+
+## 日志
+
+组件默认会注册一个名为 `oneShotLogger` 的 logger，默认写入 `midway-one-shot.log`。
+
+你可以在脚本服务里通过 `@Logger('oneShotLogger')` 注入使用，例如：
+
+```typescript
+import { Logger, ILogger } from '@midwayjs/core';
+export class ScriptService {
+  @Logger('oneShotLogger')
+  logger: ILogger;
+
+  async runOnce() {
+    this.logger.info('run one-shot task');
+  }
+}
+```
+
+如果希望自定义日志文件名或级别，可以在应用配置中覆盖 `midwayLogger.clients.oneShotLogger`：
+
+```typescript
+// src/config/config.default.ts
+export default {
+  midwayLogger: {
+    clients: {
+      oneShotLogger: {
+        fileLogName: 'my-one-shot.log',
+        level: 'info',
+      },
+    },
+  },
+};
+```

--- a/site/docs/extensions/one-shot.md
+++ b/site/docs/extensions/one-shot.md
@@ -1,4 +1,4 @@
-# One-shot
+# 单次执行
 
 `@midwayjs/one-shot` 是一个只提供 Framework 的一次性脚本执行组件，适合用 IoC 容器组织依赖，并在应用内触发一次性的任务逻辑。
 

--- a/site/docs/extensions/validation.md
+++ b/site/docs/extensions/validation.md
@@ -5,7 +5,10 @@ import TabItem from '@theme/TabItem';
 
 我们经常要在方法调用时执行一些类型检查，参数转换的操作，Midway 提供了一种简单的能力来快速检查参数的类型。
 
-本模块自 `v4.0.0` 起替换 `@midwayjs/validate` 组件。
+:::tip
+从 `v4.0.0` 起，`@midwayjs/validation` 作为 `@midwayjs/validate` 的升级替代方案推出，两者是不同的包。
+`@midwayjs/validation` 提供更上层的校验抽象，支持 joi/zod/class-validator，并预留自定义校验器扩展；`@midwayjs/validate` 仅基于 joi，仍可用但不再新增功能，建议逐步迁移。
+:::
 
 新版本提供了更灵活的验证器扩展机制，支持多种验证器（如 Joi、Zod 等）的无缝切换，并提供了更好的类型支持和性能优化。
 

--- a/site/docs/sidebars.json
+++ b/site/docs/sidebars.json
@@ -221,7 +221,8 @@
         "extensions/tenant",
         "extensions/events",
         "extensions/piscina",
-        "extensions/commander"
+        "extensions/commander",
+        "extensions/one-shot"
       ]
     },
     {

--- a/site/i18n/en/docusaurus-plugin-content-docs/current/extensions/commander.md
+++ b/site/i18n/en/docusaurus-plugin-content-docs/current/extensions/commander.md
@@ -1,4 +1,4 @@
-# Commander (Command Line)
+# Command Line
 
 `@midwayjs/commander` is a command-line component built on the Midway IoC container. It uses [commander.js](https://github.com/tj/commander.js#readme) under the hood for argument parsing and help output. You can organize commands, option parsing, and business logic with the familiar Midway dependency injection approach, and split commands into multiple classes.
 

--- a/site/i18n/en/docusaurus-plugin-content-docs/current/extensions/commander.md
+++ b/site/i18n/en/docusaurus-plugin-content-docs/current/extensions/commander.md
@@ -47,7 +47,22 @@ export class MainConfiguration {}
 
 ## Write a command
 
+Example directory layout:
+
+```bash
+.
+├── src
+│   ├── commands
+│   │   ├── hello.command.ts
+│   │   └── status.command.ts
+│   ├── configuration.ts
+│   └── ...
+├── bootstrap.js
+└── package.json
+```
+
 Each command corresponds to a class, decorated with `@Command()`, and implements the `run()` method from the `CommandRunner` interface.
+
 
 ```typescript
 // src/commands/hello.command.ts

--- a/site/i18n/en/docusaurus-plugin-content-docs/current/extensions/one-shot.md
+++ b/site/i18n/en/docusaurus-plugin-content-docs/current/extensions/one-shot.md
@@ -1,0 +1,143 @@
+# One-shot
+
+`@midwayjs/one-shot` is a one-shot script framework that only provides a Framework. It is suitable for running tasks once with IoC-managed dependencies.
+
+Related information:
+
+| Description                |      |
+| -------------------------- | ---- |
+| Available for standard app | ❌    |
+| Available for Serverless   | ❌    |
+| Available for integrated   | ❌    |
+| Includes standalone core   | ✅    |
+| Includes standalone logger | ✅    |
+
+## Install
+
+Install the one-shot component dependency in an existing project.
+
+```bash
+$ npm i @midwayjs/one-shot@4  --save
+```
+
+Or add the following dependency to `package.json`, then reinstall.
+
+```json
+{
+  "dependencies": {
+    "@midwayjs/one-shot": "^4.0.0"
+  }
+}
+```
+
+## Enable the component
+
+Import the component in the entry configuration.
+
+```typescript
+// src/configuration.ts
+import { Configuration } from '@midwayjs/core';
+import * as oneShot from '@midwayjs/one-shot';
+
+@Configuration({
+  imports: [oneShot],
+})
+export class MainConfiguration {}
+```
+
+## Run in lifecycle
+
+No extra Runner is required. It's recommended to execute one-shot logic in `onServerReady`.
+
+```typescript
+// src/configuration.ts
+import { Configuration, Inject } from '@midwayjs/core';
+import * as oneShot from '@midwayjs/one-shot';
+import { ScriptService } from './service/script';
+
+@Configuration({
+  imports: [oneShot],
+})
+export class MainConfiguration {
+  @Inject()
+  scriptService: ScriptService;
+
+  async onServerReady() {
+    await this.scriptService.runOnce();
+  }
+}
+```
+
+## When request scope is needed
+
+If your script needs request-scope services, use the framework `runScript` API with a fixed runner class. The framework will create a context for this execution and run the middleware/filter chain.
+
+```typescript
+// src/script/syncUser.ts
+import { Provide } from '@midwayjs/core';
+import { OneShotRunner, Context } from '@midwayjs/one-shot';
+
+@Provide()
+export class SyncUserScript implements OneShotRunner<{ id: number }, void> {
+  async run(payload?: { id: number }, ctx?: Context) {
+    // use payload / ctx
+    void payload;
+    void ctx;
+  }
+}
+```
+
+```typescript
+// src/configuration.ts
+import { Configuration, Inject } from '@midwayjs/core';
+import * as oneShot from '@midwayjs/one-shot';
+import { Framework } from '@midwayjs/one-shot';
+import { SyncUserScript } from './script/syncUser';
+
+@Configuration({
+  imports: [oneShot],
+})
+export class MainConfiguration {
+  @Inject()
+  framework: Framework;
+
+  async onServerReady() {
+    await this.framework.runScript(SyncUserScript, { id: 42 });
+  }
+}
+```
+
+## Logger
+
+By default, the component registers a logger named `oneShotLogger`, which writes to `midway-one-shot.log`.
+
+You can inject and use it in your script service via `@Logger('oneShotLogger')`, for example:
+
+```typescript
+import { Logger, ILogger } from '@midwayjs/core';
+
+export class ScriptService {
+  @Logger('oneShotLogger')
+  logger: ILogger;
+
+  async runOnce() {
+    this.logger.info('run one-shot task');
+  }
+}
+```
+
+If you want to customize the log file name or level, override `midwayLogger.clients.oneShotLogger` in your application config:
+
+```typescript
+// src/config/config.default.ts
+export default {
+  midwayLogger: {
+    clients: {
+      oneShotLogger: {
+        fileLogName: 'my-one-shot.log',
+        level: 'info',
+      },
+    },
+  },
+};
+```

--- a/site/i18n/en/docusaurus-plugin-content-docs/current/extensions/one-shot.md
+++ b/site/i18n/en/docusaurus-plugin-content-docs/current/extensions/one-shot.md
@@ -1,4 +1,4 @@
-# One-shot
+# One-time Execution
 
 `@midwayjs/one-shot` is a one-shot script framework that only provides a Framework. It is suitable for running tasks once with IoC-managed dependencies.
 

--- a/site/i18n/en/docusaurus-plugin-content-docs/current/extensions/validation.md
+++ b/site/i18n/en/docusaurus-plugin-content-docs/current/extensions/validation.md
@@ -5,7 +5,10 @@ import TabItem from '@theme/TabItem';
 
 We often need to perform type checking and parameter conversion operations when calling methods. Midway provides a simple capability to quickly check parameter types.
 
-This module replaces the `@midwayjs/validate` component starting from `v4.0.0`.
+:::tip
+Starting from `v4.0.0`, `@midwayjs/validation` is introduced as the upgraded replacement for `@midwayjs/validate`; they are different packages.
+`@midwayjs/validation` is a higher-level abstraction with Joi/Zod/class-validator support and room for custom validators, while `@midwayjs/validate` is Joi-only, still usable but no longer gaining new features, so migration is recommended.
+:::
 
 The new version provides a more flexible validator extension mechanism, supports seamless switching between multiple validators (such as Joi, Zod, etc.), and provides better type support and performance optimization.
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a new `@midwayjs/one-shot` component that provides a lightweight one-shot `Framework` for executing IoC-managed scripts with a request-scope context and middleware via `runScript`.
> 
> - Adds `Framework`, `Configuration`, and `OneShotRunner` interfaces; `runScript` creates anonymous context and validates runner contract
> - Configures default `oneShotLogger` (writes `midway-one-shot.log`) and extends `MidwayConfig` typings
> - Includes build/test setup and a unit test validating payload/context propagation
> - Adds docs (zh/en) for usage and logging; updates docs sidebar; minor wording fixes in `validation.md`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit edc0514c5d513434c406ffda0ae84da3c1d8b0df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->