### PR TITLE
fix: add missing root declaration type imports

### DIFF
--- a/packages/axios/index.d.ts
+++ b/packages/axios/index.d.ts
@@ -1,3 +1,4 @@
+import type { ServiceFactoryConfigOption } from '@midwayjs/core';
 import { AxiosRequestConfig } from './dist/index';
 
 export * from './dist/index';

--- a/packages/bull-board/index.d.ts
+++ b/packages/bull-board/index.d.ts
@@ -1,3 +1,4 @@
+import type { PowerPartial } from '@midwayjs/core';
 import { BullBoardOption } from './dist/index';
 export * from './dist/index';
 

--- a/packages/busboy/index.d.ts
+++ b/packages/busboy/index.d.ts
@@ -8,7 +8,7 @@ declare module '@midwayjs/core' {
 }
 declare module '@midwayjs/koa/dist/interface' {
   interface Context {
-    files?: UploadFileInfo<any>[];
+    files?: UploadFileInfo[];
     fields?: { [fieldName: string]: any };
     cleanupRequestFiles?: () => Promise<Array<boolean>>;
   }
@@ -16,7 +16,7 @@ declare module '@midwayjs/koa/dist/interface' {
 
 declare module '@midwayjs/web/dist/interface' {
   interface Context {
-    files?: UploadFileInfo<any>[];
+    files?: UploadFileInfo[];
     fields?: { [fieldName: string]: any };
     cleanupRequestFiles?: () => Promise<Array<boolean>>;
   }
@@ -24,7 +24,7 @@ declare module '@midwayjs/web/dist/interface' {
 
 declare module '@midwayjs/faas/dist/interface' {
   interface Context {
-    files?: UploadFileInfo<any>[];
+    files?: UploadFileInfo[];
     fields?: { [fieldName: string]: any };
     cleanupRequestFiles?: () => Promise<Array<boolean>>;
   }
@@ -32,7 +32,7 @@ declare module '@midwayjs/faas/dist/interface' {
 
 declare module '@midwayjs/express/dist/interface' {
   interface Context {
-    files?: UploadFileInfo<any>[];
+    files?: UploadFileInfo[];
     fields?: { [fieldName: string]: any };
     cleanupRequestFiles?: () => Promise<Array<boolean>>;
   }

--- a/packages/cache-manager/index.d.ts
+++ b/packages/cache-manager/index.d.ts
@@ -1,3 +1,4 @@
+import type { ServiceFactoryConfigOption } from '@midwayjs/core';
 import { CacheManagerOptions } from './dist/index';
 
 export * from './dist/index';

--- a/packages/commander/index.d.ts
+++ b/packages/commander/index.d.ts
@@ -1,9 +1,9 @@
-import { CommanderConfigOptions } from './dist/index';
+import { ICommanderConfigurationOptions } from './dist/index';
 
 export * from './dist/index';
 
 declare module '@midwayjs/core' {
   interface MidwayConfig {
-    commander?: Partial<CommanderConfigOptions>;
+    commander?: Partial<ICommanderConfigurationOptions>;
   }
 }

--- a/packages/consul/index.d.ts
+++ b/packages/consul/index.d.ts
@@ -1,3 +1,4 @@
+import type { ServiceFactoryConfigOption } from '@midwayjs/core';
 import { ConsulOptions } from './dist';
 
 export * from './dist/index';

--- a/packages/cos/index.d.ts
+++ b/packages/cos/index.d.ts
@@ -1,3 +1,4 @@
+import type { ServiceFactoryConfigOption } from '@midwayjs/core';
 import * as COS from 'cos-nodejs-sdk-v5';
 
 export * from './dist/index';

--- a/packages/etcd/index.d.ts
+++ b/packages/etcd/index.d.ts
@@ -1,4 +1,4 @@
-import { MidwayEtcdConfigOptions } from './dist/index';
+import { MidwayEtcdConfigOptions } from './dist/interface';
 export * from './dist/index';
 
 declare module '@midwayjs/core' {

--- a/packages/grpc/index.d.ts
+++ b/packages/grpc/index.d.ts
@@ -1,3 +1,4 @@
+import type { PowerPartial } from '@midwayjs/core';
 import { DefaultConfig, IMidwayGRPFrameworkOptions } from './dist';
 
 export * from './dist/index';

--- a/packages/i18n/index.d.ts
+++ b/packages/i18n/index.d.ts
@@ -1,3 +1,4 @@
+import type { PowerPartial } from '@midwayjs/core';
 import { I18nOptions } from './dist/';
 
 export * from './dist/index';

--- a/packages/kafka/index.d.ts
+++ b/packages/kafka/index.d.ts
@@ -1,3 +1,4 @@
+import type { PowerPartial } from '@midwayjs/core';
 import { IMidwayKafkaConfigurationOptions } from './dist';
 export * from './dist/index';
 export {

--- a/packages/mcp/index.d.ts
+++ b/packages/mcp/index.d.ts
@@ -1,3 +1,4 @@
+import type { PowerPartial } from '@midwayjs/core';
 import { IMidwayMCPConfigurationOptions } from './dist/index';
 
 export * from './dist/index';

--- a/packages/mikro/index.d.ts
+++ b/packages/mikro/index.d.ts
@@ -1,3 +1,4 @@
+import type { PowerPartial } from '@midwayjs/core';
 import { MikroConfigOptions } from './dist/index';
 
 export * from './dist/index';

--- a/packages/mikro7/index.d.ts
+++ b/packages/mikro7/index.d.ts
@@ -1,3 +1,4 @@
+import type { PowerPartial } from '@midwayjs/core';
 import { MikroConfigOptions } from './dist/index.js';
 
 export * from './dist/index.js';

--- a/packages/mongoose/index.d.ts
+++ b/packages/mongoose/index.d.ts
@@ -1,3 +1,4 @@
+import type { DataSourceManagerConfigOption } from '@midwayjs/core';
 import { ConnectionOptions } from './dist';
 export * from './dist/index';
 

--- a/packages/mqtt/index.d.ts
+++ b/packages/mqtt/index.d.ts
@@ -1,3 +1,4 @@
+import type { PowerPartial } from '@midwayjs/core';
 import { IMidwayMQTTConfigurationOptions } from './dist';
 export * from './dist/index';
 

--- a/packages/oss/index.d.ts
+++ b/packages/oss/index.d.ts
@@ -1,3 +1,4 @@
+import type { ServiceFactoryConfigOption } from '@midwayjs/core';
 import { OSSServiceFactoryCreateClientConfigType } from './dist';
 
 export * from './dist/index';

--- a/packages/rabbitmq/index.d.ts
+++ b/packages/rabbitmq/index.d.ts
@@ -1,3 +1,4 @@
+import type { PowerPartial } from '@midwayjs/core';
 import { IMidwayRabbitMQConfigurationOptions } from './dist';
 export * from './dist/index';
 

--- a/packages/sequelize/index.d.ts
+++ b/packages/sequelize/index.d.ts
@@ -1,3 +1,4 @@
+import type { PowerPartial } from '@midwayjs/core';
 import { SequelizeConfigOptions } from './dist';
 
 import { SequelizeOptions } from 'sequelize-typescript';

--- a/packages/session/index.d.ts
+++ b/packages/session/index.d.ts
@@ -1,3 +1,4 @@
+import type { PowerPartial } from '@midwayjs/core';
 import { SessionOptions, ISession } from './dist';
 export * from './dist/index';
 

--- a/packages/socketio/index.d.ts
+++ b/packages/socketio/index.d.ts
@@ -1,8 +1,8 @@
-import { IMidwaySocketIOConfigurationOptions } from './dist';
+import { IMidwaySocketIOOptions } from './dist';
 export * from './dist/index';
 
 declare module '@midwayjs/core' {
   interface MidwayConfig {
-    socketIO?: IMidwaySocketIOConfigurationOptions;
+    socketIO?: IMidwaySocketIOOptions;
   }
 }

--- a/packages/tablestore/index.d.ts
+++ b/packages/tablestore/index.d.ts
@@ -1,3 +1,4 @@
+import type { ServiceFactoryConfigOption } from '@midwayjs/core';
 import { TableStoreConfig } from './dist';
 export * from './dist/index';
 

--- a/packages/tags/index.d.ts
+++ b/packages/tags/index.d.ts
@@ -1,3 +1,4 @@
+import type { ServiceFactoryConfigOption } from '@midwayjs/core';
 import { ITagDialectOption } from './dist';
 
 export * from './dist/index';

--- a/packages/typeorm/index.d.ts
+++ b/packages/typeorm/index.d.ts
@@ -1,3 +1,4 @@
+import type { PowerPartial } from '@midwayjs/core';
 import { typeormConfigOptions } from './dist/index';
 
 export * from './dist/index';

--- a/packages/typeorm/test/index.test.ts
+++ b/packages/typeorm/test/index.test.ts
@@ -1,5 +1,6 @@
 import { join } from 'path';
 import { existsSync, unlinkSync } from 'fs';
+import * as ts from 'typescript';
 import { close, createLegacyLightApp } from '@midwayjs/mock';
 import { IMidwayApplication } from '@midwayjs/core';
 import {
@@ -120,6 +121,27 @@ describe('/test/index.test.ts', () => {
     ]);
     expect((manager as any).filterSubscriberClasses(undefined)).toEqual([]);
   });
+
+  it('should compile package type entry', () => {
+    const declarationFile = join(__dirname, '../index.d.ts');
+    const program = ts.createProgram([declarationFile], {
+      noEmit: true,
+      strict: true,
+      moduleResolution: ts.ModuleResolutionKind.Node10,
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2021,
+      skipLibCheck: false,
+      esModuleInterop: true,
+      experimentalDecorators: true,
+      emitDecoratorMetadata: true,
+    });
+
+    const diagnostics = ts
+      .getPreEmitDiagnostics(program)
+      .filter(diagnostic => diagnostic.file?.fileName === declarationFile);
+
+    expect(formatDiagnostics(diagnostics)).toEqual([]);
+  });
 });
 
 function cleanFile(file) {
@@ -153,4 +175,10 @@ async function createSubscriberDataSource(
     },
     'default'
   ) as Promise<DataSource>;
+}
+
+function formatDiagnostics(diagnostics: readonly ts.Diagnostic[]) {
+  return diagnostics.map(diagnostic =>
+    ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n')
+  );
 }

--- a/packages/web-koa/index.d.ts
+++ b/packages/web-koa/index.d.ts
@@ -28,7 +28,7 @@ declare module '@midwayjs/core' {
       json?: (err: Error, ctx: KoaContext) => void;
       html?: (err: Error, ctx: KoaContext) => void;
       redirect?: string;
-      accepts?: (...args) => any;
+      accepts?: (...args: any[]) => any;
     };
     bodyParser?: BodyParserOptions;
     siteFile?: {

--- a/packages/web/index.d.ts
+++ b/packages/web/index.d.ts
@@ -1,12 +1,12 @@
 import {
   Context as IMidwayBaseContext,
   IMidwayBaseApplication,
+  PowerPartial,
 } from '@midwayjs/core';
 import {
   IMidwayWebBaseApplication,
   IMidwayWebConfigurationOptions,
   Context as EggContext,
-  State,
 } from './dist';
 import { ILogger, LoggerOptions } from '@midwayjs/logger';
 import { EggAppConfig } from 'egg';
@@ -30,7 +30,7 @@ declare module 'egg' {
   interface Context<ResponseBodyT = any> extends IMidwayBaseContext {
     getLogger(name?: string): ILogger;
     forward: (url: string) => void;
-    state: State;
+    state: any;
   }
 }
 


### PR DESCRIPTION
## Summary
- import missing core helper types in root index.d.ts files for config augmentation
- fix several root declaration entry mismatches surfaced by TypeScript diagnostics
- add a type-entry smoke test for @midwayjs/typeorm

## Verification
- batch TypeScript check for packages/*/index.d.ts self diagnostics
- pnpm -C packages/typeorm test
- git diff --check
- npx lerna exec --since -- mwts check