### PR TITLE
fix: prepare packages for typescript 7

### DIFF
--- a/packages-serverless/midway-fc-starter/src/index.ts
+++ b/packages-serverless/midway-fc-starter/src/index.ts
@@ -3,7 +3,7 @@ import {
   AbstractBootstrapStarter,
   IFaaSConfigurationOptions,
 } from '@midwayjs/faas';
-import * as getRawBody from 'raw-body';
+import getRawBody from 'raw-body';
 import { IncomingMessage } from 'http';
 import { mockContext } from './mock';
 import { InitializeContext } from './interface';

--- a/packages-serverless/serverless-http-parser/src/application.ts
+++ b/packages-serverless/serverless-http-parser/src/application.ts
@@ -1,7 +1,7 @@
 import { context } from './context';
 import { request } from './request';
 import { response } from './response';
-import * as only from 'only';
+import only from 'only';
 import { EventEmitter } from 'events';
 import { format } from 'util';
 

--- a/packages-serverless/serverless-http-parser/src/context.ts
+++ b/packages-serverless/serverless-http-parser/src/context.ts
@@ -1,5 +1,5 @@
 import * as util from 'util';
-import * as createError from 'http-errors';
+import createError from 'http-errors';
 import { Cookies } from '@midwayjs/cookies';
 
 const COOKIES = Symbol('context#cookies');

--- a/packages-serverless/serverless-http-parser/src/http/req.ts
+++ b/packages-serverless/serverless-http-parser/src/http/req.ts
@@ -1,6 +1,6 @@
 import { is as typeis } from 'type-is';
 import * as qs from 'querystring';
-import * as parseurl from 'parseurl';
+import parseurl from 'parseurl';
 import { isPlainObject } from '../util';
 
 const EVENT = Symbol.for('ctx#event');

--- a/packages-serverless/serverless-http-parser/src/request.ts
+++ b/packages-serverless/serverless-http-parser/src/request.ts
@@ -1,7 +1,7 @@
 import { is as typeis } from 'type-is';
-import * as accepts from 'accepts';
+import accepts from 'accepts';
 import * as qs from 'querystring';
-import * as only from 'only';
+import only from 'only';
 import { isPlainObject } from './util';
 
 const BODY = Symbol.for('ctx#body');

--- a/packages-serverless/serverless-http-parser/src/response.ts
+++ b/packages-serverless/serverless-http-parser/src/response.ts
@@ -1,4 +1,4 @@
-import * as getType from 'cache-content-type';
+import getType from 'cache-content-type';
 import * as assert from 'assert';
 import * as statuses from 'statuses';
 import { is as typeis } from 'type-is';

--- a/packages-serverless/serverless-http-parser/src/response.ts
+++ b/packages-serverless/serverless-http-parser/src/response.ts
@@ -2,10 +2,10 @@ import getType from 'cache-content-type';
 import * as assert from 'assert';
 import * as statuses from 'statuses';
 import { is as typeis } from 'type-is';
-import * as encodeUrl from 'encodeurl';
-import * as escape from 'escape-html';
-import * as only from 'only';
-import * as vary from 'vary';
+import encodeUrl from 'encodeurl';
+import escape from 'escape-html';
+import only from 'only';
+import vary from 'vary';
 
 export const response = {
   _explicitStatus: false,

--- a/packages-serverless/serverless-http-parser/test/index.test.ts
+++ b/packages-serverless/serverless-http-parser/test/index.test.ts
@@ -1,6 +1,6 @@
-import * as assert from 'assert';
+import assert from 'assert';
 import { Application, HTTPRequest, HTTPResponse } from '../src';
-import * as mm from 'mm';
+import mm from 'mm';
 import { createReadStream, createWriteStream, readFileSync } from 'fs';
 import { join } from 'path';
 

--- a/packages/axios/test/factory.test.ts
+++ b/packages/axios/test/factory.test.ts
@@ -1,7 +1,7 @@
 import { join } from 'path';
 import { HttpServiceFactory } from '../src';
 import { close, createLightApp } from '@midwayjs/mock';
-import * as nock from 'nock';
+import nock from 'nock';
 import { MidwayTraceService } from '@midwayjs/core';
 
 describe('/test/factory.test.ts', () => {

--- a/packages/axios/test/index.test.ts
+++ b/packages/axios/test/index.test.ts
@@ -1,7 +1,7 @@
 import { join } from 'path';
 import { HttpService, Axios } from '../src';
 import { createLightApp } from '@midwayjs/mock';
-import * as nock from 'nock';
+import nock from 'nock';
 
 describe('/test/index.test.ts', () => {
   let httpService: any;

--- a/packages/bootstrap/test/bootstrap.test.ts
+++ b/packages/bootstrap/test/bootstrap.test.ts
@@ -1,7 +1,7 @@
 import { fork } from 'child_process';
 import { join } from 'path';
 import { sleep } from '@midwayjs/core';
-import * as request from 'request';
+import request from 'request';
 import { io as socketClient } from 'socket.io-client';
 
 describe('/test/bootstrap.test.ts', () => {

--- a/packages/bootstrap/test/fork/cp.test.ts
+++ b/packages/bootstrap/test/fork/cp.test.ts
@@ -1,6 +1,6 @@
 import { ClusterManager } from '../../src';
 import { join } from 'path';
-import * as request from 'request';
+import request from 'request';
 import { sleep } from '../../src/util';
 const cluster = require('cluster');
 

--- a/packages/bootstrap/test/fork/thread.test.ts
+++ b/packages/bootstrap/test/fork/thread.test.ts
@@ -1,5 +1,5 @@
 import { join } from 'path';
-import * as request from 'request';
+import request from 'request';
 import { sleep } from '../../src/util';
 import { ThreadManager } from '../../src/manager/thread';
 const cluster = require('cluster');

--- a/packages/bullmq/test/index.test.ts
+++ b/packages/bullmq/test/index.test.ts
@@ -10,7 +10,7 @@ import {
 import * as bullmq from '../src';
 import { Processor, Application, IProcessor, Context } from '../src';
 import { JobsOptions, Job } from 'bullmq';
-import * as assert from 'node:assert';
+import assert from 'node:assert';
 
 describe(`/test/index.test.ts`, () => {
   it('test auto repeat processor', async () => {

--- a/packages/busboy/src/middleware.ts
+++ b/packages/busboy/src/middleware.ts
@@ -31,7 +31,7 @@ import {
 import { parseMultipart } from './parse';
 import { fromBuffer } from 'file-type';
 import { formatExt, streamToAsyncIterator } from './utils';
-import * as busboy from 'busboy';
+import busboy from 'busboy';
 import { BusboyConfig } from 'busboy';
 import { EXT_KEY } from './constants';
 

--- a/packages/busboy/test/express.test.ts
+++ b/packages/busboy/test/express.test.ts
@@ -1,6 +1,6 @@
 import { createHttpRequest, close, createLegacyApp } from '@midwayjs/mock';
 import { join } from 'path';
-import * as assert from 'assert';
+import assert from 'assert';
 import { statSync } from 'fs';
 
 describe.skip('test/express.test.ts', function () {

--- a/packages/busboy/test/faas.test.ts
+++ b/packages/busboy/test/faas.test.ts
@@ -1,6 +1,6 @@
 import { createHttpRequest, close, createLegacyFunctionApp } from '@midwayjs/mock';
 import { join } from 'path';
-import * as assert from 'assert';
+import assert from 'assert';
 import { existsSync, statSync } from 'fs';
 import { Framework } from '@midwayjs/faas';
 

--- a/packages/busboy/test/index.test.ts
+++ b/packages/busboy/test/index.test.ts
@@ -2,7 +2,7 @@ import { createHttpRequest, createLightApp, close } from '@midwayjs/mock';
 import * as koa from '@midwayjs/koa';
 import { join } from 'path';
 import { createWriteStream, statSync, writeFileSync, unlinkSync, existsSync } from 'fs';
-import * as assert from 'assert';
+import assert from 'assert';
 import { Controller, createMiddleware, Post } from '@midwayjs/core';
 import { tmpdir } from 'os';
 import { UploadMiddleware, UploadStreamFileInfo } from '../src';

--- a/packages/busboy/test/koa.test.ts
+++ b/packages/busboy/test/koa.test.ts
@@ -5,7 +5,7 @@ import * as koa from '@midwayjs/koa';
 import * as busboy from '../src';
 import { Controller, createMiddleware, Fields, Files, Post, File } from "@midwayjs/core";
 import { ensureDir, removeSync } from "fs-extra";
-import * as assert from 'assert';
+import assert from 'assert';
 import { tmpdir } from "os";
 import { randomUUID } from "node:crypto";
 

--- a/packages/busboy/test/web.test.ts
+++ b/packages/busboy/test/web.test.ts
@@ -1,6 +1,6 @@
 import { createHttpRequest, close, createLegacyApp } from '@midwayjs/mock';
 import { join } from 'path';
-import * as assert from 'assert';
+import assert from 'assert';
 import { statSync } from 'fs';
 
 describe.skip('test/web.test.ts', function () {

--- a/packages/cache-manager/src/base/store.ts
+++ b/packages/cache-manager/src/base/store.ts
@@ -1,4 +1,4 @@
-import * as LRUCache from 'lru-cache';
+import LRUCache from 'lru-cache';
 import * as cloneDeep from 'lodash.clonedeep';
 import { MemoryConfig, MemoryStore, LRU } from './types';
 

--- a/packages/cache-manager/src/base/store.ts
+++ b/packages/cache-manager/src/base/store.ts
@@ -1,5 +1,5 @@
 import LRUCache from 'lru-cache';
-import * as cloneDeep from 'lodash.clonedeep';
+import cloneDeep from 'lodash.clonedeep';
 import { MemoryConfig, MemoryStore, LRU } from './types';
 
 function clone<T>(object: T): T {

--- a/packages/captcha/src/service.ts
+++ b/packages/captcha/src/service.ts
@@ -7,7 +7,7 @@ import {
 } from '@midwayjs/core';
 import { CachingFactory, MidwayCache } from '@midwayjs/cache-manager';
 import * as svgCaptcha from 'svg-captcha-fixed';
-import * as svgBase64 from 'mini-svg-data-uri';
+import svgBase64 from 'mini-svg-data-uri';
 import { nanoid } from 'nanoid';
 import {
   FormulaCaptchaOptions,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -54,14 +54,14 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     },
     "./functional": {
+      "types": "./dist/functional/index.d.ts",
       "import": "./dist/functional/index.js",
-      "require": "./dist/functional/index.js",
-      "types": "./dist/functional/index.d.ts"
+      "require": "./dist/functional/index.js"
     }
   }
 }

--- a/packages/core/src/context/managedResolverFactory.ts
+++ b/packages/core/src/context/managedResolverFactory.ts
@@ -19,7 +19,7 @@ import {
   ScopeEnum,
 } from '../interface';
 import * as util from 'util';
-import * as EventEmitter from 'events';
+import { EventEmitter } from 'events';
 import {
   MidwayCommonError,
   MidwayDefinitionNotFoundError,

--- a/packages/core/src/service/aspectService.ts
+++ b/packages/core/src/service/aspectService.ts
@@ -1,4 +1,4 @@
-import * as pm from 'picomatch';
+import pm from 'picomatch';
 import {
   IMidwayContainer,
   AspectMetadata,

--- a/packages/core/test/baseFramework.test.ts
+++ b/packages/core/test/baseFramework.test.ts
@@ -1,6 +1,6 @@
-import * as assert from 'assert';
+import assert from 'assert';
 import * as path from 'path';
-import * as mm from 'mm';
+import mm from 'mm';
 import {
   getCurrentApplicationContext,
   getCurrentMainApp,

--- a/packages/core/test/common/asyncContextManager.test.ts
+++ b/packages/core/test/common/asyncContextManager.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as assert from 'assert';
+import assert from 'assert';
 import { EventEmitter } from 'events';
 import { ASYNC_ROOT_CONTEXT, AsyncLocalStorageContextManager } from '../../src/common/asyncContextManager';
 

--- a/packages/core/test/common/contextManager.test.ts
+++ b/packages/core/test/common/contextManager.test.ts
@@ -1,4 +1,4 @@
-import * as assert from 'assert';
+import assert from 'assert';
 import { NoopContextManager, ASYNC_ROOT_CONTEXT } from '../../src/common/asyncContextManager';
 
 /** Get a key to uniquely identify a context value */

--- a/packages/core/test/common/dataSourceManager.test.ts
+++ b/packages/core/test/common/dataSourceManager.test.ts
@@ -1,6 +1,6 @@
 import { DataSourceManager, sleep } from '../../src';
 import { join } from 'path';
-import * as assert from 'assert';
+import assert from 'assert';
 
 describe('test/common/dataSourceManager.test.ts', () => {
 

--- a/packages/core/test/context/midwayContainer.test.ts
+++ b/packages/core/test/context/midwayContainer.test.ts
@@ -28,7 +28,7 @@ import {
 } from '../../src';
 import { App } from '../fixtures/ts-app-inject/app';
 import { TestCons } from '../fixtures/ts-app-inject/test';
-import * as assert from 'assert';
+import assert from 'assert';
 import { ComponentConfigurationLoader } from '../../src/context/componentLoader';
 import { defineConfiguration } from '../../src/functional';
 

--- a/packages/core/test/decorator/util/uuid.test.ts
+++ b/packages/core/test/decorator/util/uuid.test.ts
@@ -1,5 +1,5 @@
 import { Utils } from '../../../src';
-import * as assert from 'assert';
+import assert from 'assert';
 
 describe('test/util/uuid.test.ts', () => {
 

--- a/packages/core/test/fixtures/base-app-aspect/src/aspect/a.ts
+++ b/packages/core/test/fixtures/base-app-aspect/src/aspect/a.ts
@@ -1,6 +1,6 @@
 import { Aspect, IMethodAspect, JoinPoint, Provide } from '../../../../../src';
 import { Home } from '../home';
-import * as assert from 'assert';
+import assert from 'assert';
 
 @Provide()
 @Aspect([Home])

--- a/packages/core/test/fixtures/base-app-aspect/src/aspect/b.ts
+++ b/packages/core/test/fixtures/base-app-aspect/src/aspect/b.ts
@@ -1,6 +1,6 @@
 import { Aspect, IMethodAspect, JoinPoint, Provide } from '../../../../../src';
 import { Home } from '../home';
-import * as assert from 'assert';
+import assert from 'assert';
 
 @Provide()
 @Aspect([Home], '*2', 1)

--- a/packages/core/test/fixtures/base-app-aspect/src/aspect/c.ts
+++ b/packages/core/test/fixtures/base-app-aspect/src/aspect/c.ts
@@ -1,6 +1,6 @@
 import { Aspect, IMethodAspect, JoinPoint, Provide } from '../../../../../src';
 import { UserController } from '../home';
-import * as assert from 'assert';
+import assert from 'assert';
 
 @Provide()
 @Aspect([UserController])

--- a/packages/core/test/fixtures/base-app-logger/src/configuration.ts
+++ b/packages/core/test/fixtures/base-app-logger/src/configuration.ts
@@ -1,5 +1,5 @@
 import { Configuration, App, Logger, IMidwayApplication } from '../../../../src';
-import * as assert from 'assert';
+import assert from 'assert';
 import { ILogger } from '@midwayjs/logger';
 
 @Configuration()

--- a/packages/core/test/logger.test.ts
+++ b/packages/core/test/logger.test.ts
@@ -1,6 +1,6 @@
 import { MidwayContextLogger } from '@midwayjs/logger';
 import { join } from 'path';
-import * as mm from 'mm';
+import mm from 'mm';
 import { tmpdir } from 'os';
 import { existsSync } from 'fs';
 import { createLightFramework } from './util';

--- a/packages/core/test/proxy.test.ts
+++ b/packages/core/test/proxy.test.ts
@@ -1,4 +1,4 @@
-import * as assert from 'assert';
+import assert from 'assert';
 import { extend } from '../src';
 
 describe('/test/proxy.test.ts', () => {

--- a/packages/core/test/response/http.test.ts
+++ b/packages/core/test/response/http.test.ts
@@ -1,5 +1,5 @@
 // import whyIsNodeRunning from 'why-is-node-running'
-import * as EventSource from 'eventsource';
+import EventSource from 'eventsource';
 import { HttpServerResponse, ServerSendEventMessage, sleep } from '../../src';
 import { createServer, request, ServerResponse } from 'http';
 import { join } from 'path';

--- a/packages/core/test/service/aspectService.test.ts
+++ b/packages/core/test/service/aspectService.test.ts
@@ -1,4 +1,4 @@
-import * as assert from 'assert';
+import assert from 'assert';
 
 import { MidwayAspectService, MidwayContainer } from '../../src';
 

--- a/packages/core/test/service/configService.test.ts
+++ b/packages/core/test/service/configService.test.ts
@@ -1,7 +1,7 @@
 import assert = require('assert');
 import { resolve, join } from 'path';
 import { MidwayContainer, MidwayConfigService, MidwayInformationService, MidwayEnvironmentService, MidwayInvalidConfigError } from '../../src';
-import * as mm from 'mm';
+import mm from 'mm';
 
 async function createConfigService(): Promise<MidwayConfigService> {
   const container = new MidwayContainer();

--- a/packages/core/test/service/middlewareService.test.ts
+++ b/packages/core/test/service/middlewareService.test.ts
@@ -1,5 +1,5 @@
 import { Provide, MidwayMiddlewareService, MidwayContainer, Init, IgnoreMatcher, createMiddleware } from '../../src';
-import * as assert from 'assert';
+import assert from 'assert';
 
 describe('/test/services/middlewareService.test.ts', () => {
 

--- a/packages/core/test/util.ts
+++ b/packages/core/test/util.ts
@@ -21,7 +21,7 @@ import {
 } from '../src';
 import { join } from 'path';
 import * as http from 'http';
-import * as getRawBody from 'raw-body';
+import getRawBody from 'raw-body';
 
 /**
  * 任意一个数组中的对象，和预期的对象属性一致即可

--- a/packages/core/test/util/path-match.test.ts
+++ b/packages/core/test/util/path-match.test.ts
@@ -1,5 +1,5 @@
 import { pathMatching as match } from '../../src/';
-import * as assert from 'assert';
+import assert from 'assert';
 
 describe('/test/util/path-matching.test.ts', () => {
   it('options.match and options.ignore both present should throw', () => {

--- a/packages/core/test/util/util.test.ts
+++ b/packages/core/test/util/util.test.ts
@@ -1,4 +1,4 @@
-import * as assert from 'assert';
+import assert from 'assert';
 import { join } from 'path';
 import {
   safeRequire,
@@ -14,7 +14,7 @@ import {
   sleep,
 } from '../../src/util';
 import { PathFileUtils } from '../../src';
-import * as EventEmitter from 'events';
+import { EventEmitter } from 'events';
 import { fork } from 'child_process';
 
 describe('/test/util/util.test.ts', () => {

--- a/packages/cos/src/manager.ts
+++ b/packages/cos/src/manager.ts
@@ -12,7 +12,7 @@ import {
   MidwayTraceService,
 } from '@midwayjs/core';
 import * as assert from 'assert';
-import * as COS from 'cos-nodejs-sdk-v5';
+import COS from 'cos-nodejs-sdk-v5';
 
 @Provide()
 @Scope(ScopeEnum.Singleton)

--- a/packages/express-session/src/middleware/session.ts
+++ b/packages/express-session/src/middleware/session.ts
@@ -7,7 +7,7 @@ import {
   MidwayConfigMissingError,
   MidwayConfigService,
 } from '@midwayjs/core';
-import * as session from 'express-session';
+import session from 'express-session';
 import * as cookieSession from 'cookie-session';
 import { SessionStoreManager } from '../store';
 

--- a/packages/express-session/src/middleware/session.ts
+++ b/packages/express-session/src/middleware/session.ts
@@ -8,7 +8,7 @@ import {
   MidwayConfigService,
 } from '@midwayjs/core';
 import session from 'express-session';
-import * as cookieSession from 'cookie-session';
+import cookieSession from 'cookie-session';
 import { SessionStoreManager } from '../store';
 
 @Middleware()

--- a/packages/faas/src/framework.ts
+++ b/packages/faas/src/framework.ts
@@ -439,7 +439,8 @@ export class MidwayFaaSFramework extends BaseFramework<
       } else {
         encoded = true;
         // data is reserved as buffer
-        context.body = Buffer.from(data).toString('base64');
+        const buffer = isUint8Array(data) ? data : new Uint8Array(data);
+        context.body = Buffer.from(buffer).toString('base64');
         context.length = data.byteLength;
       }
     } else if (typeof data === 'object') {

--- a/packages/faas/test/new.test.ts
+++ b/packages/faas/test/new.test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import * as mm from 'mm';
+import mm from 'mm';
 import { createNewStarter, closeApp } from './utils';
 import { createLegacyFunctionApp, createHttpRequest } from '@midwayjs/mock';
 import { Framework } from '../src';

--- a/packages/grpc/src/comsumer/clients.ts
+++ b/packages/grpc/src/comsumer/clients.ts
@@ -1,4 +1,4 @@
-import * as assert from 'assert';
+import assert from 'assert';
 import {
   Config,
   Inject,

--- a/packages/http-proxy/src/middleware.ts
+++ b/packages/http-proxy/src/middleware.ts
@@ -7,7 +7,7 @@ import {
   IMidwayApplication,
 } from '@midwayjs/core';
 import { HttpProxyConfig, HttpProxyStrategy } from './interface';
-import * as axios from 'axios';
+import axios from 'axios';
 
 @Middleware()
 export class HttpProxyMiddleware implements IMiddleware<any, any> {
@@ -79,7 +79,7 @@ export class HttpProxyMiddleware implements IMiddleware<any, any> {
           .join('&');
       }
     }
-    const proxyResponse = await (axios as any)(reqOptions).catch(err => {
+    const proxyResponse = await axios(reqOptions).catch(err => {
       if (!err || !err.response) {
         throw err || new Error('proxy unknown error');
       }

--- a/packages/http-proxy/test/express.test.ts
+++ b/packages/http-proxy/test/express.test.ts
@@ -1,7 +1,7 @@
 import { createLegacyApp, createHttpRequest, close } from '@midwayjs/mock';
 import { join } from 'path';
-import * as assert from 'assert';
-import * as nock from 'nock';
+import assert from 'assert';
+import nock from 'nock';
 
 describe('test/express.test.ts', function () {
   let app;

--- a/packages/http-proxy/test/faas.test.ts
+++ b/packages/http-proxy/test/faas.test.ts
@@ -1,6 +1,6 @@
 import { createHttpRequest, close, createLegacyFunctionApp } from '@midwayjs/mock';
 import { join } from 'path';
-import * as nock from 'nock';
+import nock from 'nock';
 
 describe('test/faas.test.ts', function () {
   let app;

--- a/packages/http-proxy/test/koa.test.ts
+++ b/packages/http-proxy/test/koa.test.ts
@@ -1,7 +1,7 @@
 import { createLegacyApp, createHttpRequest, close } from '@midwayjs/mock';
 import { join } from 'path';
-import * as assert from 'assert';
-import * as nock from 'nock';
+import assert from 'assert';
+import nock from 'nock';
 
 describe('test/koa.test.ts', function () {
   let app;

--- a/packages/http-proxy/test/web.test.ts
+++ b/packages/http-proxy/test/web.test.ts
@@ -1,7 +1,7 @@
 import { createLegacyApp, createHttpRequest, close } from '@midwayjs/mock';
 import { join } from 'path';
-import * as assert from 'assert';
-import * as nock from 'nock';
+import assert from 'assert';
+import nock from 'nock';
 describe('test/web.test.ts', function () {
   let app;
   beforeAll(async () => {

--- a/packages/i18n/src/i18nService.ts
+++ b/packages/i18n/src/i18nService.ts
@@ -8,7 +8,7 @@ import {
   IMidwayContext,
 } from '@midwayjs/core';
 import { I18N_ATTR_KEY, TranslateOptions } from './interface';
-import * as pm from 'picomatch';
+import pm from 'picomatch';
 import { I18nOptions } from './interface';
 import { formatLocale, formatWithArray, formatWithObject } from './utils';
 

--- a/packages/info/src/infoService.ts
+++ b/packages/info/src/infoService.ts
@@ -24,7 +24,7 @@ import {
   totalmem,
 } from 'os';
 import { join } from 'path';
-import * as pm from 'picomatch';
+import pm from 'picomatch';
 
 @Provide()
 @Scope(ScopeEnum.Singleton)

--- a/packages/mock/src/client/http.ts
+++ b/packages/mock/src/client/http.ts
@@ -1,5 +1,5 @@
 import { IMidwayApplication } from '@midwayjs/core';
-import * as request from 'supertest';
+import request from 'supertest';
 
 export function createHttpRequest<T extends IMidwayApplication<any>>(
   app: T

--- a/packages/mock/src/creator.ts
+++ b/packages/mock/src/creator.ts
@@ -39,7 +39,7 @@ import { existsSync, readFileSync } from 'fs';
 import * as http from 'http';
 import * as https from 'https';
 import * as yaml from 'js-yaml';
-import * as getRawBody from 'raw-body';
+import getRawBody from 'raw-body';
 import { defineConfiguration } from '@midwayjs/core/functional';
 import { createSourceModuleLoader } from './sourceLoader';
 

--- a/packages/mongoose/src/manager.ts
+++ b/packages/mongoose/src/manager.ts
@@ -11,7 +11,7 @@ import {
   Scope,
   ScopeEnum,
 } from '@midwayjs/core';
-import * as mongoose from 'mongoose';
+import mongoose from 'mongoose';
 
 @Provide()
 @Scope(ScopeEnum.Singleton)

--- a/packages/mqtt/test/fixtures/base-app/src/comsumer/userConsumer.ts
+++ b/packages/mqtt/test/fixtures/base-app/src/comsumer/userConsumer.ts
@@ -1,6 +1,6 @@
 import { ILogger, Inject } from '@midwayjs/core';
 import { Context, IMqttSubscriber, MqttSubscriber } from '../../../../../src';
-import * as assert from 'node:assert';
+import assert from 'node:assert';
 
 @MqttSubscriber('test')
 export class UserConsumer implements IMqttSubscriber {

--- a/packages/nextjs/tsconfig.json
+++ b/packages/nextjs/tsconfig.json
@@ -5,7 +5,6 @@
     "rootDir": "src",
     "outDir": "dist",
     "esModuleInterop": true,
-    "baseUrl": ".",
     "paths": {
       "@midwayjs/web-bridge": [
         "../web-bridge/dist/index.d.ts"

--- a/packages/oss/src/manager.ts
+++ b/packages/oss/src/manager.ts
@@ -10,7 +10,7 @@ import {
   MidwayCommonError,
   MidwayTraceService,
 } from '@midwayjs/core';
-import * as OSS from 'ali-oss';
+import OSS from 'ali-oss';
 import * as assert from 'assert';
 import type {
   OSSServiceFactoryReturnType,

--- a/packages/processAgent/src/decorator/primary.ts
+++ b/packages/processAgent/src/decorator/primary.ts
@@ -1,5 +1,5 @@
 import { DecoratorManager, MetadataManager } from '@midwayjs/core';
-import * as request from 'request';
+import request from 'request';
 import * as path from 'path';
 import * as os from 'os';
 import { isPrimary } from '../utils/utils';

--- a/packages/processAgent/test/fixtures/primary-demo/src/configuration.ts
+++ b/packages/processAgent/test/fixtures/primary-demo/src/configuration.ts
@@ -1,6 +1,6 @@
 import { Configuration, MainApp } from '@midwayjs/core';
 import { Application } from '@midwayjs/koa';
-import * as bodyParser from 'koa-bodyparser';
+import bodyParser from 'koa-bodyparser';
 import * as primary from '../../../../src'
 
 @Configuration({

--- a/packages/prometheus/src/decorator/master.ts
+++ b/packages/prometheus/src/decorator/master.ts
@@ -1,5 +1,5 @@
 import { DecoratorManager, MetadataManager } from '@midwayjs/core';
-import * as request from 'request';
+import request from 'request';
 import * as path from 'path';
 import * as os from 'os';
 import { isMaster } from '../utils/utils';

--- a/packages/redis/src/extension/serviceDiscovery.ts
+++ b/packages/redis/src/extension/serviceDiscovery.ts
@@ -48,7 +48,7 @@ class RedisDataListener extends DataListener<RedisInstanceMetadata[]> {
     return this.fetchInstancesByKeys(keys);
   }
 
-  onData(setData) {
+  async onData(setData) {
     // 订阅当前 serviceName 的变更消息
     const channel = `service:change:${this.serviceName}`;
     const handler = async (channelName, message) => {
@@ -66,7 +66,7 @@ class RedisDataListener extends DataListener<RedisInstanceMetadata[]> {
         this.logger.error('[midway:redis] Error on service change:', err);
       }
     };
-    this.pubsub.subscribe(channel);
+    await this.pubsub.subscribe(channel);
     this.pubsub.on('message', handler);
 
     // 提供取消订阅方法

--- a/packages/security/src/middleware/csrf.middleware.ts
+++ b/packages/security/src/middleware/csrf.middleware.ts
@@ -1,6 +1,6 @@
 import { Middleware } from '@midwayjs/core';
 import { CSRFError } from '../error';
-import * as CsrfTokens from 'csrf';
+import CsrfTokens from 'csrf';
 import { isSafeDomain, parseUrl } from '../utils';
 import { BaseMiddleware } from './base';
 

--- a/packages/security/src/middleware/helper.ts
+++ b/packages/security/src/middleware/helper.ts
@@ -1,5 +1,5 @@
 import { IMiddleware, Middleware } from '@midwayjs/core';
-import * as escape from 'escape-html';
+import escape from 'escape-html';
 import { filterXSS } from 'xss';
 
 @Middleware()

--- a/packages/security/src/utils.ts
+++ b/packages/security/src/utils.ts
@@ -1,5 +1,5 @@
 import { URL } from 'url';
-import * as pm from 'picomatch';
+import pm from 'picomatch';
 export const parseUrl = (url: string, prop?: string) => {
   try {
     const parsed = new URL(url);

--- a/packages/static-file/src/middleware/static.middleware.ts
+++ b/packages/static-file/src/middleware/static.middleware.ts
@@ -10,7 +10,7 @@ import {
 } from '@midwayjs/core';
 import * as assert from 'assert';
 import * as staticCache from 'koa-static-cache';
-import * as LRU from 'ylru';
+import LRU from 'ylru';
 import * as range from 'koa-range';
 import { DirectoryNotFoundError } from '../error';
 import * as fs from 'fs';

--- a/packages/static-file/src/middleware/static.middleware.ts
+++ b/packages/static-file/src/middleware/static.middleware.ts
@@ -9,9 +9,9 @@ import {
   MidwayEnvironmentService,
 } from '@midwayjs/core';
 import * as assert from 'assert';
-import * as staticCache from 'koa-static-cache';
+import staticCache from 'koa-static-cache';
 import LRU from 'ylru';
-import * as range from 'koa-range';
+import range from 'koa-range';
 import { DirectoryNotFoundError } from '../error';
 import * as fs from 'fs';
 

--- a/packages/swagger/test/index.test.ts
+++ b/packages/swagger/test/index.test.ts
@@ -2,7 +2,7 @@ import { close, createLegacyApp, createHttpRequest, createLightApp } from '@midw
 import * as koa from '@midwayjs/koa';
 import { join } from 'path';
 import { MidwayWebRouterService } from '@midwayjs/core';
-import * as SwaggerParser from "@apidevtools/swagger-parser";
+import SwaggerParser from '@apidevtools/swagger-parser';
 import * as swagger from '../src';
 
 describe('/test/index.test.ts', () => {

--- a/packages/tags/test/memory.test.ts
+++ b/packages/tags/test/memory.test.ts
@@ -1,6 +1,6 @@
 import { TAG_ERROR, MATCH_TYPE, TagServiceFactory } from '../src';
 import { createLightApp, close } from '@midwayjs/mock';
-import * as assert from 'assert';
+import assert from 'assert';
 import { join } from 'path';
 describe('memory.test.ts', () => {
   let tagManager;

--- a/packages/tags/test/mysql.test.ts
+++ b/packages/tags/test/mysql.test.ts
@@ -1,5 +1,5 @@
 import { MATCH_TYPE, TAG_ERROR, TagServiceFactory } from '../src';
-import * as assert from 'assert';
+import assert from 'assert';
 import { createLightApp, close } from '@midwayjs/mock';
 import { join } from 'path';
 describe('mysql.test.ts', () => {

--- a/packages/upload/src/middleware.ts
+++ b/packages/upload/src/middleware.ts
@@ -18,7 +18,7 @@ import {
   UploadOptions,
 } from '.';
 import { parseFromReadableStream, parseMultipart } from './parse';
-import * as getRawBody from 'raw-body';
+import getRawBody from 'raw-body';
 import { fromBuffer } from 'file-type';
 import { formatExt } from './utils';
 

--- a/packages/upload/src/parse.ts
+++ b/packages/upload/src/parse.ts
@@ -158,7 +158,7 @@ export const parseFromReadableStream = (
           fileInfo.fieldName = head['content-disposition'].name;
           fileInfo.mimeType = head['content-type'];
           isTransformFileData = true;
-          lastChunk = data;
+          lastChunk = data as typeof lastChunk;
           allChuns = emptyBuf;
           this.pause();
           resolve({ fileInfo, fields });

--- a/packages/upload/test/index.test.ts
+++ b/packages/upload/test/index.test.ts
@@ -2,7 +2,7 @@ import { createHttpRequest, createLightApp, close } from '@midwayjs/mock';
 import * as koa from '@midwayjs/koa';
 import { join } from 'path';
 import { writeFileSync, unlinkSync, existsSync } from 'fs';
-import * as assert from 'assert';
+import assert from 'assert';
 import { Controller, Post } from '@midwayjs/core';
 import { tmpdir } from 'os';
 

--- a/packages/upload/test/koa.test.ts
+++ b/packages/upload/test/koa.test.ts
@@ -1,6 +1,6 @@
 import { createHttpRequest, close, createLegacyApp } from '@midwayjs/mock';
 import { join } from 'path';
-import * as assert from 'assert';
+import assert from 'assert';
 import { statSync } from 'fs';
 
 describe('test/koa.test.ts', function () {

--- a/packages/web-express/src/configuration.ts
+++ b/packages/web-express/src/configuration.ts
@@ -9,7 +9,7 @@ import {
 } from '@midwayjs/core';
 import * as session from '@midwayjs/express-session';
 import * as bodyParser from 'body-parser';
-import * as cookieParser from 'cookie-parser';
+import cookieParser from 'cookie-parser';
 import * as DefaultConfig from './config/config.default';
 import { MidwayExpressFramework } from './framework';
 

--- a/packages/web-express/src/framework.ts
+++ b/packages/web-express/src/framework.ts
@@ -22,7 +22,7 @@ import {
   Context,
 } from './interface';
 import type { IRouter, IRouterHandler, Response, NextFunction } from 'express';
-import * as express from 'express';
+import express from 'express';
 import { Server } from 'net';
 import {
   wrapAsyncHandler,

--- a/packages/web-koa/src/framework.ts
+++ b/packages/web-koa/src/framework.ts
@@ -21,9 +21,9 @@ import {
   IMidwayKoaConfigurationOptions,
   IMidwayKoaContext,
 } from './interface';
-import * as Router from '@koa/router';
+import Router from '@koa/router';
 import type { DefaultState, Middleware, Next } from 'koa';
-import * as koa from 'koa';
+import koa from 'koa';
 import { Server } from 'http';
 import { setupOnError } from './onerror';
 import * as qs from 'qs';

--- a/packages/web-koa/src/middleware/bodyparser.middleware.ts
+++ b/packages/web-koa/src/middleware/bodyparser.middleware.ts
@@ -1,4 +1,4 @@
-import * as koaBodyParser from 'koa-bodyparser';
+import koaBodyParser from 'koa-bodyparser';
 import { Config, Middleware } from '@midwayjs/core';
 
 @Middleware()

--- a/packages/web-koa/test/utils.ts
+++ b/packages/web-koa/test/utils.ts
@@ -2,7 +2,7 @@ import { IMidwayKoaConfigurationOptions, Framework, IMidwayKoaApplication } from
 import * as koaModule from '../src';
 import { join } from 'path';
 import { createLegacyApp, close } from '@midwayjs/mock';
-import * as axios from 'axios';
+import axios from 'axios';
 
 export async function creatApp(name: string, options: IMidwayKoaConfigurationOptions = {}): Promise<IMidwayKoaApplication> {
   return createLegacyApp<Framework>(join(__dirname, 'fixtures', name), {

--- a/packages/web/test/custom.test.ts
+++ b/packages/web/test/custom.test.ts
@@ -1,4 +1,4 @@
-import * as mm from 'mm';
+import mm from 'mm';
 import { join } from 'path';
 mm(process.env, 'MIDWAY_PROJECT_APPDIR', join(__dirname, './fixtures/feature/base-app-use-custom-egg'));
 import { closeApp, creatApp, createHttpRequest } from './utils';

--- a/packages/web/test/fixtures/enhance/base-app-decorator/src/app/controller/param.ts
+++ b/packages/web/test/fixtures/enhance/base-app-decorator/src/app/controller/param.ts
@@ -19,7 +19,7 @@ import {
 import * as path from 'path';
 import * as fs from 'fs';
 
-import * as pump from 'mz-modules/pump';
+import pump from 'mz-modules/pump';
 
 @Provide()
 @Controller('/param')

--- a/packages/web/test/logger.test.ts
+++ b/packages/web/test/logger.test.ts
@@ -1,5 +1,5 @@
 import { creatApp, closeApp, getFilepath, sleep, matchContentTimes } from './utils';
-import * as mm from 'mm';
+import mm from 'mm';
 import { join } from 'path';
 import { existsSync, readFileSync, writeFileSync, ensureDir, remove } from 'fs-extra';
 import { lstatSync } from 'fs';

--- a/packages/web/test/utils.test.ts
+++ b/packages/web/test/utils.test.ts
@@ -1,5 +1,5 @@
 import { getCurrentDateString } from '../src/utils';
-import * as dayjs from 'dayjs';
+import dayjs from 'dayjs';
 
 describe('test/utils.test.ts', function () {
 

--- a/packages/ws/src/framework.ts
+++ b/packages/ws/src/framework.ts
@@ -463,7 +463,7 @@ export class MidwayWSFramework extends BaseFramework<
       (this.configurationOptions as any)?.tracing?.enable !== false;
     const traceInjector = (this.configurationOptions as any)?.tracing?.injector;
     const sendWithTrace = async (
-      currentSocket: IMidwayWSContext | WebSocket,
+      currentSocket: { send: (data: any) => unknown },
       payload: any,
       eventName: string
     ) => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "moduleResolution": "NodeNext",
     "target": "ES2022",
     "lib": ["ES2023"],
-    "esModuleInterop": false
+    "types": ["node"]
   },
   "exclude": [
     "dist",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "moduleResolution": "NodeNext",
     "target": "ES2022",
     "lib": ["ES2023"],
+    "esModuleInterop": true,
     "types": ["node", "jest"]
   },
   "exclude": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "moduleResolution": "NodeNext",
     "target": "ES2022",
     "lib": ["ES2023"],
-    "types": ["node"]
+    "types": ["node", "jest"]
   },
   "exclude": [
     "dist",


### PR DESCRIPTION
## Summary
- remove the unsupported `esModuleInterop: false` setting and explicitly include Node types
- update CommonJS imports that are invoked or constructed under TypeScript 7 interop semantics
- fix Buffer and WebSocket type incompatibilities exposed by TypeScript 7
- remove the deprecated `baseUrl` setting from the Next.js package config

## Validation
- `pnpm exec tsc -p packages/upload/tsconfig.json --noEmit --pretty false`
- TypeScript 7 compile sweep completed for the previously failing top-level packages; remaining repo-wide fixture/sample migration is intentionally out of scope.