### PR TITLE
feat(crud): Add routing mode option and Support custom prop name for service

### DIFF
--- a/packages/core/src/util/index.ts
+++ b/packages/core/src/util/index.ts
@@ -734,5 +734,6 @@ export const Utils = {
   toAsyncFunction,
   safeStringify,
   safeParse,
+  joinURLPath,
   isTypeScriptEnvironment,
 };

--- a/packages/crud/src/functional/index.ts
+++ b/packages/crud/src/functional/index.ts
@@ -1,5 +1,4 @@
 import {
-  CrudOptions,
   FunctionalCrudOptions,
   FunctionalCrudRouteFactory,
 } from '../interface';
@@ -9,7 +8,7 @@ import { buildFunctionalCrudRoutes } from './routeBuilder';
  * Functional CRUD route entrypoint for defineApi() composition.
  */
 export function defineCrudRoutes<T = any>(
-  options: CrudOptions | FunctionalCrudOptions
+  options: FunctionalCrudOptions
 ): FunctionalCrudRouteFactory<T> {
   return buildFunctionalCrudRoutes<T>(options);
 }

--- a/packages/crud/src/interface.ts
+++ b/packages/crud/src/interface.ts
@@ -61,13 +61,13 @@ export interface CrudContext {
   [key: string]: any;
 }
 
-export interface CrudRouteOverride {
+export interface CrudRouteOverride extends Omit<CrudRouteDefinition, 'name'> {
   enabled?: boolean;
 }
 
 export interface CrudOptions {
   model: new (...args: any[]) => any;
-  service?: new (...args: any[]) => CrudServiceAdapter<any>;
+  service?: string | (new (...args: any[]) => CrudServiceAdapter<any>);
   id?: string;
   dto?: {
     create?: new (...args: any[]) => any;
@@ -76,10 +76,48 @@ export interface CrudOptions {
     query?: new (...args: any[]) => any;
   };
   routes?: {
+    /**
+     * API Route Mode (default: RESTful)
+     * - RESTful: Resource-based route. with HTTP methods defines the operation
+     *            (e.g., `POST /users`, `DELETE /users/:id`)
+     * - RPC:     Action-based route. with the URL defines the operation
+     *            (e.g., `POST /users/create`, `POST /users/delete/:id`)
+     * - CUSTOM:  Custom route. defined by `{ name, method, path }`
+     */
+    mode?: 'RESTful' | 'RPC' | 'CUSTOM';
+    /**
+     * Allowed routes. When set, `include` and `exclude` are ignored.
+     */
     only?: CrudRouteName[];
+    /**
+     * Defaults to [list, detail, create, update, delete].
+     * When specified, merged with the default set.
+     */
+    include?: CrudRouteName[];
+    /**
+     * Defaults to empty. Exclusions override inclusions.
+     */
     exclude?: CrudRouteName[];
-    overrides?: Partial<Record<CrudRouteName, CrudRouteOverride>>;
-  };
+    /**
+     * Route overrides.
+     * - When mode is RESTful/RPC: merges with (overrides) existing routes.
+     * - When mode is CUSTOM: fully replaces all routes.
+     * - The `enabled` flag takes precedence over `include` and `exclude`.
+     */
+    overrides?: {
+      [P in CrudRouteName]?: Partial<CrudRouteOverride>;
+    };
+  } & (
+    | {
+        mode?: 'RESTful' | 'RPC';
+      }
+    | {
+        mode: 'CUSTOM';
+        overrides: {
+          [P in CrudRouteName]?: CrudRouteOverride;
+        };
+      }
+  );
   query?: {
     maxLimit?: number;
     defaultLimit?: number;
@@ -153,4 +191,6 @@ export type FunctionalCrudRouteFactory<T = any> = (
   __entityType__?: T;
 };
 
-export type FunctionalCrudOptions = CrudOptions;
+export type FunctionalCrudOptions = Omit<CrudOptions, 'service'> & {
+  service: new (...args: any[]) => CrudServiceAdapter<any>;
+};

--- a/packages/crud/src/routeBuilder.ts
+++ b/packages/crud/src/routeBuilder.ts
@@ -4,7 +4,7 @@ import { CrudOptions, CrudRouteDefinition, CrudRouteName } from './interface';
 import { parseCrudId, parseCrudQuery } from './queryParser';
 import { applyCrudValidation } from './validation';
 
-const DEFAULT_ROUTE_DEFINITIONS: Record<CrudRouteName, CrudRouteDefinition> = {
+const REST_ROUTE_DEFINITIONS: Record<CrudRouteName, CrudRouteDefinition> = {
   list: { name: 'list', method: 'GET', path: '/' },
   detail: { name: 'detail', method: 'GET', path: '/:id' },
   create: { name: 'create', method: 'POST', path: '/' },
@@ -15,25 +15,97 @@ const DEFAULT_ROUTE_DEFINITIONS: Record<CrudRouteName, CrudRouteDefinition> = {
   deleteMany: { name: 'deleteMany', method: 'DELETE', path: '/bulk' },
 };
 
+const RPC_ROUTE_DEFINITIONS: Record<CrudRouteName, CrudRouteDefinition> = {
+  list: { name: 'list', method: 'GET', path: '/list' },
+  detail: { name: 'detail', method: 'GET', path: '/detail/:id' },
+  create: { name: 'create', method: 'POST', path: '/create' },
+  update: { name: 'update', method: 'POST', path: '/update/:id' },
+  replace: { name: 'replace', method: 'POST', path: '/replace/:id' },
+  delete: { name: 'delete', method: 'POST', path: '/delete/:id' },
+  createMany: { name: 'createMany', method: 'POST', path: '/bulk/create' },
+  deleteMany: { name: 'deleteMany', method: 'POST', path: '/bulk/delete' },
+};
+
 /**
- * Returns enabled CRUD routes after applying only/exclude rules.
+ * Default enabled routes
  */
-export function getEnabledCrudRoutes(options: CrudOptions): CrudRouteName[] {
-  const only = options.routes?.only;
-  const exclude = options.routes?.exclude ?? [];
-  const source = only?.length
-    ? only
-    : (['list', 'detail', 'create', 'update', 'delete'] as CrudRouteName[]);
-  return source.filter(route => !exclude.includes(route));
+export const defaultRoutes: CrudRouteName[] = [
+  'list',
+  'detail',
+  'create',
+  'update',
+  'delete',
+];
+
+/**
+ * Returns enabled CRUD routes after applying only/include/exclude rules.
+ */
+export function getEnabledCrudRoutes({ routes }: CrudOptions): CrudRouteName[] {
+  const include = routes?.include ?? [];
+  const exclude = routes?.exclude ?? [];
+  const source = new Set(
+    routes?.mode === 'CUSTOM'
+      ? []
+      : (routes?.only ??
+          [...defaultRoutes, ...include].filter(m => !exclude.includes(m)))
+  );
+
+  if (routes?.overrides) {
+    for (const key in routes.overrides) {
+      if (routes.overrides[key].enabled === false) {
+        source.delete(key as CrudRouteName);
+      } else {
+        source.add(key as CrudRouteName);
+      }
+    }
+  }
+
+  return [...source];
 }
 
 /**
  * Builds the default route table for a CRUD resource.
  */
 export function buildCrudRoutes(options: CrudOptions): CrudRouteDefinition[] {
-  return getEnabledCrudRoutes(options).map(
-    name => DEFAULT_ROUTE_DEFINITIONS[name]
+  const mode = options.routes?.mode || 'RESTful';
+  const overrides = options.routes?.overrides || {};
+  return getEnabledCrudRoutes(options).map(name =>
+    mode === 'CUSTOM'
+      ? ({ name, ...overrides[name] } as CrudRouteDefinition)
+      : mode === 'RPC'
+        ? { ...RPC_ROUTE_DEFINITIONS[name], ...overrides[name] }
+        : { ...REST_ROUTE_DEFINITIONS[name], ...overrides[name] }
   );
+}
+
+/**
+ * Return the bound CRUD service
+ */
+export async function getService(
+  controller: any,
+  ctx: any,
+  options: CrudOptions
+) {
+  const name =
+    typeof options.service === 'string' ? options.service : CRUD_SERVICE_KEY;
+  let service = controller[name];
+
+  if (!service && typeof options.service === 'function') {
+    const requestContext =
+      ctx?.requestContext ?? (ctx?.request ?? ctx?.req)?.requestContext;
+    if (requestContext) {
+      service = controller[name] = await requestContext.getAsync?.(
+        options.service,
+        [options]
+      );
+    }
+  }
+
+  if (!service) {
+    throw new CrudConfigError(`Controller is missing "${name}" binding`);
+  }
+
+  return service;
 }
 
 /**
@@ -45,13 +117,7 @@ export function createCrudRouteHandler(
   options: CrudOptions
 ): (payload?: any) => Promise<any> {
   return async function crudRouteHandler(payload: any = {}) {
-    const service = (controllerInstance as any)?.[CRUD_SERVICE_KEY];
-    if (!service) {
-      throw new CrudConfigError(
-        `Controller is missing "${CRUD_SERVICE_KEY}" binding`
-      );
-    }
-
+    const service = await getService(controllerInstance, payload.ctx, options);
     const ctxPayload = {
       ctx: payload.ctx,
     };

--- a/packages/crud/test/route-builder.test.ts
+++ b/packages/crud/test/route-builder.test.ts
@@ -5,7 +5,12 @@ import {
   CrudNotFoundError,
   getEnabledCrudRoutes,
 } from '../src';
-import { createCrudControllerMethod } from '../src/routeBuilder';
+import { CRUD_SERVICE_KEY } from '../src/constants';
+import {
+  createCrudControllerMethod,
+  getService,
+  defaultRoutes
+} from '../src/routeBuilder';
 
 class TestModel {}
 class TestService {}
@@ -17,7 +22,7 @@ const baseOptions = {
 };
 
 describe('route builder helpers', () => {
-  it('should respect routes.only and routes.exclude', () => {
+  it('should respect routes.only, routes.include and routes.exclude', () => {
     expect(
       getEnabledCrudRoutes({
         ...baseOptions,
@@ -26,6 +31,15 @@ describe('route builder helpers', () => {
         },
       })
     ).toEqual(['list', 'detail', 'replace']);
+
+    expect(
+      getEnabledCrudRoutes({
+        ...baseOptions,
+        routes: {
+          include: ['replace'],
+        },
+      })
+    ).toEqual([ ...defaultRoutes, 'replace']);
 
     expect(
       getEnabledCrudRoutes({
@@ -54,9 +68,108 @@ describe('route builder helpers', () => {
     ]);
   });
 
+  it('should merge pre-defined routes when use routes.overrides', () => {
+    const routes = buildCrudRoutes({
+      ...baseOptions,
+      routes: {
+        mode: 'RESTful',
+        overrides: {
+          list: {
+            path: '/list',
+            method: 'POST'
+          },
+          delete: {
+            enabled: false
+          }
+        }
+      },
+    });
+
+    expect(routes?.length).toBe(defaultRoutes.length - 1);
+
+    const route = routes?.find(m => m.name === 'list');
+    expect(route).toEqual({
+      name: 'list',
+      method: 'POST',
+      path: '/list',
+    });
+  });
+
+  it('should respect routes.mode and build routes', () => {
+    let routes = buildCrudRoutes({
+      ...baseOptions,
+      routes: {
+        mode: 'RPC'
+      },
+    });
+
+    expect(routes?.length).toBe(defaultRoutes.length);
+
+    const route = routes?.find(m => m.name === 'list');
+    expect(route).toEqual({
+      name: 'list',
+      method: 'GET',
+      path: '/list',
+    });
+
+    routes = buildCrudRoutes({
+      ...baseOptions,
+      routes: {
+        mode: 'CUSTOM',
+        overrides: {
+          create: {
+            path: '/create',
+            method: 'POST'
+          },
+          delete: {
+            path: '/delete/:id',
+            method: 'DELETE'
+          }
+        }
+      },
+    });
+
+    expect(routes).toEqual([
+      {
+        name: 'create',
+        method: 'POST',
+        path: '/create',
+      },
+      {
+        name: 'delete',
+        method: 'DELETE',
+        path: '/delete/:id',
+      }
+    ]);
+  });
+
   it('should reject missing crudService bindings', async () => {
     const handler = createCrudRouteHandler('list', {}, baseOptions);
     await expect(handler({ query: {} })).rejects.toThrow(CrudConfigError);
+  });
+
+  it('should retrieve the CRUD service instance by prop name or type', async () => {
+    const ctx = {
+      requestContext: {
+        getAsync: async (type) => {
+          if (type === TestService) return new TestService();
+          return null;
+        }
+      }
+    };
+    let controller: any = { testService: new TestService() };
+
+    let service = await getService(controller, ctx, { ...baseOptions, service: 'testService' });
+    expect(service).toBeTruthy();
+    expect(controller[CRUD_SERVICE_KEY]).not.toBeTruthy();
+
+    controller = { };
+    service = await getService(controller, ctx, { ...baseOptions, service: TestService as any });
+    expect(service).toBeTruthy();
+    expect(controller[CRUD_SERVICE_KEY]).toBeTruthy();
+
+    const res = getService({}, ctx, { ...baseOptions, service: 'testService' });
+    await expect(res).rejects.toThrow(CrudConfigError);
   });
 
   it('should route replace to replace() and fallback to update()', async () => {

--- a/packages/swagger/src/swaggerExplorer.ts
+++ b/packages/swagger/src/swaggerExplorer.ts
@@ -17,6 +17,7 @@ import {
   CUSTOM_PARAM_INJECT_KEY,
   CUSTOM_PROPERTY_INJECT_KEY,
   safeRequire,
+  Utils,
 } from '@midwayjs/core';
 import {
   MixDecoratorMetadata,
@@ -263,7 +264,7 @@ export class SwaggerExplorer {
     if (webRouterInfo && typeof webRouterInfo[Symbol.iterator] === 'function') {
       for (const webRouter of webRouterInfo) {
         // 生成URL
-        let url = (prefix + webRouter.path).replace('//', '/');
+        let url = Utils.joinURLPath(prefix, webRouter.path);
         url = replaceUrl(url, parseParamsInPath(url));
 
         // 方法元数据

--- a/site/docs/extensions/crud.md
+++ b/site/docs/extensions/crud.md
@@ -319,10 +319,7 @@ import { UserCrudService } from '../service/user.crud';
   model: UserEntity,
   service: UserCrudService,
 })
-export class UserController {
-  @Inject()
-  crudService: UserCrudService;
-}
+export class UserController { }
 ```
 
 默认会生成：
@@ -333,14 +330,40 @@ export class UserController {
 - `PATCH /users/:id`
 - `DELETE /users/:id`
 
-### 为什么还要 `@Inject() crudService`
+以及设置控制器实例属性`crudService`
 
-因为 `@Crud()` 只是声明“这个 Controller 是一个 CRUD 资源”，真正执行业务的是你绑定的 `crudService`。
+### 自定义服务属性名
+
+```typescript
+import { Controller, Inject } from '@midwayjs/core';
+import { Crud } from '@midwayjs/crud';
+
+import { UserEntity } from '../entity/user';
+import { UserCrudService } from '../service/user.crud';
+
+@Controller('/users')
+@Crud<UserEntity>({
+  model: UserEntity,
+  service: 'userService',
+})
+export class UserController {
+  @Inject()
+  userService: UserCrudService
+}
+```
+
+:::tip
+仅设置属性名未手动注入同名服务，调用Rest接口会因获取不到服务实例而异常
+:::
+
+### 为什么还要 `@Inject() [name]`
+
+因为 `@Crud()` 只是声明“这个 Controller 是一个 CRUD 资源”，真正执行业务的是你绑定的 `[serviceName]`。
 
 也就是说：
 
 - `@Crud()` 负责生成默认路由
-- `crudService` 负责真正执行 CRUD 逻辑
+- `[serviceName]` 负责真正执行 CRUD 逻辑
 
 这是这个组件最重要的设计原则之一。
 
@@ -380,7 +403,7 @@ export class UserController {
 
 ### 裁剪默认路由
 
-如果你不想暴露所有默认路由，可以通过 `routes.only` 或 `routes.exclude` 控制。
+如果你不想暴露所有默认路由，可以通过 `routes.only` 或 `routes.include` 或 `routes.exclude` 控制。
 
 ```typescript
 @Crud<UserEntity>({
@@ -393,6 +416,10 @@ export class UserController {
 ```
 
 这对于“只能查、不能删”或“只开放后台管理的一部分动作”的场景很有用。
+
+- `routes.only` 仅支持的路由，设置后忽略`include`和`exclude`
+- `routes.include` 设置后将与默认路由合并 (默认包括[list,detail,create,update,delete])
+- `routes.exclude` 默认排除为空，排除优先级高于`routes.include`
 
 ## 函数式路由模式
 
@@ -433,6 +460,70 @@ export default defineApi('/users', api => ({
 ```
 
 这样可以让“标准资源动作”和“业务动作”共存在同一个资源路由下。
+
+## 路由模式
+
+`routes.mode` 支持 RESTful | RPC | CUSTOM，默认为 `RESTful` 模式
+
+- `RESTful` 资源型路由，通过 HTTP Method 表达操作（如：`POST /users`、`DELETE /users/:id`）
+- `RPC`     行为型路由，通过 URL 表达操作（如：`POST /users/create`、`POST /users/delete/:id`）
+- `CUSTOM`  自定义路由，通过 `{ name, method, path }` 描述数据操作
+
+### 重写内置路由
+
+`routes.mode` 设置为 RESTful / RPC 时，也可以通过 `routes.overrides` 进行增量覆盖
+
+```typescript
+@Controller('/users')
+@Crud<UserEntity>({
+  model: UserEntity,
+  service: UserCrudService,
+  routes: {
+    mode: 'RESTful',
+    overrides: {
+      list: {
+        path: '/list',
+        method: 'GET'
+      },
+      delete: {
+        enabled: false
+      }
+    }
+  }
+})
+export class UserController {
+
+}
+```
+
+### 自定义路由
+
+`routes.mode` 设置为 `CUSTOM` 时，`routes.overrides` 是必填项，完整定义接口对应的路由和方法
+
+```typescript
+@Controller('/users')
+@Crud<UserEntity>({
+  model: UserEntity,
+  service: UserCrudService,
+  routes: {
+    mode: 'CUSTOM',
+    overrides: {
+      create: {
+        path: '/add',
+        method: 'POST'
+      },
+      delete: {
+        path: '/del/:id',
+        method: 'POST'
+      }
+    }
+  }
+})
+export class UserController {
+
+}
+```
+
 
 ## 查询协议
 

--- a/site/i18n/en/docusaurus-plugin-content-docs/current/extensions/crud.md
+++ b/site/i18n/en/docusaurus-plugin-content-docs/current/extensions/crud.md
@@ -319,10 +319,7 @@ import { UserCrudService } from '../service/user.crud';
   model: UserEntity,
   service: UserCrudService,
 })
-export class UserController {
-  @Inject()
-  crudService: UserCrudService;
-}
+export class UserController { }
 ```
 
 By default, it generates:
@@ -333,14 +330,40 @@ By default, it generates:
 - `PATCH /users/:id`
 - `DELETE /users/:id`
 
-### Why do I still need `@Inject() crudService`
+and sets a `crudService` property on the controller instance.
 
-Because `@Crud()` only declares that this controller is a CRUD resource. The actual behavior still comes from your bound `crudService`.
+### Customize the service property name
+
+```typescript
+import { Controller, Inject } from '@midwayjs/core';
+import { Crud } from '@midwayjs/crud';
+
+import { UserEntity } from '../entity/user';
+import { UserCrudService } from '../service/user.crud';
+
+@Controller('/users')
+@Crud<UserEntity>({
+  model: UserEntity,
+  service: 'userService',
+})
+export class UserController {
+  @Inject()
+  userService: UserCrudService
+}
+```
+
+:::tip
+If you only set the property name without manually injecting a service with the same name, calling the REST API will throw because no service instance can be resolved.
+:::
+
+### Why do I still need `@Inject() [name]`
+
+Because `@Crud()` only declares that this controller is a CRUD resource. The actual behavior still comes from the `[serviceName]` you bound.
 
 That means:
 
 - `@Crud()` defines the default route surface
-- `crudService` performs the actual CRUD operations
+- `[serviceName]` performs the actual CRUD operations
 
 This is one of the most important design rules in this component.
 
@@ -378,9 +401,9 @@ export class UserController {
 
 If you implement a method with the same name, your custom method overrides the generated default behavior.
 
-### Restrict default routes
+### Configure default routes
 
-If you do not want to expose the full default route set, use `routes.only` or `routes.exclude`.
+If you do not want to expose the full default route set, use `routes.only`, `routes.include`, or `routes.exclude`.
 
 ```typescript
 @Crud<UserEntity>({
@@ -393,6 +416,10 @@ If you do not want to expose the full default route set, use `routes.only` or `r
 ```
 
 This is useful for “read-only” resources or back-office modules that intentionally expose only part of the CRUD surface.
+
+- `routes.only` the only routes allowed; when set, it ignores `include` and `exclude`
+- `routes.include` when set, merges with the default routes (defaults to [list, detail, create, update, delete])
+- `routes.exclude` defaults to empty; exclusion takes precedence over `routes.include`
 
 ## Functional routing mode
 
@@ -433,6 +460,70 @@ export default defineApi('/users', api => ({
 ```
 
 This keeps standard resource actions and business-specific actions together in the same resource route group.
+
+## Route modes
+
+`routes.mode` supports RESTful | RPC | CUSTOM, and defaults to `RESTful`.
+
+- `RESTful` resource-based routes, expressing operations via the HTTP method (e.g. `POST /users`, `DELETE /users/:id`)
+- `RPC`     action-based routes, expressing operations via the URL (e.g. `POST /users/create`, `POST /users/delete/:id`)
+- `CUSTOM`  custom routes, describing data operations via `{ name, method, path }`
+
+### Override built-in routes
+
+When `routes.mode` is RESTful / RPC, you can still incrementally override routes with `routes.overrides`.
+
+```typescript
+@Controller('/users')
+@Crud<UserEntity>({
+  model: UserEntity,
+  service: UserCrudService,
+  routes: {
+    mode: 'RESTful',
+    overrides: {
+      list: {
+        path: '/list',
+        method: 'GET'
+      },
+      delete: {
+        enabled: false
+      }
+    }
+  }
+})
+export class UserController {
+
+}
+```
+
+### Custom routes
+
+When `routes.mode` is `CUSTOM`, `routes.overrides` is required, and you fully define the route path and method for each operation.
+
+```typescript
+@Controller('/users')
+@Crud<UserEntity>({
+  model: UserEntity,
+  service: UserCrudService,
+  routes: {
+    mode: 'CUSTOM',
+    overrides: {
+      create: {
+        path: '/add',
+        method: 'POST'
+      },
+      delete: {
+        path: '/del/:id',
+        method: 'POST'
+      }
+    }
+  }
+})
+export class UserController {
+
+}
+```
+
 
 ## Query protocol
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/midwayjs/midway/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->
- midway/swagger
- midway/crud

##### Description of change
<!-- Provide a description of the change below this comment. -->

- Remove the last `/` from the route path in swagger extension
- Add routing mode option for CRUD decorator
- Support custom prop name for service only within controller
- Update the CRUD extension docs
