### PR TITLE
fix: make npm publish version selection non-interactive

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,15 @@ on:
           - next
           - beta
           - canary
+      version_bump:
+        description: Version bump
+        required: true
+        default: patch
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
 
 permissions:
   contents: write
@@ -71,15 +80,15 @@ jobs:
         run: |
           case "${{ inputs.release_type }}" in
             beta)
-              bash scripts/publish.sh beta
+              bash scripts/publish.sh beta "${{ inputs.version_bump }}"
               ;;
             next)
-              bash scripts/publish.sh next
+              bash scripts/publish.sh next "${{ inputs.version_bump }}"
               ;;
             canary)
-              bash scripts/publish.sh canary
+              bash scripts/publish.sh canary "${{ inputs.version_bump }}"
               ;;
             release)
-              bash scripts/publish.sh
+              bash scripts/publish.sh release "${{ inputs.version_bump }}"
               ;;
           esac

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -7,14 +7,23 @@ pnpm -w run build:skill-midway
 git add .
 
 RELEASE_TYPE="$1"
+VERSION_BUMP="$2"
+
+version() {
+  if [ -n "$VERSION_BUMP" ]; then
+    lerna version "$VERSION_BUMP" --yes "$@"
+  else
+    lerna version --yes "$@"
+  fi
+}
 
 case "$RELEASE_TYPE" in
   "beta")
-    SKIP_VERSION_SCRIPTS=true lerna version --yes --force-publish=*
+    SKIP_VERSION_SCRIPTS=true version --force-publish=*
     lerna publish from-git --yes --dist-tag beta
     ;;
   "next")
-    SKIP_VERSION_SCRIPTS=true lerna version --yes
+    SKIP_VERSION_SCRIPTS=true version
     lerna publish from-git --yes --dist-tag next
     ;;
   "canary")
@@ -23,7 +32,7 @@ case "$RELEASE_TYPE" in
     ;;
   *)
     # release (default) - 只有这个会执行完整的 version 脚本
-    lerna version --yes
+    version
     lerna publish from-git --yes
     ;;
 esac


### PR DESCRIPTION
## Summary
- add a `patch`/`minor`/`major` version bump input to the trusted npm publish workflow
- pass the selected bump to Lerna so GitHub Actions does not wait for interactive input
- preserve the existing interactive behavior for local `npm run release`

## Verification
- `bash -n scripts/publish.sh`
- workflow YAML parse check
- `git diff --check`
