### PR TITLE
fix: remove npm token config for oidc publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,11 +14,12 @@ on:
           - beta
           - canary
       version_bump:
-        description: Version bump
+        description: Version bump, or existing to retry a generated tag
         required: true
         default: patch
         type: choice
         options:
+          - existing
           - patch
           - minor
           - major

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,6 +63,13 @@ jobs:
           registry-url: https://registry.npmjs.org
           cache: pnpm
 
+      - name: Configure npm for trusted publishing
+        run: |
+          npmrc="${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
+          if [ -f "$npmrc" ]; then
+            sed -i '/_authToken/d' "$npmrc"
+          fi
+
       - name: Use npm with trusted publishing support
         run: npm install -g npm@11.19.0
 

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -17,13 +17,19 @@ version() {
   fi
 }
 
+version_if_needed() {
+  if [ "$VERSION_BUMP" != "existing" ]; then
+    version "$@"
+  fi
+}
+
 case "$RELEASE_TYPE" in
   "beta")
-    SKIP_VERSION_SCRIPTS=true version --force-publish=*
+    SKIP_VERSION_SCRIPTS=true version_if_needed --force-publish=*
     lerna publish from-git --yes --dist-tag beta
     ;;
   "next")
-    SKIP_VERSION_SCRIPTS=true version
+    SKIP_VERSION_SCRIPTS=true version_if_needed
     lerna publish from-git --yes --dist-tag next
     ;;
   "canary")
@@ -32,7 +38,7 @@ case "$RELEASE_TYPE" in
     ;;
   *)
     # release (default) - 只有这个会执行完整的 version 脚本
-    version
+    version_if_needed
     lerna publish from-git --yes
     ;;
 esac


### PR DESCRIPTION
## Summary
- remove the `_authToken` entry generated by `actions/setup-node`
- allow npm 11 Trusted Publisher OIDC authentication to activate during publish

The previous run completed versioning and changelog generation, then npm returned misleading `E404` errors for every package because the generated npm config short-circuited OIDC authentication.

## Verification
- workflow YAML parse check
- `git diff --check`
