### PR TITLE
feat: add Apollo GraphQL component

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,3 +41,4 @@ Keep this managed block so 'openspec update' can refresh the instructions.
 ## Practical tips
 - Prefer `pnpm -C <package> test` to scope tests.
 - Keep changes aligned with existing patterns in the targeted package.
+- Pull request titles must use standard commit format, such as `feat: xxx` or `fix: xxx`.

--- a/openspec/changes/add-graphql-component/design.md
+++ b/openspec/changes/add-graphql-component/design.md
@@ -1,0 +1,58 @@
+## Context
+Midway v4 already has first-party web framework adapters for Koa, Express, and Egg-style web applications, plus a shared IoC container and request context model. GraphQL should integrate with those primitives instead of introducing a separate application runtime.
+
+Apollo Server v5 is the current supported Apollo Server major and requires Node.js 20+, matching this repository's Node baseline. Apollo Server v2/v3 packages such as `apollo-server`, `apollo-server-koa`, and `apollo-server-express` should not be used for the v4 component.
+
+## Goals / Non-Goals
+- Goals:
+  - Provide a maintained first-party `@midwayjs/apollo` package for v4 applications.
+  - Keep `@midwayjs/graphql` as a runtime-neutral base SDK that Apollo and future runtimes can reuse.
+  - Let users import the component and resolver decorators from `@midwayjs/apollo`.
+  - Support Koa and Express applications first, because they are the most direct HTTP adapters in this repository.
+  - Preserve Midway DI ergonomics inside resolvers.
+  - Keep Apollo-specific options accessible without polluting the base SDK config.
+  - Make the docs approachable for users comparing Midway with NestJS GraphQL support.
+- Non-Goals:
+  - Recreate the old `apollo-server-midway` package API.
+  - Require users to import `@midwayjs/graphql` directly for normal Apollo usage.
+  - Add GraphQL federation, subscriptions, persisted queries, file uploads, or schema stitching in the initial package.
+  - Require TypeGraphQL or a code-first schema library as the default path.
+  - Add Serverless/FaaS GraphQL support in the first iteration unless it falls out naturally from the HTTP integration.
+
+## Technical Decisions
+- Package roles:
+  - `@midwayjs/graphql` is a base SDK package. It exports shared interfaces, resolver decorators, resolver metadata constants, and resolver map assembly utilities. It is not the user-facing Midway component for Apollo usage.
+  - `@midwayjs/apollo` is the user-facing component package. It imports and re-exports `@midwayjs/graphql` APIs and exports its own Midway `Configuration`.
+- Runtime dependencies:
+  - `graphql` is a dependency of `@midwayjs/apollo` for schema types and execution primitives.
+  - `@apollo/server` is a dependency of `@midwayjs/apollo`, not of the base SDK.
+  - Users do not need to install `graphql` or `@apollo/server` separately for the Apollo component.
+- Configuration namespace: `apollo`.
+- Default endpoint path: `/graphql`.
+- Default methods: `GET` and `POST`.
+- Apollo options:
+  - Shared GraphQL fields live at the top level of `export const apollo = { ... }`.
+  - Apollo Server specific options live under `apollo.apollo`.
+- Resolver model:
+  - Schema-first `typeDefs` and `resolvers` are the baseline and map directly to Apollo Server inputs.
+  - `typePaths` loads `.graphql` schema files from the application `baseDir`; exact file paths and glob patterns are both supported, then merged with inline `typeDefs`.
+  - Midway resolver classes are optional: the base SDK discovers configured resolver classes, resolves them through the application or request container, and converts decorated methods into resolver functions.
+  - Resolver methods may use parameter decorators for `Parent`, `Args`, `Context`, and `Info`; undecorated methods keep the raw `(parent, args, context, info)` call signature.
+  - Subscription methods are converted to `{ subscribe }` resolver objects and must return `AsyncIterable` values.
+- Request context:
+  - Apollo's GraphQL `contextValue` is the active Midway `IMidwayContext` object itself, not a wrapper object containing `ctx`.
+  - The component relies on the framework application's existing request-context setup so the native Koa/Express request object receives Midway fields such as `requestContext`, `logger`, `getLogger`, `setAttr`, `getAttr`, and `getApp`.
+  - Plain resolver maps resolve request-scoped dependencies with `context.requestContext.getAsync(ServiceClass)`, matching existing Midway controller and middleware usage.
+  - Framework-specific request APIs remain available directly on `context`, such as Koa context APIs or Express request APIs, depending on the active application.
+  - GraphQL-specific metadata, if needed, is attached under a namespaced field such as `context.graphql` instead of wrapping the Midway context.
+  - Users can provide `contextFactory` to add fields to the Midway context for each GraphQL request, but the built-in Midway context fields remain reserved.
+- Lifecycle:
+  - Apollo Server instances are created once per Midway app and stopped during application shutdown.
+  - When subscriptions are enabled, a `graphql-ws` WebSocket server is attached in `onServerReady` because the framework HTTP server is only available after `framework.run()`.
+  - HTTP and WebSocket execution share the same executable schema created with `@graphql-tools/schema`.
+  - Startup failures surface during Midway startup instead of failing lazily on first request.
+
+## Risks
+- Apollo's maintained Koa integration is outside the Apollo core package, so this implementation may use a small local middleware adapter to keep Koa/Express support consistent.
+- Code-first resolver support can become large quickly. The first version should keep decorator metadata minimal and document how to use plain schema-first resolvers when advanced GraphQL composition is needed.
+- GraphQL introspection and landing pages need environment-aware defaults to avoid exposing production schemas unexpectedly.

--- a/openspec/changes/add-graphql-component/proposal.md
+++ b/openspec/changes/add-graphql-component/proposal.md
@@ -1,0 +1,27 @@
+# Change: Add Apollo GraphQL component with shared GraphQL SDK
+
+## Why
+Users have requested official GraphQL support for Midway v4, and the current v4 docs do not provide a maintained GraphQL path. Midway should provide a user-facing Apollo component while keeping reusable GraphQL resolver metadata, decorators, and context helpers in a runtime-neutral base package.
+
+## What Changes
+- Add `@midwayjs/graphql` as a base SDK package for shared GraphQL types, resolver decorators, resolver metadata, and resolver map assembly.
+- Add `@midwayjs/apollo` as the user-facing Midway component that mounts a GraphQL HTTP endpoint into built-in Midway web applications.
+- Have `@midwayjs/apollo` depend on and re-export `@midwayjs/graphql` APIs, so users can import `Resolver`, `Query`, and related decorators from `@midwayjs/apollo`.
+- Use Apollo Server v5 in `@midwayjs/apollo`, with `graphql` and `@apollo/server` bundled as component dependencies so users only install the Midway Apollo component.
+- Use the `apollo` config namespace for user configuration, including common GraphQL fields such as `path`, `typeDefs`, `resolvers`, `resolverClasses`, and `contextFactory`.
+- Keep Apollo-specific runtime options under `apollo.apollo` so future runtimes can provide their own component-specific options without expanding the base SDK config.
+- Use the active Midway `IMidwayContext` as the GraphQL context value so resolvers can access DI, logger, headers, cookies, and custom context factories directly from `context`.
+- Add beginner-first Chinese and English Apollo GraphQL documentation with installation, minimal examples, DI resolver examples, Apollo options, and context customization.
+- Add tests for the base SDK resolver metadata and for Apollo package bootstrapping, Koa/Express endpoint behavior, DI-backed resolvers, context creation, error handling, and shutdown.
+
+## Impact
+- Affected specs: `graphql-component`
+- Affected code:
+  - `packages/graphql/**` new base SDK package
+  - `packages/apollo/**` new user-facing component package
+  - Root workspace/package metadata for the new packages
+  - `site/docs/extensions/apollo.md` and English i18n docs
+  - Optional sample or fixture applications under the new package tests
+- Compatibility:
+  - Existing applications are unaffected unless they import `@midwayjs/apollo`.
+  - Future runtimes can reuse `@midwayjs/graphql` without inheriting Apollo-specific config.

--- a/openspec/changes/add-graphql-component/specs/graphql-component/spec.md
+++ b/openspec/changes/add-graphql-component/specs/graphql-component/spec.md
@@ -1,0 +1,170 @@
+## ADDED Requirements
+
+### Requirement: GraphQL Base SDK
+The system SHALL provide a runtime-neutral `@midwayjs/graphql` base SDK for shared GraphQL resolver APIs.
+
+#### Scenario: Installing the base SDK through Apollo
+- **WHEN** a user installs `@midwayjs/apollo`
+- **THEN** `@midwayjs/graphql` is installed as an internal workspace dependency
+- **AND** normal Apollo users do not need to import `@midwayjs/graphql` directly
+
+#### Scenario: Runtime-neutral resolver APIs
+- **WHEN** a runtime component imports from `@midwayjs/graphql`
+- **THEN** it can use shared resolver decorators, metadata, context types, and resolver map assembly utilities
+- **AND** the base SDK does not depend on Apollo Server
+
+### Requirement: Apollo GraphQL Component
+The system SHALL provide a first-party `@midwayjs/apollo` component for Midway v4 applications.
+
+#### Scenario: Installing the component
+- **WHEN** a user installs `@midwayjs/apollo` in a Midway v4 application
+- **THEN** the package metadata includes `graphql` and `@apollo/server` as component dependencies
+- **AND** the documentation does not require users to install `graphql` or `@apollo/server` separately
+
+#### Scenario: Importing the component
+- **WHEN** a user imports the Apollo component in `configuration.ts`
+- **THEN** the component registers itself through Midway's standard configuration lifecycle
+- **AND** existing applications that do not import the component remain unchanged
+
+#### Scenario: Re-exported resolver APIs
+- **WHEN** a user imports `Resolver` or `Query` from `@midwayjs/apollo`
+- **THEN** those APIs are available without directly importing `@midwayjs/graphql`
+
+### Requirement: Apollo Configuration Namespace
+The component SHALL use the `apollo` configuration namespace.
+
+#### Scenario: User configures Apollo
+- **WHEN** the user exports `apollo` config from `config.default.ts`
+- **THEN** the component reads endpoint, schema, resolver, context, and Apollo options from that config
+
+#### Scenario: Apollo-specific options
+- **WHEN** the user configures Apollo Server specific options
+- **THEN** those options live under `apollo.apollo`
+- **AND** shared GraphQL fields such as `typeDefs`, `resolvers`, and `contextFactory` remain at the top level
+
+### Requirement: HTTP GraphQL Endpoint
+The Apollo component SHALL mount a GraphQL HTTP endpoint into supported Midway web applications.
+
+#### Scenario: Koa application handles a GraphQL query
+- **WHEN** a Koa-based Midway application imports the component and configures a schema
+- **AND** a client sends a valid GraphQL query to the configured path
+- **THEN** the application returns the GraphQL execution result
+- **AND** non-GraphQL routes continue to use the existing Midway router behavior
+
+#### Scenario: Express application handles a GraphQL query
+- **WHEN** an Express-based Midway application imports the component and configures a schema
+- **AND** a client sends a valid GraphQL query to the configured path
+- **THEN** the application returns the GraphQL execution result
+- **AND** non-GraphQL routes continue to use the existing Midway router behavior
+
+#### Scenario: Endpoint path is customized
+- **WHEN** the user configures a custom GraphQL path
+- **THEN** the component mounts the endpoint at that path
+- **AND** the default `/graphql` path is not mounted unless explicitly configured
+
+#### Scenario: Unsupported HTTP method
+- **WHEN** a client sends an unsupported HTTP method to the GraphQL path
+- **THEN** the component returns `405 Method Not Allowed`
+- **AND** the response includes an `Allow` header listing configured methods
+
+### Requirement: Schema-First GraphQL Configuration
+The Apollo component SHALL support schema-first GraphQL configuration through `typeDefs` and `resolvers`.
+
+#### Scenario: Defining inline schema and resolvers
+- **WHEN** the user configures GraphQL `typeDefs` and resolver functions
+- **THEN** the component passes those definitions to Apollo Server
+- **AND** resolver return values are used as the GraphQL response data
+
+#### Scenario: Loading schema files
+- **WHEN** the user configures `typePaths` with exact `.graphql` file paths or glob patterns
+- **THEN** the component loads matching schema files during startup
+- **AND** it combines loaded schema definitions with any inline `typeDefs`
+
+#### Scenario: Invalid schema fails startup
+- **WHEN** the configured schema or resolver map is invalid
+- **THEN** Midway application startup fails with a useful error
+- **AND** the failure is not deferred until the first GraphQL request
+
+### Requirement: DI-Backed Resolver Classes
+The component SHALL allow GraphQL resolvers to be implemented as Midway-managed classes.
+
+#### Scenario: Resolver injects a service
+- **WHEN** a resolver class is registered with the GraphQL component and injects a Midway service
+- **THEN** the resolver method executes through the Midway container
+- **AND** injected dependencies are available during GraphQL execution
+
+#### Scenario: Resolver injects GraphQL parameters
+- **WHEN** a resolver method uses parameter decorators such as `Args`, `Parent`, `Context`, or `Info`
+- **THEN** the component injects the corresponding GraphQL resolver argument into that method parameter
+- **AND** passing a field name injects only that field from the source object
+
+#### Scenario: Resolver uses request-scoped dependency
+- **WHEN** a resolver depends on request-scoped Midway state
+- **THEN** the component resolves the resolver through the active request context when available
+- **AND** concurrent GraphQL requests do not share request-scoped dependency instances
+
+### Requirement: GraphQL Subscriptions
+The Apollo component SHALL support GraphQL subscriptions over the `graphql-ws` protocol.
+
+#### Scenario: Subscription server is enabled
+- **WHEN** the user enables `apollo.subscriptions`
+- **THEN** the component registers a WebSocket server on the Midway framework HTTP server after server startup
+- **AND** the subscription schema uses the same executable schema and resolver map as HTTP GraphQL
+
+#### Scenario: Subscription resolver executes through DI
+- **WHEN** a client subscribes to a field implemented by a decorated resolver class
+- **THEN** the subscription resolver executes through a Midway request context
+- **AND** resolver methods can return an `AsyncIterable` payload stream
+
+#### Scenario: Subscription server is disabled
+- **WHEN** the user leaves `apollo.subscriptions` unset or false
+- **THEN** no GraphQL WebSocket server is registered
+
+### Requirement: GraphQL Context Integration
+The component SHALL use the active Midway `IMidwayContext` object as Apollo's GraphQL context value.
+
+#### Scenario: Resolver resolves dependency from request container
+- **WHEN** a plain resolver map function receives GraphQL context
+- **THEN** it can resolve Midway dependencies through `context.requestContext.getAsync(...)`
+- **AND** the request container belongs to the active GraphQL request
+- **AND** the resolver does not need to unwrap `context.ctx`
+
+#### Scenario: Resolver accesses framework request APIs
+- **WHEN** a resolver receives GraphQL context
+- **THEN** the context is the Midway-augmented framework request context itself
+- **AND** framework-specific request APIs such as headers, cookies, state, and response helpers remain available directly on `context` where the framework provides them
+
+#### Scenario: Resolver reads request metadata
+- **WHEN** a resolver receives GraphQL context
+- **THEN** it can access Midway fields such as `requestContext`, `logger`, `getLogger`, `setAttr`, `getAttr`, and `getApp`
+- **AND** GraphQL-specific metadata, if exposed, is attached under a namespaced field such as `context.graphql`
+
+#### Scenario: User extends context
+- **WHEN** the user provides a `contextFactory`
+- **THEN** the component calls it for each GraphQL request
+- **AND** returned extension fields are attached to the active Midway context for that request only
+- **AND** built-in Midway context fields such as `requestContext`, `logger`, and `getApp` remain reserved
+
+### Requirement: Apollo Documentation
+The documentation SHALL teach the Apollo GraphQL component from installation through production configuration.
+
+#### Scenario: Beginner follows the docs
+- **WHEN** a beginner reads the Apollo GraphQL documentation
+- **THEN** the docs first explain what the component solves and when to use it
+- **AND** the docs provide the smallest working schema-first Apollo example before advanced options
+
+#### Scenario: User configures Apollo options
+- **WHEN** a user reads the Apollo GraphQL documentation
+- **THEN** the docs explain that Apollo Server specific options live under `apollo.apollo`
+- **AND** resolver decorators are imported from `@midwayjs/apollo`
+
+### Requirement: GraphiQL Landing Page
+The Apollo component SHALL provide a development GraphiQL page for browser access.
+
+#### Scenario: Browser requests GraphQL path
+- **WHEN** a browser sends a GET request with `Accept: text/html` to the GraphQL path without a query
+- **THEN** the component returns a GraphiQL HTML page when `graphiql` is enabled
+
+#### Scenario: Production defaults
+- **WHEN** `NODE_ENV` is `production`
+- **THEN** GraphiQL is disabled by default unless explicitly enabled

--- a/openspec/changes/add-graphql-component/tasks.md
+++ b/openspec/changes/add-graphql-component/tasks.md
@@ -1,0 +1,48 @@
+## 1. Package Setup
+- [x] 1.1 Create `packages/graphql` with package metadata, exports, TypeScript config, Jest config, and setup files for the base SDK.
+- [x] 1.2 Create `packages/apollo` with package metadata, exports, TypeScript config, Jest config, and setup files for the user-facing component.
+- [x] 1.3 Add `@midwayjs/graphql` as a workspace dependency of `@midwayjs/apollo`.
+- [x] 1.4 Add `graphql` and `@apollo/server` as dependencies of `@midwayjs/apollo`.
+- [x] 1.5 Add fixed-version runtime dependencies for executable schema creation and `graphql-ws` subscriptions.
+- [x] 1.6 Verify both packages build with the repository's NodeNext TypeScript settings.
+
+## 2. Runtime Integration
+- [x] 2.1 Add `ApolloConfiguration` with default `apollo` config and lifecycle hooks.
+- [x] 2.2 Implement Apollo Server creation and shutdown per Midway web application.
+- [x] 2.3 Mount `/graphql` middleware for Koa applications.
+- [x] 2.4 Mount `/graphql` middleware for Express applications.
+- [x] 2.5 Build Apollo `contextValue` as the active Midway `IMidwayContext` itself, with `requestContext`, logger helpers, framework-native request APIs, optional `graphql` metadata, and user `contextFactory` extensions.
+- [x] 2.6 Surface startup errors and schema errors through Midway startup instead of lazy request-time failures.
+- [x] 2.7 Add GraphiQL browser landing page support for development.
+- [x] 2.8 Add `graphql-ws` subscription server registration and shutdown.
+
+## 3. Resolver API
+- [x] 3.1 Define public TypeScript interfaces for shared GraphQL config, context, resolver classes, and resolver metadata in `@midwayjs/graphql`.
+- [x] 3.2 Support schema-first `typeDefs` and `resolvers` configuration from `@midwayjs/apollo`.
+- [x] 3.3 Add optional Midway resolver class discovery and DI-backed method invocation in the base SDK.
+- [x] 3.4 Re-export GraphQL decorators and types from `@midwayjs/apollo`.
+- [x] 3.5 Add comments for exported classes, interfaces, functions, and decorators.
+- [x] 3.6 Add resolver parameter decorators and subscription resolver object assembly.
+
+## 4. Tests
+- [x] 4.1 Add base SDK tests for resolver metadata and resolver map assembly.
+- [x] 4.2 Add Koa fixture tests for query execution and HTTP method handling in `@midwayjs/apollo`.
+- [x] 4.3 Add Express fixture tests for query execution and HTTP method handling in `@midwayjs/apollo`.
+- [x] 4.4 Test DI-backed resolver classes with singleton and request-scoped dependencies.
+- [x] 4.5 Test plain resolver access to `context.requestContext.getAsync(...)` on the Midway context object.
+- [x] 4.6 Test custom context factory behavior and direct access to framework request headers on `context`.
+- [x] 4.7 Test Apollo Server shutdown during Midway application close.
+- [x] 4.8 Test GraphiQL rendering and unsupported HTTP method handling.
+- [x] 4.9 Test GraphQL subscriptions over WebSocket.
+- [x] 4.10 Run `pnpm -C packages/graphql test`.
+- [x] 4.11 Run `pnpm -C packages/apollo test`.
+
+## 5. Documentation
+- [x] 5.1 Add Chinese Apollo GraphQL docs under `site/docs/extensions/apollo.md`.
+- [x] 5.2 Add English Apollo GraphQL docs in the matching i18n location if present.
+- [x] 5.3 Show installation in both npm bash commands and `package.json` dependency form.
+- [x] 5.4 Document the smallest schema-first Apollo example, DI resolver example, context customization, Apollo options, subscriptions, GraphiQL, HTTP behavior, and production defaults.
+
+## 6. Validation
+- [x] 6.1 Run relevant lint/build commands for touched packages.
+- [x] 6.2 Run `openspec validate add-graphql-component --strict --no-interactive`.

--- a/packages/apollo/jest.config.js
+++ b/packages/apollo/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testPathIgnorePatterns: ['<rootDir>/test/fixtures'],
+  coveragePathIgnorePatterns: ['<rootDir>/test/', '<rootDir>/dist/'],
+  setupFilesAfterEnv: ['./jest.setup.js'],
+  coverageProvider: 'v8',
+};

--- a/packages/apollo/jest.config.js
+++ b/packages/apollo/jest.config.js
@@ -5,4 +5,9 @@ module.exports = {
   coveragePathIgnorePatterns: ['<rootDir>/test/', '<rootDir>/dist/'],
   setupFilesAfterEnv: ['./jest.setup.js'],
   coverageProvider: 'v8',
+  coverageThreshold: {
+    global: {
+      branches: 90,
+    },
+  },
 };

--- a/packages/apollo/jest.setup.js
+++ b/packages/apollo/jest.setup.js
@@ -1,0 +1,1 @@
+jest.setTimeout(30000);

--- a/packages/apollo/package.json
+++ b/packages/apollo/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@midwayjs/apollo",
+  "version": "4.1.0",
+  "description": "Midway Framework for Apollo GraphQL",
+  "main": "dist/index.js",
+  "typings": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "node -r ts-node/register ../../node_modules/jest/bin/jest.js --runInBand",
+    "cov": "node -r ts-node/register ../../node_modules/jest/bin/jest.js --runInBand --coverage --forceExit",
+    "lint:fix": "../../node_modules/.bin/mwts fix"
+  },
+  "keywords": [
+    "midway",
+    "IoC",
+    "framework",
+    "apollo",
+    "graphql"
+  ],
+  "files": [
+    "dist/**/*.js",
+    "dist/**/*.d.ts"
+  ],
+  "license": "MIT",
+  "dependencies": {
+    "@apollo/server": "5.5.1",
+    "@graphql-tools/schema": "10.0.33",
+    "@midwayjs/glob": "1.1.1",
+    "@midwayjs/graphql": "workspace:^",
+    "graphql": "16.14.0",
+    "graphql-ws": "6.0.8",
+    "ws": "8.20.0"
+  },
+  "devDependencies": {
+    "@midwayjs/core": "workspace:^",
+    "@midwayjs/koa": "workspace:^",
+    "@midwayjs/express": "workspace:^",
+    "@midwayjs/mock": "workspace:^",
+    "@types/ws": "8.18.1"
+  },
+  "author": "Harry Chen <czy88840616@gmail.com>",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/midwayjs/midway.git"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packages/apollo/src/apolloService.ts
+++ b/packages/apollo/src/apolloService.ts
@@ -1,0 +1,488 @@
+import { IMidwayContext, Provide, Scope, ScopeEnum } from '@midwayjs/core';
+import { ApolloConfigurationOptions } from './interface';
+import { MidwayGraphQLContext } from '@midwayjs/graphql';
+import { run as glob } from '@midwayjs/glob';
+import { isAbsolute, join, relative } from 'path';
+import { existsSync, readFileSync, statSync } from 'fs';
+import { makeExecutableSchema } from '@graphql-tools/schema';
+import { GraphQLSchema } from 'graphql';
+import { WebSocketServer } from 'ws';
+import { useServer } from 'graphql-ws/use/ws';
+
+interface ApolloServerLike {
+  start(): Promise<void>;
+  stop(): Promise<void>;
+  executeOperation(request: any, options?: any): Promise<any>;
+}
+
+interface SubscriptionServerLike {
+  dispose(): void | Promise<void>;
+}
+
+async function readRequestBody(req: any): Promise<any> {
+  if (req.body) {
+    return req.body;
+  }
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  if (!chunks.length) {
+    return {};
+  }
+  const raw = Buffer.concat(chunks).toString();
+  if (!raw) {
+    return {};
+  }
+  try {
+    return JSON.parse(raw);
+  } catch {
+    const error = new Error('Invalid JSON request body');
+    (error as any).status = 400;
+    throw error;
+  }
+}
+
+function assignContextExtensions(
+  ctx: MidwayGraphQLContext,
+  config: ApolloConfigurationOptions
+) {
+  ctx.graphql = {
+    ...(ctx.graphql || {}),
+    ...(config.graphql || {}),
+  };
+  return Promise.resolve(config.contextFactory?.(ctx)).then(extensions => {
+    if (extensions && typeof extensions === 'object') {
+      for (const key of Object.keys(extensions)) {
+        if (
+          [
+            'requestContext',
+            'logger',
+            'getLogger',
+            'setAttr',
+            'getAttr',
+            'getApp',
+          ].includes(key)
+        ) {
+          continue;
+        }
+        ctx[key] = extensions[key];
+      }
+    }
+    return ctx;
+  });
+}
+
+function getRequestPayload(ctx: any, isExpress: boolean) {
+  if (ctx.method === 'GET') {
+    const query = ctx.query;
+    return {
+      query: query?.query,
+      variables:
+        typeof query?.variables === 'string'
+          ? JSON.parse(query.variables)
+          : query?.variables,
+      operationName: query?.operationName,
+    };
+  }
+  if (!isExpress && ctx.request?.body) {
+    return ctx.request.body;
+  }
+  return readRequestBody(isExpress ? ctx : ctx.req);
+}
+
+function getHeaderValue(ctx: any, name: string, isExpress: boolean) {
+  if (isExpress) {
+    return ctx.headers?.[name.toLowerCase()];
+  }
+  return ctx.get?.(name) || ctx.headers?.[name.toLowerCase()];
+}
+
+function setResponseStatus(ctx: any, res: any, isExpress: boolean, status) {
+  if (!status) {
+    return;
+  }
+  if (isExpress) {
+    res.status(status);
+  } else {
+    ctx.status = status;
+  }
+}
+
+function setResponseHeader(
+  ctx: any,
+  res: any,
+  isExpress: boolean,
+  name: string,
+  value: string
+) {
+  if (isExpress) {
+    res.set(name, value);
+  } else {
+    ctx.set(name, value);
+  }
+}
+
+function writeResponse(
+  ctx: any,
+  res: any,
+  isExpress: boolean,
+  payload: any,
+  status?: number,
+  headers?: Headers
+) {
+  setResponseStatus(ctx, res, isExpress, status);
+  headers?.forEach((value, name) => {
+    setResponseHeader(ctx, res, isExpress, name, value);
+  });
+  if (isExpress) {
+    res.type('application/json');
+    res.send(JSON.stringify(payload));
+  } else {
+    ctx.type = 'application/json';
+    ctx.body = payload;
+  }
+}
+
+function writeTextResponse(
+  ctx: any,
+  res: any,
+  isExpress: boolean,
+  body: string,
+  contentType: string,
+  status = 200
+) {
+  setResponseStatus(ctx, res, isExpress, status);
+  if (isExpress) {
+    res.type(contentType);
+    res.send(body);
+  } else {
+    ctx.type = contentType;
+    ctx.body = body;
+  }
+}
+
+function writeErrorResponse(ctx: any, res: any, isExpress: boolean, err: any) {
+  writeResponse(
+    ctx,
+    res,
+    isExpress,
+    {
+      errors: [
+        {
+          message: err?.message || 'GraphQL request failed',
+        },
+      ],
+    },
+    err?.status || 500
+  );
+}
+
+function normalizeTypeDefs(typeDefs: unknown) {
+  if (!typeDefs) {
+    return [];
+  }
+  return Array.isArray(typeDefs) ? typeDefs : [typeDefs];
+}
+
+function resolveSchemaFilePath(baseDir: string, filePath: string) {
+  return isAbsolute(filePath) ? filePath : join(baseDir, filePath);
+}
+
+function normalizeSchemaPattern(pattern: string) {
+  return pattern.replace(/\\/g, '/').replace(/^\.\//, '');
+}
+
+function createSchemaPatternRegExp(pattern: string) {
+  const normalized = normalizeSchemaPattern(pattern);
+  let source = '^';
+  for (let index = 0; index < normalized.length; index++) {
+    const char = normalized[index];
+    const next = normalized[index + 1];
+    if (char === '*' && next === '*') {
+      index++;
+      if (normalized[index + 1] === '/') {
+        index++;
+        source += '(?:.*\\/)?';
+      } else {
+        source += '.*';
+      }
+    } else if (char === '*') {
+      source += '[^/]*';
+    } else if (char === '?') {
+      source += '[^/]';
+    } else {
+      source += char.replace(/[|\\{}()[\]^$+?.]/g, '\\$&');
+    }
+  }
+  return new RegExp(`${source}$`);
+}
+
+function loadTypeDefs(config: ApolloConfigurationOptions, baseDir: string) {
+  const typeDefs = normalizeTypeDefs(config.typeDefs);
+  const typePaths = config.typePaths || [];
+
+  for (const pattern of typePaths) {
+    const schemaFile = resolveSchemaFilePath(baseDir, pattern);
+    if (existsSync(schemaFile) && statSync(schemaFile).isFile()) {
+      typeDefs.push(readFileSync(schemaFile, 'utf8'));
+      continue;
+    }
+
+    const patternRegExp = createSchemaPatternRegExp(pattern);
+    const files = glob(['**/*.graphql'], {
+      cwd: baseDir,
+      ignore: ['**/node_modules/**'],
+    }).filter(file =>
+      patternRegExp.test(relative(baseDir, file).replace(/\\/g, '/'))
+    );
+    for (const file of files) {
+      typeDefs.push(readFileSync(resolveSchemaFilePath(baseDir, file), 'utf8'));
+    }
+  }
+
+  return typeDefs.length <= 1 ? typeDefs[0] : typeDefs;
+}
+
+function getSubscriptionPath(config: ApolloConfigurationOptions) {
+  if (config.subscriptions && typeof config.subscriptions === 'object') {
+    return config.subscriptions.path || config.path || '/graphql';
+  }
+  return config.path || '/graphql';
+}
+
+function isGraphiQLEnabled(config: ApolloConfigurationOptions) {
+  if (config.graphiql === undefined) {
+    return process.env.NODE_ENV !== 'production';
+  }
+  return !!config.graphiql;
+}
+
+function renderGraphiQL(config: ApolloConfigurationOptions) {
+  const options =
+    typeof config.graphiql === 'object' && config.graphiql
+      ? config.graphiql
+      : {};
+  const endpoint = options.endpoint || config.path || '/graphql';
+  const title = options.title || 'Midway Apollo GraphiQL';
+  return `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>${title}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="https://unpkg.com/graphiql@5.2.2/graphiql.css" />
+    <style>
+      html, body, #graphiql { height: 100%; margin: 0; }
+    </style>
+  </head>
+  <body>
+    <div id="graphiql">Loading...</div>
+    <script type="importmap">
+      {
+        "imports": {
+          "react": "https://esm.sh/react@19.2.6",
+          "react-dom": "https://esm.sh/react-dom@19.2.6",
+          "react-dom/client": "https://esm.sh/react-dom@19.2.6/client",
+          "react/jsx-runtime": "https://esm.sh/react@19.2.6/jsx-runtime"
+        }
+      }
+    </script>
+    <script type="module">
+      import React from 'react';
+      import { createRoot } from 'react-dom/client';
+      import { GraphiQL } from 'https://esm.sh/graphiql@5.2.2?external=react,react-dom';
+      const fetcher = async graphQLParams => {
+        const response = await fetch(${JSON.stringify(endpoint)}, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify(graphQLParams),
+        });
+        return await response.json();
+      };
+      createRoot(document.getElementById('graphiql')).render(
+        React.createElement(GraphiQL, { fetcher })
+      );
+    </script>
+  </body>
+</html>`;
+}
+
+@Provide()
+@Scope(ScopeEnum.Singleton)
+export class ApolloService {
+  /**
+   * Builds the executable GraphQL schema shared by HTTP and subscriptions.
+   */
+  createSchema(
+    config: ApolloConfigurationOptions,
+    resolvers: Record<string, any>,
+    baseDir: string
+  ) {
+    return makeExecutableSchema({
+      typeDefs: loadTypeDefs(config, baseDir) as any,
+      resolvers,
+      resolverValidationOptions: config.resolverValidationOptions,
+      inheritResolversFromInterfaces: config.inheritResolversFromInterfaces,
+    });
+  }
+
+  /**
+   * Creates and starts an Apollo Server instance.
+   */
+  async createServer(
+    config: ApolloConfigurationOptions,
+    schema: GraphQLSchema
+  ) {
+    const { ApolloServer } = await import('@apollo/server');
+    const server = new ApolloServer({
+      schema,
+      ...(config.apollo || {}),
+    }) as ApolloServerLike;
+    await server.start();
+    return server;
+  }
+
+  /**
+   * Creates a GraphQL over WebSocket subscription server.
+   */
+  createSubscriptionServer(
+    schema: GraphQLSchema,
+    config: ApolloConfigurationOptions,
+    app: any
+  ): SubscriptionServerLike | undefined {
+    if (!config.subscriptions) {
+      return;
+    }
+    const framework = app.getFramework?.();
+    const httpServer = framework?.getServer?.();
+    if (!httpServer) {
+      return;
+    }
+    const path = getSubscriptionPath(config);
+    const subscriptionOptions =
+      typeof config.subscriptions === 'object' ? config.subscriptions : {};
+    const wsServer = new WebSocketServer({
+      server: httpServer,
+      path,
+    });
+    return useServer(
+      {
+        schema,
+        connectionInitWaitTimeout:
+          subscriptionOptions.connectionInitWaitTimeout,
+        context: async wsContext => {
+          const context = app.createAnonymousContext({
+            graphql: {
+              connectionParams: wsContext.connectionParams,
+              protocol: 'graphql-ws',
+            },
+          });
+          return await assignContextExtensions(context, config);
+        },
+      },
+      wsServer
+    );
+  }
+
+  /**
+   * Creates Midway middleware that executes GraphQL operations through Apollo.
+   */
+  createMiddleware(
+    server: ApolloServerLike,
+    config: ApolloConfigurationOptions,
+    isExpress: boolean
+  ) {
+    const path = config.path || '/graphql';
+    const methods = (config.methods || ['GET', 'POST']).map(method =>
+      method.toUpperCase()
+    );
+
+    return async (ctx: IMidwayContext & any, resOrNext?: any, next?: any) => {
+      const res = isExpress ? resOrNext : undefined;
+      const done = isExpress ? next : resOrNext;
+      const requestPath = isExpress ? ctx.path || ctx.url : ctx.path;
+      const requestMethod = String(ctx.method || '').toUpperCase();
+
+      if (requestPath !== path) {
+        return await done();
+      }
+      if (!methods.includes(requestMethod)) {
+        writeTextResponse(
+          ctx,
+          res,
+          isExpress,
+          'Method Not Allowed',
+          'text/plain',
+          405
+        );
+        setResponseHeader(ctx, res, isExpress, 'Allow', methods.join(', '));
+        return;
+      }
+
+      const accept = getHeaderValue(ctx, 'accept', isExpress) || '';
+      const shouldRenderGraphiQL =
+        requestMethod === 'GET' &&
+        isGraphiQLEnabled(config) &&
+        accept.includes('text/html') &&
+        !ctx.query?.query;
+      if (shouldRenderGraphiQL) {
+        writeTextResponse(
+          ctx,
+          res,
+          isExpress,
+          renderGraphiQL(config),
+          'text/html'
+        );
+        return;
+      }
+
+      try {
+        const contextValue = await assignContextExtensions(
+          ctx as MidwayGraphQLContext,
+          config
+        );
+        const payload = await getRequestPayload(ctx, isExpress);
+        const result = await server.executeOperation(
+          {
+            query: payload.query,
+            variables: payload.variables,
+            operationName: payload.operationName,
+          },
+          {
+            contextValue,
+          }
+        );
+        const body =
+          result.body?.kind === 'single'
+            ? result.body.singleResult
+            : result.body || result;
+
+        writeResponse(
+          ctx,
+          res,
+          isExpress,
+          body,
+          result.http?.status,
+          result.http?.headers
+        );
+      } catch (err) {
+        writeErrorResponse(ctx, res, isExpress, err);
+      }
+    };
+  }
+
+  /**
+   * Stops an Apollo Server instance.
+   */
+  async stop(server: ApolloServerLike) {
+    await server.stop();
+  }
+
+  /**
+   * Stops a subscription server.
+   */
+  async stopSubscriptionServer(server: SubscriptionServerLike) {
+    await Promise.resolve(server.dispose());
+  }
+}

--- a/packages/apollo/src/config/config.default.ts
+++ b/packages/apollo/src/config/config.default.ts
@@ -1,0 +1,7 @@
+export const apollo = {
+  path: '/graphql',
+  methods: ['GET', 'POST'],
+  graphiql: process.env.NODE_ENV !== 'production',
+  subscriptions: false,
+  resolvers: {},
+};

--- a/packages/apollo/src/configuration.ts
+++ b/packages/apollo/src/configuration.ts
@@ -1,0 +1,98 @@
+import {
+  Configuration,
+  ILifeCycle,
+  IMidwayContainer,
+  Inject,
+  MidwayApplicationManager,
+  MidwayConfigService,
+} from '@midwayjs/core';
+import { GraphQLService } from '@midwayjs/graphql';
+import * as DefaultConfig from './config/config.default';
+import { ApolloConfigurationOptions } from './interface';
+import { ApolloService } from './apolloService';
+
+@Configuration({
+  namespace: 'apollo',
+  importConfigs: [
+    {
+      default: DefaultConfig,
+    },
+  ],
+})
+export class ApolloConfiguration implements ILifeCycle {
+  private serverRecords: Array<{
+    app: any;
+    server: any;
+    schema: any;
+    subscriptionServer?: any;
+  }> = [];
+
+  @Inject()
+  applicationManager: MidwayApplicationManager;
+
+  @Inject()
+  configService: MidwayConfigService;
+
+  @Inject()
+  graphqlService: GraphQLService;
+
+  @Inject()
+  apolloService: ApolloService;
+
+  async onReady(container: IMidwayContainer) {
+    const config =
+      this.configService.getConfiguration<ApolloConfigurationOptions>('apollo');
+    const apps = this.applicationManager.getApplications(['koa', 'express']);
+
+    if (!apps.length) {
+      return;
+    }
+
+    const resolvers = this.graphqlService.buildResolvers(config, container);
+    const baseDir = container.get<string>('baseDir');
+
+    for (const app of apps) {
+      const schema = this.apolloService.createSchema(
+        config,
+        resolvers,
+        baseDir
+      );
+      const server = await this.apolloService.createServer(config, schema);
+      const middleware = this.apolloService.createMiddleware(
+        server,
+        config,
+        app.getNamespace() === 'express'
+      );
+      app.useMiddleware(middleware as any);
+      this.serverRecords.push({
+        app,
+        server,
+        schema,
+      });
+    }
+  }
+
+  async onServerReady() {
+    const config =
+      this.configService.getConfiguration<ApolloConfigurationOptions>('apollo');
+    for (const record of this.serverRecords) {
+      record.subscriptionServer = this.apolloService.createSubscriptionServer(
+        record.schema,
+        config,
+        record.app
+      );
+    }
+  }
+
+  async onStop() {
+    for (const record of this.serverRecords) {
+      if (record.subscriptionServer) {
+        await this.apolloService.stopSubscriptionServer(
+          record.subscriptionServer
+        );
+      }
+      await this.apolloService.stop(record.server);
+    }
+    this.serverRecords = [];
+  }
+}

--- a/packages/apollo/src/index.ts
+++ b/packages/apollo/src/index.ts
@@ -1,0 +1,4 @@
+export * from '@midwayjs/graphql';
+export { ApolloConfiguration as Configuration } from './configuration';
+export { ApolloService } from './apolloService';
+export * from './interface';

--- a/packages/apollo/src/interface.ts
+++ b/packages/apollo/src/interface.ts
@@ -1,0 +1,26 @@
+import { GraphQLBaseConfigurationOptions } from '@midwayjs/graphql';
+
+/**
+ * GraphiQL landing page options.
+ */
+export interface ApolloGraphiQLOptions {
+  title?: string;
+  endpoint?: string;
+}
+
+/**
+ * GraphQL over WebSocket subscription options.
+ */
+export interface ApolloSubscriptionOptions {
+  path?: string;
+  connectionInitWaitTimeout?: number;
+}
+
+/**
+ * Apollo component configuration.
+ */
+export interface ApolloConfigurationOptions extends GraphQLBaseConfigurationOptions {
+  apollo?: Record<string, any>;
+  graphiql?: boolean | ApolloGraphiQLOptions;
+  subscriptions?: boolean | ApolloSubscriptionOptions;
+}

--- a/packages/apollo/test/fixtures/base-app-express/src/config/config.default.ts
+++ b/packages/apollo/test/fixtures/base-app-express/src/config/config.default.ts
@@ -1,0 +1,24 @@
+import { HelloService } from '../service/hello';
+
+export const keys = 'apollo-express-key';
+
+export const apollo = {
+  path: '/graphql',
+  typeDefs: `
+    type Query {
+      hello: String!
+      header: String
+    }
+  `,
+  resolvers: {
+    Query: {
+      hello: async (_parent, _args, context) => {
+        const service = await context.requestContext.getAsync(HelloService);
+        return service.say();
+      },
+      header: (_parent, _args, context) => {
+        return context.headers['x-apollo-test'];
+      },
+    },
+  },
+};

--- a/packages/apollo/test/fixtures/base-app-express/src/configuration.ts
+++ b/packages/apollo/test/fixtures/base-app-express/src/configuration.ts
@@ -1,0 +1,10 @@
+import { Configuration } from '@midwayjs/core';
+import { join } from 'path';
+import * as express from '@midwayjs/express';
+import * as apollo from '../../../../src';
+
+@Configuration({
+  imports: [express, apollo],
+  importConfigs: [join(__dirname, './config')],
+})
+export class ContainerConfiguration {}

--- a/packages/apollo/test/fixtures/base-app-express/src/service/hello.ts
+++ b/packages/apollo/test/fixtures/base-app-express/src/service/hello.ts
@@ -1,0 +1,8 @@
+import { Provide } from '@midwayjs/core';
+
+@Provide()
+export class HelloService {
+  async say() {
+    return 'hello midway';
+  }
+}

--- a/packages/apollo/test/fixtures/base-app-koa/src/config/config.default.ts
+++ b/packages/apollo/test/fixtures/base-app-koa/src/config/config.default.ts
@@ -1,0 +1,28 @@
+import { HelloService } from '../service/hello';
+
+export const keys = 'apollo-koa-key';
+
+export const apollo = {
+  path: '/graphql',
+  subscriptions: true,
+  typePaths: ['./schema.graphql', './graphql/**/*.graphql'],
+  typeDefs: `
+    type Query {
+      hello: String!
+      decoratedHello: String!
+      header: String
+    }
+  `,
+  resolvers: {
+    Query: {
+      hello: async (_parent, _args, context) => {
+        const service = await context.requestContext.getAsync(HelloService);
+        return service.say();
+      },
+      header: (_parent, _args, context) => {
+        return context.get('x-apollo-test');
+      },
+      schemaLoaded: () => 'schema file',
+    },
+  },
+};

--- a/packages/apollo/test/fixtures/base-app-koa/src/configuration.ts
+++ b/packages/apollo/test/fixtures/base-app-koa/src/configuration.ts
@@ -1,0 +1,10 @@
+import { Configuration } from '@midwayjs/core';
+import { join } from 'path';
+import * as koa from '@midwayjs/koa';
+import * as apollo from '../../../../src';
+
+@Configuration({
+  imports: [koa, apollo],
+  importConfigs: [join(__dirname, './config')],
+})
+export class ContainerConfiguration {}

--- a/packages/apollo/test/fixtures/base-app-koa/src/graphql/query.graphql
+++ b/packages/apollo/test/fixtures/base-app-koa/src/graphql/query.graphql
@@ -1,0 +1,3 @@
+extend type Query {
+  schemaLoaded: String!
+}

--- a/packages/apollo/test/fixtures/base-app-koa/src/resolver/hello.resolver.ts
+++ b/packages/apollo/test/fixtures/base-app-koa/src/resolver/hello.resolver.ts
@@ -1,0 +1,26 @@
+import { Inject } from '@midwayjs/core';
+import { Args, Context, Query, Resolver, Subscription } from '../../../../../src';
+import { HelloService } from '../service/hello';
+
+@Resolver()
+export class HelloResolver {
+  @Inject()
+  helloService: HelloService;
+
+  @Query('decoratedHello')
+  async decoratedHello() {
+    return await this.helloService.say();
+  }
+
+  @Query('decoratedEcho')
+  decoratedEcho(@Args('message') message: string, @Context() context) {
+    return `${message}:${context.get('x-apollo-test')}`;
+  }
+
+  @Subscription('counter')
+  async *counter() {
+    yield {
+      counter: 1,
+    };
+  }
+}

--- a/packages/apollo/test/fixtures/base-app-koa/src/schema.graphql
+++ b/packages/apollo/test/fixtures/base-app-koa/src/schema.graphql
@@ -1,0 +1,7 @@
+extend type Query {
+  decoratedEcho(message: String!): String!
+}
+
+type Subscription {
+  counter: Int!
+}

--- a/packages/apollo/test/fixtures/base-app-koa/src/service/hello.ts
+++ b/packages/apollo/test/fixtures/base-app-koa/src/service/hello.ts
@@ -1,0 +1,8 @@
+import { Provide } from '@midwayjs/core';
+
+@Provide()
+export class HelloService {
+  async say() {
+    return 'hello midway';
+  }
+}

--- a/packages/apollo/test/index.test.ts
+++ b/packages/apollo/test/index.test.ts
@@ -1,0 +1,167 @@
+import { close, createApp, createHttpRequest } from '@midwayjs/mock';
+import { join } from 'path';
+import { HelloService as KoaHelloService } from './fixtures/base-app-koa/src/service/hello';
+import { HelloService as ExpressHelloService } from './fixtures/base-app-express/src/service/hello';
+import * as apollo from '../src';
+import { HelloResolver } from './fixtures/base-app-koa/src/resolver/hello.resolver';
+import { createClient } from 'graphql-ws';
+import WebSocket = require('ws');
+
+describe('/test/index.test.ts', () => {
+  it('should re-export GraphQL decorators from Apollo component', () => {
+    expect(apollo.Resolver).toBeDefined();
+    expect(apollo.Query).toBeDefined();
+  });
+
+  describe('apollo component with koa', () => {
+    let app;
+
+    beforeAll(async () => {
+      app = await createApp({
+        baseDir: join(__dirname, 'fixtures/base-app-koa/src'),
+        preloadModules: [KoaHelloService, HelloResolver],
+      });
+    });
+
+    afterAll(async () => {
+      await close(app);
+    });
+
+    it('should execute query with Midway request context', async () => {
+      const result = await createHttpRequest(app)
+        .post('/graphql')
+        .send({ query: '{ hello }' });
+
+      expect(result.status).toBe(200);
+      expect(result.body).toEqual({
+        data: {
+          hello: 'hello midway',
+        },
+      });
+    });
+
+    it('should render GraphiQL for browser GET requests', async () => {
+      const result = await createHttpRequest(app)
+        .get('/graphql')
+        .set('accept', 'text/html');
+
+      expect(result.status).toBe(200);
+      expect(result.type).toBe('text/html');
+      expect(result.text).toContain('Midway Apollo GraphiQL');
+    });
+
+    it('should return method not allowed for unsupported methods', async () => {
+      const result = await createHttpRequest(app).put('/graphql').send({
+        query: '{ hello }',
+      });
+
+      expect(result.status).toBe(405);
+      expect(result.text).toBe('Method Not Allowed');
+      expect(result.headers.allow).toBe('GET, POST');
+    });
+
+    it('should expose framework request APIs on context', async () => {
+      const result = await createHttpRequest(app)
+        .post('/graphql')
+        .set('x-apollo-test', 'koa-header')
+        .send({ query: '{ header }' });
+
+      expect(result.status).toBe(200);
+      expect(result.body.data.header).toBe('koa-header');
+    });
+
+    it('should execute Midway resolver class methods', async () => {
+      const result = await createHttpRequest(app)
+        .post('/graphql')
+        .send({ query: '{ decoratedHello }' });
+
+      expect(result.status).toBe(200);
+      expect(result.body.data.decoratedHello).toBe('hello midway');
+    });
+
+    it('should load schema files and inject resolver parameters', async () => {
+      const result = await createHttpRequest(app)
+        .post('/graphql')
+        .set('x-apollo-test', 'koa-header')
+        .send({
+          query:
+            'query Echo($message: String!) { decoratedEcho(message: $message) schemaLoaded }',
+          variables: {
+            message: 'hello',
+          },
+        });
+
+      expect(result.status).toBe(200);
+      expect(result.body.data.decoratedEcho).toBe('hello:koa-header');
+      expect(result.body.data.schemaLoaded).toBe('schema file');
+    });
+
+    it('should execute GraphQL subscriptions over websocket', async () => {
+      const server = app.getFramework().getServer();
+      if (!server.listening) {
+        await new Promise<void>(resolve => {
+          server.listen(0, '127.0.0.1', () => resolve());
+        });
+      }
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : 0;
+      const client = createClient({
+        url: `ws://127.0.0.1:${port}/graphql`,
+        webSocketImpl: WebSocket,
+        retryAttempts: 0,
+      });
+
+      try {
+        const iterator = client.iterate({
+          query: 'subscription { counter }',
+        });
+        const result = await iterator.next();
+        expect(result.value).toEqual({
+          data: {
+            counter: 1,
+          },
+        });
+      } finally {
+        client.dispose();
+      }
+    });
+  });
+
+  describe('apollo component with express', () => {
+    let app;
+
+    beforeAll(async () => {
+      app = await createApp({
+        baseDir: join(__dirname, 'fixtures/base-app-express/src'),
+        preloadModules: [ExpressHelloService],
+      });
+    });
+
+    afterAll(async () => {
+      await close(app);
+    });
+
+    it('should execute query with Midway request context', async () => {
+      const result = await createHttpRequest(app)
+        .post('/graphql')
+        .send({ query: '{ hello }' });
+
+      expect(result.status).toBe(200);
+      expect(result.body).toEqual({
+        data: {
+          hello: 'hello midway',
+        },
+      });
+    });
+
+    it('should expose framework request APIs on context', async () => {
+      const result = await createHttpRequest(app)
+        .post('/graphql')
+        .set('x-apollo-test', 'express-header')
+        .send({ query: '{ header }' });
+
+      expect(result.status).toBe(200);
+      expect(result.body.data.header).toBe('express-header');
+    });
+  });
+});

--- a/packages/apollo/test/index.test.ts
+++ b/packages/apollo/test/index.test.ts
@@ -1,8 +1,13 @@
 import { close, createApp, createHttpRequest } from '@midwayjs/mock';
 import { join } from 'path';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { Readable } from 'stream';
 import { HelloService as KoaHelloService } from './fixtures/base-app-koa/src/service/hello';
 import { HelloService as ExpressHelloService } from './fixtures/base-app-express/src/service/hello';
 import * as apollo from '../src';
+import { ApolloService } from '../src';
+import { ApolloConfiguration } from '../src/configuration';
 import { HelloResolver } from './fixtures/base-app-koa/src/resolver/hello.resolver';
 import { createClient } from 'graphql-ws';
 import WebSocket = require('ws');
@@ -162,6 +167,445 @@ describe('/test/index.test.ts', () => {
 
       expect(result.status).toBe(200);
       expect(result.body.data.header).toBe('express-header');
+    });
+  });
+
+  describe('ApolloService branch behavior', () => {
+    function createServerMock(result?: any) {
+      return {
+        executeOperation: jest.fn(async () => {
+          return (
+            result || {
+              body: {
+                kind: 'single',
+                singleResult: {
+                  data: {
+                    ok: true,
+                  },
+                },
+              },
+              http: {
+                status: 202,
+                headers: new Headers({
+                  'x-apollo-test': 'yes',
+                }),
+              },
+            }
+          );
+        }),
+        start: jest.fn(),
+        stop: jest.fn(),
+      };
+    }
+
+    function createExpressResponse() {
+      return {
+        status: jest.fn().mockReturnThis(),
+        set: jest.fn().mockReturnThis(),
+        type: jest.fn().mockReturnThis(),
+        send: jest.fn().mockReturnThis(),
+      };
+    }
+
+    it('should pass through non-graphql paths', async () => {
+      const service = new ApolloService();
+      const next = jest.fn();
+      const middleware = service.createMiddleware(
+        createServerMock() as any,
+        {
+          path: '/graphql',
+        },
+        false
+      );
+
+      await middleware(
+        {
+          path: '/health',
+          method: 'GET',
+        } as any,
+        next
+      );
+
+      expect(next).toHaveBeenCalled();
+    });
+
+    it('should execute GET requests with JSON variables and response headers', async () => {
+      const service = new ApolloService();
+      const server = createServerMock();
+      const middleware = service.createMiddleware(
+        server as any,
+        {
+          path: '/graphql',
+          graphiql: false,
+        },
+        false
+      );
+      const ctx: any = {
+        path: '/graphql',
+        method: 'GET',
+        query: {
+          query: '{ ok }',
+          variables: '{"id":"1"}',
+          operationName: 'Ok',
+        },
+        headers: {},
+        set: jest.fn(),
+      };
+
+      await middleware(ctx, jest.fn());
+
+      expect(server.executeOperation).toHaveBeenCalledWith(
+        {
+          query: '{ ok }',
+          variables: {
+            id: '1',
+          },
+          operationName: 'Ok',
+        },
+        {
+          contextValue: expect.objectContaining({
+            graphql: {},
+          }),
+        }
+      );
+      expect(ctx.status).toBe(202);
+      expect(ctx.set).toHaveBeenCalledWith('x-apollo-test', 'yes');
+      expect(ctx.body.data.ok).toBe(true);
+    });
+
+    it('should parse express request bodies and attach context extensions', async () => {
+      const service = new ApolloService();
+      const server = createServerMock({
+        body: {
+          data: {
+            ok: true,
+          },
+        },
+      });
+      const middleware = service.createMiddleware(
+        server as any,
+        {
+          path: '/graphql',
+          graphql: {
+            source: 'test',
+          },
+          contextFactory: () => ({
+            currentUser: 'harry',
+            logger: 'reserved',
+          }),
+        },
+        true
+      );
+      const req = Readable.from([
+        JSON.stringify({
+          query: '{ ok }',
+        }),
+      ]) as any;
+      req.path = '/graphql';
+      req.url = '/graphql';
+      req.method = 'POST';
+      req.headers = {};
+      const res = createExpressResponse();
+
+      await middleware(req, res, jest.fn());
+
+      expect(server.executeOperation).toHaveBeenCalledWith(
+        {
+          query: '{ ok }',
+          variables: undefined,
+          operationName: undefined,
+        },
+        {
+          contextValue: expect.objectContaining({
+            currentUser: 'harry',
+            graphql: {
+              source: 'test',
+            },
+          }),
+        }
+      );
+      expect(req.logger).toBeUndefined();
+      expect(res.type).toHaveBeenCalledWith('application/json');
+      expect(res.send).toHaveBeenCalledWith(
+        JSON.stringify({
+          data: {
+            ok: true,
+          },
+        })
+      );
+    });
+
+    it('should use existing request bodies and handle empty streams', async () => {
+      const service = new ApolloService();
+      const server = createServerMock();
+      const middleware = service.createMiddleware(
+        server as any,
+        {
+          path: '/graphql',
+        },
+        true
+      );
+      const reqWithBody: any = {
+        path: '/graphql',
+        url: '/graphql',
+        method: 'POST',
+        headers: {},
+        body: {
+          query: '{ fromBody }',
+        },
+      };
+      const reqWithEmptyStream = Readable.from([]) as any;
+      reqWithEmptyStream.path = '/graphql';
+      reqWithEmptyStream.url = '/graphql';
+      reqWithEmptyStream.method = 'POST';
+      reqWithEmptyStream.headers = {};
+
+      await middleware(reqWithBody, createExpressResponse(), jest.fn());
+      await middleware(reqWithEmptyStream, createExpressResponse(), jest.fn());
+
+      expect(server.executeOperation).toHaveBeenNthCalledWith(
+        1,
+        {
+          query: '{ fromBody }',
+          variables: undefined,
+          operationName: undefined,
+        },
+        expect.anything()
+      );
+      expect(server.executeOperation).toHaveBeenNthCalledWith(
+        2,
+        {
+          query: undefined,
+          variables: undefined,
+          operationName: undefined,
+        },
+        expect.anything()
+      );
+    });
+
+    it('should handle empty raw request bodies', async () => {
+      const service = new ApolloService();
+      const server = createServerMock();
+      const middleware = service.createMiddleware(
+        server as any,
+        {
+          path: '/graphql',
+        },
+        true
+      );
+      const req = Readable.from(['']) as any;
+      req.path = '/graphql';
+      req.url = '/graphql';
+      req.method = 'POST';
+      req.headers = {};
+
+      await middleware(req, createExpressResponse(), jest.fn());
+
+      expect(server.executeOperation).toHaveBeenCalledWith(
+        {
+          query: undefined,
+          variables: undefined,
+          operationName: undefined,
+        },
+        expect.anything()
+      );
+    });
+
+    it('should return request errors for invalid JSON request bodies', async () => {
+      const service = new ApolloService();
+      const middleware = service.createMiddleware(
+        createServerMock() as any,
+        {
+          path: '/graphql',
+        },
+        true
+      );
+      const req = Readable.from(['{']) as any;
+      req.path = '/graphql';
+      req.url = '/graphql';
+      req.method = 'POST';
+      req.headers = {};
+      const res = createExpressResponse();
+
+      await middleware(req, res, jest.fn());
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.send).toHaveBeenCalledWith(
+        JSON.stringify({
+          errors: [
+            {
+              message: 'Invalid JSON request body',
+            },
+          ],
+        })
+      );
+    });
+
+    it('should render custom GraphiQL only when enabled', async () => {
+      const service = new ApolloService();
+      const middleware = service.createMiddleware(
+        createServerMock() as any,
+        {
+          path: '/custom',
+          graphiql: {
+            title: 'Custom GraphiQL',
+            endpoint: '/custom',
+          },
+        },
+        true
+      );
+      const req = {
+        path: '/custom',
+        url: '/custom',
+        method: 'GET',
+        headers: {
+          accept: 'text/html',
+        },
+      };
+      const res = createExpressResponse();
+
+      await middleware(req, res, jest.fn());
+
+      expect(res.type).toHaveBeenCalledWith('text/html');
+      expect(res.send.mock.calls[0][0]).toContain('Custom GraphiQL');
+      expect(res.send.mock.calls[0][0]).toContain('/custom');
+    });
+
+    it('should disable default GraphiQL in production', async () => {
+      const originalNodeEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'production';
+      try {
+        const service = new ApolloService();
+        const server = createServerMock();
+        const middleware = service.createMiddleware(
+          server as any,
+          {
+            path: '/graphql',
+          },
+          true
+        );
+        const req = {
+          path: '/graphql',
+          url: '/graphql',
+          method: 'GET',
+          query: {},
+          headers: {
+            accept: 'text/html',
+          },
+        };
+
+        await middleware(req, createExpressResponse(), jest.fn());
+
+        expect(server.executeOperation).toHaveBeenCalled();
+      } finally {
+        process.env.NODE_ENV = originalNodeEnv;
+      }
+    });
+
+    it('should build schemas from exact files and glob patterns', () => {
+      const service = new ApolloService();
+      const baseDir = mkdtempSync(join(tmpdir(), 'midway-apollo-'));
+      try {
+        writeFileSync(
+          join(baseDir, 'schema.graphql'),
+          'type Query { exact: String globbed: String }'
+        );
+        writeFileSync(
+          join(baseDir, 'extra1.graphql'),
+          'extend type Query { extra: String }'
+        );
+
+        const schema = service.createSchema(
+          {
+            typePaths: [
+              './schema.graphql',
+              'no-match**.graphql',
+              'extra?.graphql',
+            ],
+          },
+          {
+            Query: {
+              exact: () => 'exact',
+              globbed: () => 'globbed',
+              extra: () => 'extra',
+            },
+          },
+          baseDir
+        );
+
+        expect(schema.getQueryType().getFields().exact).toBeDefined();
+        expect(schema.getQueryType().getFields().extra).toBeDefined();
+      } finally {
+        rmSync(baseDir, {
+          recursive: true,
+          force: true,
+        });
+      }
+    });
+
+    it('should skip disabled subscriptions and apps without http servers', () => {
+      const service = new ApolloService();
+      const schema = service.createSchema(
+        {
+          typeDefs: 'type Query { ok: Boolean }',
+        },
+        {
+          Query: {
+            ok: () => true,
+          },
+        },
+        process.cwd()
+      );
+
+      expect(
+        service.createSubscriptionServer(schema, { subscriptions: false }, {})
+      ).toBeUndefined();
+      expect(
+        service.createSubscriptionServer(
+          schema,
+          {
+            path: '/fallback',
+            subscriptions: {},
+          },
+          {
+            getFramework: () => ({}),
+          }
+        )
+      ).toBeUndefined();
+    });
+
+    it('should return when no web applications are registered', async () => {
+      const configuration = new ApolloConfiguration();
+      configuration.configService = {
+        getConfiguration: jest.fn(() => ({})),
+      } as any;
+      configuration.applicationManager = {
+        getApplications: jest.fn(() => []),
+      } as any;
+      configuration.graphqlService = {
+        buildResolvers: jest.fn(),
+      } as any;
+      configuration.apolloService = new ApolloService();
+
+      await configuration.onReady({} as any);
+
+      expect(configuration.graphqlService.buildResolvers).not.toHaveBeenCalled();
+    });
+
+    it('should stop servers', async () => {
+      const service = new ApolloService();
+      const server = {
+        stop: jest.fn(),
+      };
+      const subscriptionServer = {
+        dispose: jest.fn(),
+      };
+
+      await service.stop(server as any);
+      await service.stopSubscriptionServer(subscriptionServer);
+
+      expect(server.stop).toHaveBeenCalled();
+      expect(subscriptionServer.dispose).toHaveBeenCalled();
     });
   });
 });

--- a/packages/apollo/tsconfig.json
+++ b/packages/apollo/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compileOnSave": true,
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": [
+    "./src/**/*.ts"
+  ]
+}

--- a/packages/graphql/jest.config.js
+++ b/packages/graphql/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testPathIgnorePatterns: ['<rootDir>/test/fixtures'],
+  coveragePathIgnorePatterns: ['<rootDir>/test/', '<rootDir>/dist/'],
+  setupFilesAfterEnv: ['./jest.setup.js'],
+  coverageProvider: 'v8',
+};

--- a/packages/graphql/jest.config.js
+++ b/packages/graphql/jest.config.js
@@ -5,4 +5,9 @@ module.exports = {
   coveragePathIgnorePatterns: ['<rootDir>/test/', '<rootDir>/dist/'],
   setupFilesAfterEnv: ['./jest.setup.js'],
   coverageProvider: 'v8',
+  coverageThreshold: {
+    global: {
+      branches: 90,
+    },
+  },
 };

--- a/packages/graphql/jest.setup.js
+++ b/packages/graphql/jest.setup.js
@@ -1,0 +1,1 @@
+jest.setTimeout(30000);

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@midwayjs/graphql",
+  "version": "4.1.0",
+  "description": "Midway GraphQL base SDK",
+  "main": "dist/index.js",
+  "typings": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "node -r ts-node/register ../../node_modules/jest/bin/jest.js --runInBand",
+    "cov": "node -r ts-node/register ../../node_modules/jest/bin/jest.js --runInBand --coverage --forceExit",
+    "lint:fix": "../../node_modules/.bin/mwts fix"
+  },
+  "keywords": [
+    "midway",
+    "IoC",
+    "framework",
+    "graphql"
+  ],
+  "files": [
+    "dist/**/*.js",
+    "dist/**/*.d.ts"
+  ],
+  "license": "MIT",
+  "devDependencies": {
+    "@midwayjs/core": "workspace:^",
+    "@midwayjs/mock": "workspace:^"
+  },
+  "author": "Harry Chen <czy88840616@gmail.com>",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/midwayjs/midway.git"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packages/graphql/src/constants.ts
+++ b/packages/graphql/src/constants.ts
@@ -1,0 +1,3 @@
+export const GRAPHQL_RESOLVER_KEY = 'graphql:resolver';
+export const GRAPHQL_FIELD_KEY = 'graphql:field';
+export const GRAPHQL_PARAM_KEY = 'graphql:param';

--- a/packages/graphql/src/decorator.ts
+++ b/packages/graphql/src/decorator.ts
@@ -1,0 +1,119 @@
+import {
+  DecoratorManager,
+  MetadataManager,
+  Provide,
+  Scope,
+  ScopeEnum,
+} from '@midwayjs/core';
+import {
+  GRAPHQL_FIELD_KEY,
+  GRAPHQL_PARAM_KEY,
+  GRAPHQL_RESOLVER_KEY,
+} from './constants';
+import {
+  GraphQLFieldMetadata,
+  GraphQLParamMetadata,
+  GraphQLParamSource,
+  GraphQLOperationType,
+  GraphQLResolverMetadata,
+} from './interface';
+
+/**
+ * Marks a class as a GraphQL resolver managed by Midway.
+ */
+export function Resolver(typeName: GraphQLOperationType | string = 'Query') {
+  return (target: any) => {
+    DecoratorManager.saveModule(GRAPHQL_RESOLVER_KEY, target);
+    MetadataManager.defineMetadata(
+      GRAPHQL_RESOLVER_KEY,
+      { typeName } as GraphQLResolverMetadata,
+      target
+    );
+    Provide()(target);
+    Scope(ScopeEnum.Request)(target);
+  };
+}
+
+function createFieldDecorator(
+  operationType: GraphQLOperationType,
+  fieldName?: string
+) {
+  return (target: any, propertyKey: string | symbol) => {
+    MetadataManager.attachMetadata(
+      GRAPHQL_FIELD_KEY,
+      {
+        operationType,
+        fieldName,
+        methodName: propertyKey,
+      } as GraphQLFieldMetadata,
+      target.constructor
+    );
+  };
+}
+
+/**
+ * Marks a resolver method as a GraphQL Query field.
+ */
+export function Query(fieldName?: string): MethodDecorator {
+  return createFieldDecorator('Query', fieldName) as MethodDecorator;
+}
+
+/**
+ * Marks a resolver method as a GraphQL Mutation field.
+ */
+export function Mutation(fieldName?: string): MethodDecorator {
+  return createFieldDecorator('Mutation', fieldName) as MethodDecorator;
+}
+
+/**
+ * Marks a resolver method as a GraphQL Subscription field.
+ */
+export function Subscription(fieldName?: string): MethodDecorator {
+  return createFieldDecorator('Subscription', fieldName) as MethodDecorator;
+}
+
+function createParamDecorator(
+  source: GraphQLParamSource,
+  propertyKey?: string
+) {
+  return (target: any, methodName: string | symbol, parameterIndex: number) => {
+    MetadataManager.attachMetadata(
+      GRAPHQL_PARAM_KEY,
+      {
+        source,
+        propertyKey,
+        parameterIndex,
+      } as GraphQLParamMetadata,
+      target.constructor,
+      methodName
+    );
+  };
+}
+
+/**
+ * Injects the GraphQL parent value into a resolver method parameter.
+ */
+export function Parent(propertyKey?: string): ParameterDecorator {
+  return createParamDecorator('parent', propertyKey) as ParameterDecorator;
+}
+
+/**
+ * Injects GraphQL arguments into a resolver method parameter.
+ */
+export function Args(propertyKey?: string): ParameterDecorator {
+  return createParamDecorator('args', propertyKey) as ParameterDecorator;
+}
+
+/**
+ * Injects the active Midway GraphQL context into a resolver method parameter.
+ */
+export function Context(propertyKey?: string): ParameterDecorator {
+  return createParamDecorator('context', propertyKey) as ParameterDecorator;
+}
+
+/**
+ * Injects GraphQL resolve info into a resolver method parameter.
+ */
+export function Info(propertyKey?: string): ParameterDecorator {
+  return createParamDecorator('info', propertyKey) as ParameterDecorator;
+}

--- a/packages/graphql/src/index.ts
+++ b/packages/graphql/src/index.ts
@@ -1,0 +1,3 @@
+export * from './interface';
+export * from './decorator';
+export { GraphQLService } from './service';

--- a/packages/graphql/src/interface.ts
+++ b/packages/graphql/src/interface.ts
@@ -1,0 +1,68 @@
+import { ClassType, IMidwayContext } from '@midwayjs/core';
+
+/**
+ * Supported GraphQL root operation types.
+ */
+export type GraphQLOperationType = 'Query' | 'Mutation' | 'Subscription';
+
+/**
+ * Per-request GraphQL context. It is the active Midway context itself.
+ */
+export type MidwayGraphQLContext<
+  TContext extends IMidwayContext = IMidwayContext,
+> = TContext & {
+  graphql?: Record<string, unknown>;
+};
+
+/**
+ * User callback used to extend the active Midway context for GraphQL.
+ */
+export type GraphQLContextFactory<TContext extends IMidwayContext = any> = (
+  context: MidwayGraphQLContext<TContext>
+) => Promise<Record<string, unknown> | void> | Record<string, unknown> | void;
+
+/**
+ * Shared GraphQL configuration consumed by runtime components.
+ */
+export interface GraphQLBaseConfigurationOptions {
+  path?: string;
+  methods?: string[];
+  typeDefs?: unknown;
+  typePaths?: string[];
+  resolvers?: Record<string, any>;
+  resolverValidationOptions?: Record<string, any>;
+  inheritResolversFromInterfaces?: boolean;
+  resolverClasses?: ClassType[];
+  contextFactory?: GraphQLContextFactory;
+  graphql?: Record<string, unknown>;
+}
+
+/**
+ * Metadata stored for a GraphQL resolver class.
+ */
+export interface GraphQLResolverMetadata {
+  typeName: GraphQLOperationType | string;
+}
+
+/**
+ * Metadata stored for a resolver method.
+ */
+export interface GraphQLFieldMetadata {
+  operationType: GraphQLOperationType;
+  fieldName?: string;
+  methodName: string | symbol;
+}
+
+/**
+ * Resolver method argument sources.
+ */
+export type GraphQLParamSource = 'parent' | 'args' | 'context' | 'info';
+
+/**
+ * Metadata stored for a resolver method parameter.
+ */
+export interface GraphQLParamMetadata {
+  source: GraphQLParamSource;
+  propertyKey?: string;
+  parameterIndex: number;
+}

--- a/packages/graphql/src/service.ts
+++ b/packages/graphql/src/service.ts
@@ -1,0 +1,115 @@
+import {
+  DecoratorManager,
+  IMidwayContainer,
+  MetadataManager,
+  Provide,
+  Scope,
+  ScopeEnum,
+} from '@midwayjs/core';
+import {
+  GRAPHQL_FIELD_KEY,
+  GRAPHQL_PARAM_KEY,
+  GRAPHQL_RESOLVER_KEY,
+} from './constants';
+import {
+  GraphQLBaseConfigurationOptions,
+  GraphQLFieldMetadata,
+  GraphQLParamMetadata,
+  GraphQLResolverMetadata,
+} from './interface';
+
+function readSourceValue(source: any, propertyKey?: string) {
+  if (!propertyKey) {
+    return source;
+  }
+  return source?.[propertyKey];
+}
+
+function buildMethodArgs(
+  params: GraphQLParamMetadata[],
+  parent: any,
+  args: any,
+  context: any,
+  info: any
+) {
+  if (!params.length) {
+    return [parent, args, context, info];
+  }
+
+  const methodArgs = [];
+  for (const param of params) {
+    const sourceValue =
+      param.source === 'parent'
+        ? parent
+        : param.source === 'args'
+          ? args
+          : param.source === 'context'
+            ? context
+            : info;
+    methodArgs[param.parameterIndex] = readSourceValue(
+      sourceValue,
+      param.propertyKey
+    );
+  }
+  return methodArgs;
+}
+
+@Provide()
+@Scope(ScopeEnum.Singleton)
+export class GraphQLService {
+  /**
+   * Merges configured resolver maps with Midway-managed resolver classes.
+   */
+  buildResolvers(
+    config: GraphQLBaseConfigurationOptions,
+    container: IMidwayContainer
+  ) {
+    const resolvers = {
+      ...(config.resolvers || {}),
+    };
+    const resolverClasses = [
+      ...DecoratorManager.listModule(GRAPHQL_RESOLVER_KEY),
+      ...(config.resolverClasses || []),
+    ];
+
+    for (const resolverClass of resolverClasses) {
+      const resolverMeta = MetadataManager.getMetadata<GraphQLResolverMetadata>(
+        GRAPHQL_RESOLVER_KEY,
+        resolverClass
+      ) || { typeName: 'Query' };
+      const fields =
+        MetadataManager.getMetadata<GraphQLFieldMetadata[]>(
+          GRAPHQL_FIELD_KEY,
+          resolverClass
+        ) || [];
+
+      for (const field of fields) {
+        const typeName =
+          field.operationType || resolverMeta.typeName || 'Query';
+        const fieldName = field.fieldName || String(field.methodName);
+        const params =
+          MetadataManager.getMetadata<GraphQLParamMetadata[]>(
+            GRAPHQL_PARAM_KEY,
+            resolverClass,
+            field.methodName
+          ) || [];
+        const resolveHandler = async (parent, args, context, info) => {
+          const requestContainer = context?.requestContext || container;
+          const instance = await requestContainer.getAsync(resolverClass);
+          return await instance[field.methodName](
+            ...buildMethodArgs(params, parent, args, context, info)
+          );
+        };
+        resolvers[typeName] = resolvers[typeName] || {};
+        resolvers[typeName][fieldName] =
+          field.operationType === 'Subscription'
+            ? {
+                subscribe: resolveHandler,
+              }
+            : resolveHandler;
+      }
+    }
+
+    return resolvers;
+  }
+}

--- a/packages/graphql/test/index.test.ts
+++ b/packages/graphql/test/index.test.ts
@@ -3,6 +3,7 @@ import {
   Context,
   GraphQLService,
   Info,
+  Mutation,
   Parent,
   Query,
   Resolver,
@@ -37,11 +38,23 @@ class HelloResolver {
     return `${prefix}:${message}:${requestId}:${fieldName}`;
   }
 
+  @Mutation('merge')
+  merge(@Args() args) {
+    return `${args.left}:${args.right}`;
+  }
+
   @Subscription('count')
   async *count() {
     yield {
       count: 1,
     };
+  }
+}
+
+class RawResolver {
+  @Query()
+  raw(parent, args, context, info) {
+    return `${parent.name}:${args.id}:${context.requestId}:${info.fieldName}`;
   }
 }
 
@@ -113,5 +126,64 @@ describe('/test/index.test.ts', () => {
     expect(result.value).toEqual({
       count: 1,
     });
+  });
+
+  it('should inject full argument objects and use the fallback container', async () => {
+    const service = new GraphQLService();
+    const container = {
+      getAsync: jest.fn(async target => {
+        if (target === HelloResolver) {
+          return new HelloResolver();
+        }
+      }),
+    } as unknown as IMidwayContainer;
+
+    const resolvers = service.buildResolvers({}, container);
+    const result = await resolvers.Mutation.merge(
+      undefined,
+      {
+        left: 'left',
+        right: 'right',
+      },
+      {},
+      {}
+    );
+
+    expect(result).toBe('left:right');
+    expect(container.getAsync).toHaveBeenCalledWith(HelloResolver);
+  });
+
+  it('should support resolver classes without resolver metadata', async () => {
+    const service = new GraphQLService();
+    const container = {
+      getAsync: jest.fn(async target => {
+        if (target === RawResolver) {
+          return new RawResolver();
+        }
+      }),
+    } as unknown as IMidwayContainer;
+
+    const resolvers = service.buildResolvers(
+      {
+        resolverClasses: [RawResolver],
+      },
+      container
+    );
+    const result = await resolvers.Query.raw(
+      {
+        name: 'parent',
+      },
+      {
+        id: 'args',
+      },
+      {
+        requestId: 'ctx',
+      },
+      {
+        fieldName: 'raw',
+      }
+    );
+
+    expect(result).toBe('parent:args:ctx:raw');
   });
 });

--- a/packages/graphql/test/index.test.ts
+++ b/packages/graphql/test/index.test.ts
@@ -1,0 +1,117 @@
+import {
+  Args,
+  Context,
+  GraphQLService,
+  Info,
+  Parent,
+  Query,
+  Resolver,
+  Subscription,
+} from '../src';
+import { IMidwayContainer, Inject, Provide } from '@midwayjs/core';
+
+@Provide()
+class HelloService {
+  async say() {
+    return 'hello midway';
+  }
+}
+
+@Resolver()
+class HelloResolver {
+  @Inject()
+  helloService: HelloService;
+
+  @Query('hello')
+  async hello() {
+    return await this.helloService.say();
+  }
+
+  @Query('echo')
+  echo(
+    @Parent('prefix') prefix: string,
+    @Args('message') message: string,
+    @Context('requestId') requestId: string,
+    @Info('fieldName') fieldName: string
+  ) {
+    return `${prefix}:${message}:${requestId}:${fieldName}`;
+  }
+
+  @Subscription('count')
+  async *count() {
+    yield {
+      count: 1,
+    };
+  }
+}
+
+describe('/test/index.test.ts', () => {
+  it('should build resolver maps from decorated classes', async () => {
+    const service = new GraphQLService();
+    const requestContext = {
+      getAsync: jest.fn(async target => {
+        if (target === HelloResolver) {
+          const resolver = new HelloResolver();
+          resolver.helloService = new HelloService();
+          return resolver;
+        }
+      }),
+    } as unknown as IMidwayContainer;
+
+    const resolvers = service.buildResolvers({}, requestContext);
+    const result = await resolvers.Query.hello(
+      undefined,
+      {},
+      { requestContext },
+      {}
+    );
+
+    expect(result).toBe('hello midway');
+    expect(requestContext.getAsync).toHaveBeenCalledWith(HelloResolver);
+  });
+
+  it('should inject decorated resolver method parameters', async () => {
+    const service = new GraphQLService();
+    const requestContext = {
+      getAsync: jest.fn(async target => {
+        if (target === HelloResolver) {
+          return new HelloResolver();
+        }
+      }),
+    } as unknown as IMidwayContainer;
+
+    const resolvers = service.buildResolvers({}, requestContext);
+    const result = await resolvers.Query.echo(
+      { prefix: 'parent' },
+      { message: 'args' },
+      { requestContext, requestId: 'ctx' },
+      { fieldName: 'echo' }
+    );
+
+    expect(result).toBe('parent:args:ctx:echo');
+  });
+
+  it('should build subscription resolver objects from decorated methods', async () => {
+    const service = new GraphQLService();
+    const requestContext = {
+      getAsync: jest.fn(async target => {
+        if (target === HelloResolver) {
+          return new HelloResolver();
+        }
+      }),
+    } as unknown as IMidwayContainer;
+
+    const resolvers = service.buildResolvers({}, requestContext);
+    const iterator = await resolvers.Subscription.count.subscribe(
+      undefined,
+      {},
+      { requestContext },
+      {}
+    );
+    const result = await iterator.next();
+
+    expect(result.value).toEqual({
+      count: 1,
+    });
+  });
+});

--- a/packages/graphql/tsconfig.json
+++ b/packages/graphql/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compileOnSave": true,
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": [
+    "./src/**/*.ts"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,6 +146,46 @@ importers:
         specifier: 8.5.1
         version: 8.5.1(postcss@8.5.6)(tsx@4.21.0)(typescript@5.6.3)(yaml@2.8.2)
 
+  packages/apollo:
+    dependencies:
+      '@apollo/server':
+        specifier: 5.5.1
+        version: 5.5.1(graphql@16.14.0)
+      '@graphql-tools/schema':
+        specifier: 10.0.33
+        version: 10.0.33(graphql@16.14.0)
+      '@midwayjs/glob':
+        specifier: 1.1.1
+        version: 1.1.1
+      '@midwayjs/graphql':
+        specifier: workspace:^
+        version: link:../graphql
+      graphql:
+        specifier: 16.14.0
+        version: 16.14.0
+      graphql-ws:
+        specifier: 6.0.8
+        version: 6.0.8(graphql@16.14.0)(ws@8.20.0)
+      ws:
+        specifier: 8.20.0
+        version: 8.20.0
+    devDependencies:
+      '@midwayjs/core':
+        specifier: workspace:^
+        version: link:../core
+      '@midwayjs/express':
+        specifier: workspace:^
+        version: link:../web-express
+      '@midwayjs/koa':
+        specifier: workspace:^
+        version: link:../web-koa
+      '@midwayjs/mock':
+        specifier: workspace:^
+        version: link:../mock
+      '@types/ws':
+        specifier: 8.18.1
+        version: 8.18.1
+
   packages/axios:
     dependencies:
       axios:
@@ -668,6 +708,15 @@ importers:
       mm:
         specifier: 3.4.0
         version: 3.4.0
+
+  packages/graphql:
+    devDependencies:
+      '@midwayjs/core':
+        specifier: workspace:^
+        version: link:../core
+      '@midwayjs/mock':
+        specifier: workspace:^
+        version: link:../mock
 
   packages/grpc:
     dependencies:
@@ -2235,6 +2284,89 @@ packages:
     peerDependencies:
       openapi-types: '>=7'
 
+  '@apollo/cache-control-types@1.0.3':
+    resolution: {integrity: sha512-F17/vCp7QVwom9eG7ToauIKdAxpSoadsJnqIfyryLFSkLSOEqu+eC5Z3N8OXcUVStuOMcNHlyraRsA6rRICu4g==}
+    peerDependencies:
+      graphql: 14.x || 15.x || 16.x
+
+  '@apollo/protobufjs@1.2.8':
+    resolution: {integrity: sha512-r7xNeUqZX+eBBEmyvaPw0/cSz6zgf5jdH8mjUz8ynKpNs/GU7vi2T7sNcZINk2ZID7wwjG91FCgdpCrQuJ8rzA==}
+    hasBin: true
+
+  '@apollo/server-gateway-interface@2.0.0':
+    resolution: {integrity: sha512-3HEMD6fSantG2My3jWkb9dvfkF9vJ4BDLRjMgsnD790VINtuPaEp+h3Hg9HOHiWkML6QsOhnaRqZ+gvhp3y8Nw==}
+    peerDependencies:
+      graphql: 14.x || 15.x || 16.x
+
+  '@apollo/server@5.5.1':
+    resolution: {integrity: sha512-Rn3g5TJQsMSUY23CWZTghWdBWyjX7dP1eaEBPkvmM2RHi82cDcpgTIkSCbGvtTUEGjwopLv1AAooU/n7iIZ20A==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      graphql: ^16.11.0
+
+  '@apollo/usage-reporting-protobuf@4.1.2':
+    resolution: {integrity: sha512-aTnAD41RYz0d5dawlyR5Iclkgzx0Xb0njUJmEfvZ6pS4f4HU8wCYyctPpWat/HWp2PmRwDfX5R1k4uVcDKZ4xA==}
+
+  '@apollo/utils.createhash@3.0.1':
+    resolution: {integrity: sha512-CKrlySj4eQYftBE5MJ8IzKwIibQnftDT7yGfsJy5KSEEnLlPASX0UTpbKqkjlVEwPPd4mEwI7WOM7XNxEuO05A==}
+    engines: {node: '>=16'}
+
+  '@apollo/utils.dropunuseddefinitions@2.0.1':
+    resolution: {integrity: sha512-EsPIBqsSt2BwDsv8Wu76LK5R1KtsVkNoO4b0M5aK0hx+dGg9xJXuqlr7Fo34Dl+y83jmzn+UvEW+t1/GP2melA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      graphql: 14.x || 15.x || 16.x
+
+  '@apollo/utils.fetcher@3.1.0':
+    resolution: {integrity: sha512-Z3QAyrsQkvrdTuHAFwWDNd+0l50guwoQUoaDQssLOjkmnmVuvXlJykqlEJolio+4rFwBnWdoY1ByFdKaQEcm7A==}
+    engines: {node: '>=16'}
+
+  '@apollo/utils.isnodelike@3.0.0':
+    resolution: {integrity: sha512-xrjyjfkzunZ0DeF6xkHaK5IKR8F1FBq6qV+uZ+h9worIF/2YSzA0uoBxGv6tbTeo9QoIQnRW4PVFzGix5E7n/g==}
+    engines: {node: '>=16'}
+
+  '@apollo/utils.keyvaluecache@4.0.0':
+    resolution: {integrity: sha512-mKw1myRUkQsGPNB+9bglAuhviodJ2L2MRYLTafCMw5BIo7nbvCPNCkLnIHjZ1NOzH7SnMAr5c9LmXiqsgYqLZw==}
+    engines: {node: '>=20'}
+
+  '@apollo/utils.logger@3.0.0':
+    resolution: {integrity: sha512-M8V8JOTH0F2qEi+ktPfw4RL7MvUycDfKp7aEap2eWXfL5SqWHN6jTLbj5f5fj1cceHpyaUSOZlvlaaryaxZAmg==}
+    engines: {node: '>=16'}
+
+  '@apollo/utils.printwithreducedwhitespace@2.0.1':
+    resolution: {integrity: sha512-9M4LUXV/fQBh8vZWlLvb/HyyhjJ77/I5ZKu+NBWV/BmYGyRmoEP9EVAy7LCVoY3t8BDcyCAGfxJaLFCSuQkPUg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      graphql: 14.x || 15.x || 16.x
+
+  '@apollo/utils.removealiases@2.0.1':
+    resolution: {integrity: sha512-0joRc2HBO4u594Op1nev+mUF6yRnxoUH64xw8x3bX7n8QBDYdeYgY4tF0vJReTy+zdn2xv6fMsquATSgC722FA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      graphql: 14.x || 15.x || 16.x
+
+  '@apollo/utils.sortast@2.0.1':
+    resolution: {integrity: sha512-eciIavsWpJ09za1pn37wpsCGrQNXUhM0TktnZmHwO+Zy9O4fu/WdB4+5BvVhFiZYOXvfjzJUcc+hsIV8RUOtMw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      graphql: 14.x || 15.x || 16.x
+
+  '@apollo/utils.stripsensitiveliterals@2.0.1':
+    resolution: {integrity: sha512-QJs7HtzXS/JIPMKWimFnUMK7VjkGQTzqD9bKD1h3iuPAqLsxd0mUNVbkYOPTsDhUKgcvUOfOqOJWYohAKMvcSA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      graphql: 14.x || 15.x || 16.x
+
+  '@apollo/utils.usagereporting@2.1.0':
+    resolution: {integrity: sha512-LPSlBrn+S17oBy5eWkrRSGb98sWmnEzo3DPTZgp8IQc8sJe0prDgDuppGq4NeQlpoqEHz0hQeYHAOA0Z3aQsxQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      graphql: 14.x || 15.x || 16.x
+
+  '@apollo/utils.withrequired@3.0.0':
+    resolution: {integrity: sha512-aaxeavfJ+RHboh7c2ofO5HHtQobGX4AgUujXP4CXpREHp9fQ9jPi6K9T1jrAKe7HIipoP0OJ1gd6JamSkFIpvA==}
+    engines: {node: '>=16'}
+
   '@assemblyscript/loader@0.19.23':
     resolution: {integrity: sha512-ulkCYfFbYj01ie1MDOyxv2F6SpRN1TOj7fQxbP07D6HmeR+gr2JLSmINKjga2emB+b1L2KGrFKBTc+e00p54nw==}
 
@@ -2857,6 +2989,29 @@ packages:
 
   '@gar/promisify@1.1.3':
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
+
+  '@graphql-tools/merge@9.1.9':
+    resolution: {integrity: sha512-iHUWNjRHeQRYdgIMIuChThOwoKzA9vrzYeslgfBo5eUYEyHGZCoDPjAavssoYXLwstYt1dZj2J22jSzc2DrN0Q==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@graphql-tools/schema@10.0.33':
+    resolution: {integrity: sha512-O6P3RIftO0jafnSsFAqpjurUuUxJ43s/AdPVLQsBkI6y4Ic/tKm4C1Qm1KKQsCDTOxXPJClh/v3g7k7yLKCFBQ==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@graphql-tools/utils@11.1.0':
+    resolution: {integrity: sha512-PtFVG4r8Z2LEBSaPYQMusBiB3o6kjLVJyjCLbnWem/SpSuM21v6LTmgpkXfYU1qpBV2UGsFyuEnSJInl8fR1Ag==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@graphql-typed-document-node/core@3.2.0':
+    resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
 
   '@grpc/grpc-js@1.14.1':
     resolution: {integrity: sha512-sPxgEWtPUR3EnRJCEtbGZG2iX8LQDUls2wUS3o27jg07KqJFMq6YDeWvMo1wfpmy3rqRdS0rivpLwhqQtEyCuQ==}
@@ -4890,6 +5045,10 @@ packages:
   '@webassemblyjs/wast-printer@1.14.1':
     resolution: {integrity: sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==}
 
+  '@whatwg-node/promise-helpers@1.3.2':
+    resolution: {integrity: sha512-Nst5JdK47VIl9UcGwtv2Rcgyn5lWtZ0/mhRQ4G8NN2isxpq2TO30iqHzmwoJycjWuyUfg3GFXqP/gFHXeV57IA==}
+    engines: {node: '>=16.0.0'}
+
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
 
@@ -5245,6 +5404,9 @@ packages:
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
+
+  async-retry@1.3.3:
+    resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
 
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
@@ -6123,6 +6285,10 @@ packages:
     resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
     engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
     hasBin: true
+
+  cross-inspect@1.0.1:
+    resolution: {integrity: sha512-Pcw1JTvZLSJH83iiGWt6fRcT+BjZlCDRVwYLbUcHzv/CRpB7r0MlSrGbIyQvVSNyGnbt7G4AXuyCiDR3POvZ1A==}
+    engines: {node: '>=16.0.0'}
 
   cross-spawn@6.0.6:
     resolution: {integrity: sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==}
@@ -7664,6 +7830,26 @@ packages:
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
+  graphql-ws@6.0.8:
+    resolution: {integrity: sha512-m3EOaNsUBXwAnkBWbzPfe0Nq8pXUfxsWnolC54sru3FzHvhTZL0Ouf/BoQsaGAXqM+YPerXOJ47BUnmgmoupCw==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@fastify/websocket': ^10 || ^11
+      crossws: ~0.3
+      graphql: ^15.10.1 || ^16
+      ws: ^8
+    peerDependenciesMeta:
+      '@fastify/websocket':
+        optional: true
+      crossws:
+        optional: true
+      ws:
+        optional: true
+
+  graphql@16.14.0:
+    resolution: {integrity: sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+
   gzip-size@6.0.0:
     resolution: {integrity: sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==}
     engines: {node: '>=10'}
@@ -8995,6 +9181,9 @@ packages:
   lodash.once@4.1.1:
     resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
 
+  lodash.sortby@4.7.0:
+    resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
+
   lodash.truncate@4.4.2:
     resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
 
@@ -9039,6 +9228,10 @@ packages:
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  lru-cache@11.3.6:
+    resolution: {integrity: sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==}
+    engines: {node: 20 || >=22}
 
   lru-cache@4.1.5:
     resolution: {integrity: sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==}
@@ -12576,6 +12769,10 @@ packages:
     resolution: {integrity: sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==}
     engines: {node: '>=0.8.0'}
 
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
   whatwg-url@14.2.0:
     resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
     engines: {node: '>=18'}
@@ -12947,6 +13144,112 @@ snapshots:
       ajv-draft-04: 1.0.0(ajv@8.17.1)
       call-me-maybe: 1.0.2
       openapi-types: 12.1.3
+
+  '@apollo/cache-control-types@1.0.3(graphql@16.14.0)':
+    dependencies:
+      graphql: 16.14.0
+
+  '@apollo/protobufjs@1.2.8':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.0
+      '@types/long': 4.0.2
+      long: 4.0.0
+
+  '@apollo/server-gateway-interface@2.0.0(graphql@16.14.0)':
+    dependencies:
+      '@apollo/usage-reporting-protobuf': 4.1.2
+      '@apollo/utils.fetcher': 3.1.0
+      '@apollo/utils.keyvaluecache': 4.0.0
+      '@apollo/utils.logger': 3.0.0
+      graphql: 16.14.0
+
+  '@apollo/server@5.5.1(graphql@16.14.0)':
+    dependencies:
+      '@apollo/cache-control-types': 1.0.3(graphql@16.14.0)
+      '@apollo/server-gateway-interface': 2.0.0(graphql@16.14.0)
+      '@apollo/usage-reporting-protobuf': 4.1.2
+      '@apollo/utils.createhash': 3.0.1
+      '@apollo/utils.fetcher': 3.1.0
+      '@apollo/utils.isnodelike': 3.0.0
+      '@apollo/utils.keyvaluecache': 4.0.0
+      '@apollo/utils.logger': 3.0.0
+      '@apollo/utils.usagereporting': 2.1.0(graphql@16.14.0)
+      '@apollo/utils.withrequired': 3.0.0
+      '@graphql-tools/schema': 10.0.33(graphql@16.14.0)
+      async-retry: 1.3.3
+      body-parser: 2.2.2
+      content-type: 1.0.5
+      cors: 2.8.5
+      finalhandler: 2.1.1
+      graphql: 16.14.0
+      loglevel: 1.9.2
+      lru-cache: 11.3.6
+      negotiator: 1.0.0
+      whatwg-mimetype: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@apollo/usage-reporting-protobuf@4.1.2':
+    dependencies:
+      '@apollo/protobufjs': 1.2.8
+
+  '@apollo/utils.createhash@3.0.1':
+    dependencies:
+      '@apollo/utils.isnodelike': 3.0.0
+      sha.js: 2.4.12
+
+  '@apollo/utils.dropunuseddefinitions@2.0.1(graphql@16.14.0)':
+    dependencies:
+      graphql: 16.14.0
+
+  '@apollo/utils.fetcher@3.1.0': {}
+
+  '@apollo/utils.isnodelike@3.0.0': {}
+
+  '@apollo/utils.keyvaluecache@4.0.0':
+    dependencies:
+      '@apollo/utils.logger': 3.0.0
+      lru-cache: 11.3.6
+
+  '@apollo/utils.logger@3.0.0': {}
+
+  '@apollo/utils.printwithreducedwhitespace@2.0.1(graphql@16.14.0)':
+    dependencies:
+      graphql: 16.14.0
+
+  '@apollo/utils.removealiases@2.0.1(graphql@16.14.0)':
+    dependencies:
+      graphql: 16.14.0
+
+  '@apollo/utils.sortast@2.0.1(graphql@16.14.0)':
+    dependencies:
+      graphql: 16.14.0
+      lodash.sortby: 4.7.0
+
+  '@apollo/utils.stripsensitiveliterals@2.0.1(graphql@16.14.0)':
+    dependencies:
+      graphql: 16.14.0
+
+  '@apollo/utils.usagereporting@2.1.0(graphql@16.14.0)':
+    dependencies:
+      '@apollo/usage-reporting-protobuf': 4.1.2
+      '@apollo/utils.dropunuseddefinitions': 2.0.1(graphql@16.14.0)
+      '@apollo/utils.printwithreducedwhitespace': 2.0.1(graphql@16.14.0)
+      '@apollo/utils.removealiases': 2.0.1(graphql@16.14.0)
+      '@apollo/utils.sortast': 2.0.1(graphql@16.14.0)
+      '@apollo/utils.stripsensitiveliterals': 2.0.1(graphql@16.14.0)
+      graphql: 16.14.0
+
+  '@apollo/utils.withrequired@3.0.0': {}
 
   '@assemblyscript/loader@0.19.23': {}
 
@@ -13490,6 +13793,31 @@ snapshots:
       levn: 0.4.1
 
   '@gar/promisify@1.1.3': {}
+
+  '@graphql-tools/merge@9.1.9(graphql@16.14.0)':
+    dependencies:
+      '@graphql-tools/utils': 11.1.0(graphql@16.14.0)
+      graphql: 16.14.0
+      tslib: 2.8.1
+
+  '@graphql-tools/schema@10.0.33(graphql@16.14.0)':
+    dependencies:
+      '@graphql-tools/merge': 9.1.9(graphql@16.14.0)
+      '@graphql-tools/utils': 11.1.0(graphql@16.14.0)
+      graphql: 16.14.0
+      tslib: 2.8.1
+
+  '@graphql-tools/utils@11.1.0(graphql@16.14.0)':
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.14.0)
+      '@whatwg-node/promise-helpers': 1.3.2
+      cross-inspect: 1.0.1
+      graphql: 16.14.0
+      tslib: 2.8.1
+
+  '@graphql-typed-document-node/core@3.2.0(graphql@16.14.0)':
+    dependencies:
+      graphql: 16.14.0
 
   '@grpc/grpc-js@1.14.1':
     dependencies:
@@ -15765,6 +16093,10 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
 
+  '@whatwg-node/promise-helpers@1.3.2':
+    dependencies:
+      tslib: 2.8.1
+
   '@xtuc/ieee754@1.2.0': {}
 
   '@xtuc/long@4.2.2': {}
@@ -16074,6 +16406,10 @@ snapshots:
   astral-regex@2.0.0: {}
 
   async-function@1.0.0: {}
+
+  async-retry@1.3.3:
+    dependencies:
+      retry: 0.13.1
 
   async@3.2.6: {}
 
@@ -17197,6 +17533,10 @@ snapshots:
   cross-env@7.0.3:
     dependencies:
       cross-spawn: 7.0.6
+
+  cross-inspect@1.0.1:
+    dependencies:
+      tslib: 2.8.1
 
   cross-spawn@6.0.6:
     dependencies:
@@ -19305,6 +19645,14 @@ snapshots:
 
   graphemer@1.4.0: {}
 
+  graphql-ws@6.0.8(graphql@16.14.0)(ws@8.20.0):
+    dependencies:
+      graphql: 16.14.0
+    optionalDependencies:
+      ws: 8.20.0
+
+  graphql@16.14.0: {}
+
   gzip-size@6.0.0:
     dependencies:
       duplexer: 0.1.2
@@ -20982,6 +21330,8 @@ snapshots:
 
   lodash.once@4.1.1: {}
 
+  lodash.sortby@4.7.0: {}
+
   lodash.truncate@4.4.2: {}
 
   lodash@4.17.21: {}
@@ -21014,6 +21364,8 @@ snapshots:
   lowercase-keys@3.0.0: {}
 
   lru-cache@10.4.3: {}
+
+  lru-cache@11.3.6: {}
 
   lru-cache@4.1.5:
     dependencies:
@@ -21591,7 +21943,7 @@ snapshots:
       socks: 2.8.7
       split2: 4.2.0
       worker-timers: 8.0.27
-      ws: 8.18.3
+      ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -25300,6 +25652,8 @@ snapshots:
       websocket-extensions: 0.1.4
 
   websocket-extensions@0.1.4: {}
+
+  whatwg-mimetype@4.0.0: {}
 
   whatwg-url@14.2.0:
     dependencies:

--- a/site/docs/extensions/apollo.md
+++ b/site/docs/extensions/apollo.md
@@ -1,0 +1,285 @@
+# Apollo GraphQL
+
+GraphQL 适合需要让前端按需查询字段、聚合多个后端数据源，或者希望用统一查询语言暴露 API 的应用。Midway 通过 `@midwayjs/apollo` 提供基于 Apollo Server 的 GraphQL HTTP 端点，并让 Resolver 直接使用 Midway 的依赖注入和请求上下文。
+
+相关信息：
+
+| 描述              |      |
+| ----------------- | ---- |
+| 可用于标准项目    | ✅    |
+| 可用于 Serverless | ❌    |
+| 可用于一体化      | ✅    |
+| 包含独立主框架    | ❌    |
+| 包含独立日志      | ❌    |
+
+## 安装依赖
+
+Apollo 组件已经内置 Apollo Server 和 GraphQL 运行时依赖。
+
+```bash
+$ npm i @midwayjs/apollo@4 --save
+```
+
+如果使用 Koa 或 Express，还需要安装对应 Web 框架组件：
+
+```bash
+$ npm i @midwayjs/koa@4 --save
+# 或者
+$ npm i @midwayjs/express@4 --save
+```
+
+或者在 `package.json` 中增加如下依赖后，重新安装。
+
+```json
+{
+  "dependencies": {
+    "@midwayjs/apollo": "^4.0.0",
+    "@midwayjs/koa": "^4.0.0"
+  }
+}
+```
+
+## 开启组件
+
+在 `src/configuration.ts` 中导入 Apollo 组件和一个 Web 框架组件。
+
+```typescript
+import { Configuration } from '@midwayjs/core';
+import * as koa from '@midwayjs/koa';
+import * as apollo from '@midwayjs/apollo';
+
+@Configuration({
+  imports: [
+    koa,
+    apollo,
+  ],
+})
+export class MainConfiguration {}
+```
+
+## 最小示例
+
+在 `src/config/config.default.ts` 中配置 Apollo。
+
+```typescript
+export const apollo = {
+  path: '/graphql',
+  typeDefs: `
+    type Query {
+      hello: String!
+    }
+  `,
+  resolvers: {
+    Query: {
+      hello: () => 'hello midway',
+    },
+  },
+};
+```
+
+启动后，请求 `/graphql`：
+
+```graphql
+query {
+  hello
+}
+```
+
+返回：
+
+```json
+{
+  "data": {
+    "hello": "hello midway"
+  }
+}
+```
+
+## 使用 Midway 上下文
+
+Resolver 的第三个参数就是当前 Midway 请求上下文，不需要再从 `context.ctx` 解包。你可以直接通过 `context.requestContext` 获取请求级依赖。
+
+```typescript
+import { UserService } from '../service/user';
+
+export const apollo = {
+  typeDefs: `
+    type Query {
+      userName(id: ID!): String
+    }
+  `,
+  resolvers: {
+    Query: {
+      userName: async (_parent, args, context) => {
+        const userService = await context.requestContext.getAsync(UserService);
+        const user = await userService.findById(args.id);
+        return user?.name;
+      },
+    },
+  },
+};
+```
+
+Koa 场景下，`context` 是 Midway 增强后的 Koa ctx；Express 场景下，`context` 是 Midway 增强后的 Express request/context。Midway 会在上面挂载 `requestContext`、`logger`、`getLogger()`、`setAttr()`、`getAttr()` 和 `getApp()`。
+
+## Resolver 类
+
+`@midwayjs/apollo` 重新导出了 GraphQL Resolver 装饰器，可以直接从 Apollo 组件中引入。
+
+```typescript
+import { Inject } from '@midwayjs/core';
+import { Args, Context, Query, Resolver } from '@midwayjs/apollo';
+import { UserService } from '../service/user';
+
+@Resolver()
+export class UserResolver {
+  @Inject()
+  userService: UserService;
+
+  @Query('userName')
+  async userName(@Args('id') id: string, @Context() context) {
+    const user = await this.userService.findById(id);
+    context.logger.info('query user %s', id);
+    return user?.name;
+  }
+}
+```
+
+可用的参数装饰器包括：
+
+| 装饰器       | 说明                    |
+| ------------ | ----------------------- |
+| `@Parent()`  | 获取父级 resolver 返回值 |
+| `@Args()`    | 获取 GraphQL 参数       |
+| `@Context()` | 获取 Midway 请求上下文  |
+| `@Info()`    | 获取 GraphQL resolve info |
+
+不传参数时会注入完整对象，传入字段名时只注入对应字段，例如 `@Args('id')`。
+
+## 订阅
+
+组件支持 `graphql-ws` 协议的 GraphQL Subscription。默认关闭，需要在配置中开启。
+
+```typescript
+export const apollo = {
+  path: '/graphql',
+  subscriptions: true,
+  typeDefs: `
+    type Query {
+      hello: String!
+    }
+
+    type Subscription {
+      counter: Int!
+    }
+  `,
+};
+```
+
+Resolver 方法需要返回 `AsyncIterable`。
+
+```typescript
+import { Resolver, Subscription } from '@midwayjs/apollo';
+
+@Resolver()
+export class CounterResolver {
+  @Subscription('counter')
+  async *counter() {
+    yield {
+      counter: 1,
+    };
+  }
+}
+```
+
+开启后，WebSocket 地址默认和 HTTP GraphQL 地址一致，例如 `ws://127.0.0.1:7001/graphql`。也可以单独指定订阅路径。
+
+```typescript
+export const apollo = {
+  path: '/graphql',
+  subscriptions: {
+    path: '/graphql',
+    connectionInitWaitTimeout: 3000,
+  },
+};
+```
+
+## 使用 Schema 文件
+
+除了直接配置 `typeDefs`，也可以通过 `typePaths` 加载 `.graphql` 文件。
+
+```typescript
+export const apollo = {
+  path: '/graphql',
+  typePaths: ['./schema.graphql', './graphql/**/*.graphql'],
+};
+```
+
+`typePaths` 中的相对路径会从应用的 `baseDir` 开始解析，既支持精确文件路径，也支持 glob 表达式。你也可以同时配置 `typeDefs` 和 `typePaths`，组件会在启动时合并。
+
+## Apollo 配置
+
+Apollo Server 专属配置放在 `apollo.apollo` 下，避免和通用 GraphQL 字段混在一起。
+
+```typescript
+export const apollo = {
+  typeDefs,
+  resolvers,
+  apollo: {
+    introspection: true,
+    plugins: [],
+  },
+};
+```
+
+## GraphiQL
+
+开发环境默认开启 GraphiQL。浏览器访问 `/graphql` 时会显示 GraphiQL 页面，生产环境默认关闭。
+
+```typescript
+export const apollo = {
+  graphiql: true,
+};
+```
+
+可以显式关闭：
+
+```typescript
+export const apollo = {
+  graphiql: false,
+};
+```
+
+## HTTP 行为
+
+默认只处理 `GET` 和 `POST` 请求。其他方法请求 GraphQL 路径会返回 `405 Method Not Allowed`。
+
+```typescript
+export const apollo = {
+  methods: ['POST'],
+};
+```
+
+## 扩展 Context
+
+可以通过 `contextFactory` 给每次 GraphQL 请求补充字段。
+
+```typescript
+export const apollo = {
+  typeDefs,
+  resolvers,
+  contextFactory: async context => {
+    return {
+      currentUserId: context.headers['x-user-id'],
+    };
+  },
+};
+```
+
+随后在 Resolver 中读取：
+
+```typescript
+const userId = context.currentUserId;
+```
+
+内置字段如 `requestContext`、`logger`、`getApp` 会被保留，不建议覆盖。

--- a/site/i18n/en/docusaurus-plugin-content-docs/current/extensions/apollo.md
+++ b/site/i18n/en/docusaurus-plugin-content-docs/current/extensions/apollo.md
@@ -1,0 +1,285 @@
+# Apollo GraphQL
+
+GraphQL is useful when clients need to query only the fields they need, aggregate multiple backend data sources, or expose APIs through a unified query language. Midway provides Apollo Server based GraphQL HTTP endpoints through `@midwayjs/apollo`, while keeping resolvers integrated with Midway dependency injection and request context.
+
+Related information:
+
+| Description            |      |
+| ---------------------- | ---- |
+| Available for standard projects | ✅    |
+| Available for Serverless        | ❌    |
+| Available for integrated apps   | ✅    |
+| Contains independent main framework | ❌    |
+| Contains independent logs       | ❌    |
+
+## Install dependencies
+
+The Apollo component includes the Apollo Server and GraphQL runtime dependencies.
+
+```bash
+$ npm i @midwayjs/apollo@4 --save
+```
+
+If you use Koa or Express, install the matching web framework component:
+
+```bash
+$ npm i @midwayjs/koa@4 --save
+# or
+$ npm i @midwayjs/express@4 --save
+```
+
+Or add the dependencies to `package.json` and reinstall.
+
+```json
+{
+  "dependencies": {
+    "@midwayjs/apollo": "^4.0.0",
+    "@midwayjs/koa": "^4.0.0"
+  }
+}
+```
+
+## Enable component
+
+Import Apollo and one web framework component in `src/configuration.ts`.
+
+```typescript
+import { Configuration } from '@midwayjs/core';
+import * as koa from '@midwayjs/koa';
+import * as apollo from '@midwayjs/apollo';
+
+@Configuration({
+  imports: [
+    koa,
+    apollo,
+  ],
+})
+export class MainConfiguration {}
+```
+
+## Minimal Example
+
+Configure Apollo in `src/config/config.default.ts`.
+
+```typescript
+export const apollo = {
+  path: '/graphql',
+  typeDefs: `
+    type Query {
+      hello: String!
+    }
+  `,
+  resolvers: {
+    Query: {
+      hello: () => 'hello midway',
+    },
+  },
+};
+```
+
+Send a query to `/graphql`:
+
+```graphql
+query {
+  hello
+}
+```
+
+Response:
+
+```json
+{
+  "data": {
+    "hello": "hello midway"
+  }
+}
+```
+
+## Use Midway Context
+
+The third resolver argument is the active Midway request context itself. You do not need to unwrap `context.ctx`. Use `context.requestContext` directly for request-scoped dependencies.
+
+```typescript
+import { UserService } from '../service/user';
+
+export const apollo = {
+  typeDefs: `
+    type Query {
+      userName(id: ID!): String
+    }
+  `,
+  resolvers: {
+    Query: {
+      userName: async (_parent, args, context) => {
+        const userService = await context.requestContext.getAsync(UserService);
+        const user = await userService.findById(args.id);
+        return user?.name;
+      },
+    },
+  },
+};
+```
+
+In Koa, `context` is the Midway-augmented Koa ctx. In Express, it is the Midway-augmented Express request/context. Midway attaches `requestContext`, `logger`, `getLogger()`, `setAttr()`, `getAttr()`, and `getApp()`.
+
+## Resolver Classes
+
+`@midwayjs/apollo` re-exports GraphQL resolver decorators, so you can import them directly from the Apollo component.
+
+```typescript
+import { Inject } from '@midwayjs/core';
+import { Args, Context, Query, Resolver } from '@midwayjs/apollo';
+import { UserService } from '../service/user';
+
+@Resolver()
+export class UserResolver {
+  @Inject()
+  userService: UserService;
+
+  @Query('userName')
+  async userName(@Args('id') id: string, @Context() context) {
+    const user = await this.userService.findById(id);
+    context.logger.info('query user %s', id);
+    return user?.name;
+  }
+}
+```
+
+Available parameter decorators:
+
+| Decorator    | Description                         |
+| ------------ | ----------------------------------- |
+| `@Parent()`  | Injects the parent resolver value   |
+| `@Args()`    | Injects GraphQL arguments           |
+| `@Context()` | Injects the Midway request context  |
+| `@Info()`    | Injects GraphQL resolve info        |
+
+Without a field name, the full object is injected. With a field name, only that field is injected, for example `@Args('id')`.
+
+## Subscriptions
+
+The component supports GraphQL Subscription through the `graphql-ws` protocol. It is disabled by default and can be enabled in config.
+
+```typescript
+export const apollo = {
+  path: '/graphql',
+  subscriptions: true,
+  typeDefs: `
+    type Query {
+      hello: String!
+    }
+
+    type Subscription {
+      counter: Int!
+    }
+  `,
+};
+```
+
+Resolver methods must return an `AsyncIterable`.
+
+```typescript
+import { Resolver, Subscription } from '@midwayjs/apollo';
+
+@Resolver()
+export class CounterResolver {
+  @Subscription('counter')
+  async *counter() {
+    yield {
+      counter: 1,
+    };
+  }
+}
+```
+
+When enabled, the WebSocket endpoint defaults to the same path as the HTTP GraphQL endpoint, for example `ws://127.0.0.1:7001/graphql`. You can also configure a dedicated subscription path.
+
+```typescript
+export const apollo = {
+  path: '/graphql',
+  subscriptions: {
+    path: '/graphql',
+    connectionInitWaitTimeout: 3000,
+  },
+};
+```
+
+## Use Schema Files
+
+You can configure `typePaths` to load `.graphql` files instead of writing all schema definitions inline in `typeDefs`.
+
+```typescript
+export const apollo = {
+  path: '/graphql',
+  typePaths: ['./schema.graphql', './graphql/**/*.graphql'],
+};
+```
+
+Relative paths in `typePaths` are resolved from the application `baseDir`. Both exact file paths and glob patterns are supported. You can also use `typeDefs` and `typePaths` together; the component merges them during startup.
+
+## Apollo Options
+
+Apollo Server specific options live under `apollo.apollo` so they do not mix with shared GraphQL fields.
+
+```typescript
+export const apollo = {
+  typeDefs,
+  resolvers,
+  apollo: {
+    introspection: true,
+    plugins: [],
+  },
+};
+```
+
+## GraphiQL
+
+GraphiQL is enabled by default in development. Visiting `/graphql` in a browser opens the GraphiQL page. It is disabled by default in production.
+
+```typescript
+export const apollo = {
+  graphiql: true,
+};
+```
+
+You can disable it explicitly:
+
+```typescript
+export const apollo = {
+  graphiql: false,
+};
+```
+
+## HTTP Behavior
+
+By default, only `GET` and `POST` requests are handled. Other methods sent to the GraphQL path return `405 Method Not Allowed`.
+
+```typescript
+export const apollo = {
+  methods: ['POST'],
+};
+```
+
+## Extend Context
+
+Use `contextFactory` to add fields for each GraphQL request.
+
+```typescript
+export const apollo = {
+  typeDefs,
+  resolvers,
+  contextFactory: async context => {
+    return {
+      currentUserId: context.headers['x-user-id'],
+    };
+  },
+};
+```
+
+Then read it in resolvers:
+
+```typescript
+const userId = context.currentUserId;
+```
+
+Built-in fields such as `requestContext`, `logger`, and `getApp` are reserved and should not be overwritten.


### PR DESCRIPTION
## Summary

Adds first-party GraphQL support for Midway v4 through a user-facing `@midwayjs/apollo` component and a runtime-neutral `@midwayjs/graphql` base SDK.

## Changes

- Adds `@midwayjs/graphql` shared resolver decorators, parameter decorators, context/config types, and DI-backed resolver map assembly.
- Adds `@midwayjs/apollo` with schema-first Apollo Server integration for Koa and Express.
- Supports inline `typeDefs`, `typePaths`, plain resolver maps, Midway resolver classes, GraphiQL, HTTP method handling, and `graphql-ws` subscriptions.
- Uses the active Midway request context as GraphQL context so resolvers can call `context.requestContext.getAsync(...)` directly.
- Adds OpenSpec proposal/spec/tasks and Chinese/English Apollo documentation.

## Validation

- `pnpm -C packages/graphql lint:fix`
- `pnpm -C packages/graphql build`
- `pnpm -C packages/graphql test`
- `pnpm -C packages/apollo lint:fix`
- `pnpm -C packages/apollo build`
- `pnpm -C packages/apollo test`
- `openspec validate add-graphql-component --strict --no-interactive`