### PR TITLE
fix: publish existing versions from packages

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -23,22 +23,30 @@ version_if_needed() {
   fi
 }
 
+publish_packages() {
+  if [ "$VERSION_BUMP" = "existing" ]; then
+    lerna publish from-package --yes "$@"
+  else
+    lerna publish from-git --yes "$@"
+  fi
+}
+
 case "$RELEASE_TYPE" in
   "beta")
     SKIP_VERSION_SCRIPTS=true version_if_needed --force-publish=*
-    lerna publish from-git --yes --dist-tag beta
+    publish_packages --dist-tag beta
     ;;
   "next")
     SKIP_VERSION_SCRIPTS=true version_if_needed
-    lerna publish from-git --yes --dist-tag next
+    publish_packages --dist-tag next
     ;;
   "canary")
     SKIP_VERSION_SCRIPTS=true lerna version major --yes
-    lerna publish from-git --yes --canary --preid alpha --dist-tag alpha
+    publish_packages --canary --preid alpha --dist-tag alpha
     ;;
   *)
     # release (default) - 只有这个会执行完整的 version 脚本
     version_if_needed
-    lerna publish from-git --yes
+    publish_packages
     ;;
 esac


### PR DESCRIPTION
## Summary
- use `lerna publish from-package` when retrying an existing version
- keep `from-git` for normal releases

The previous recovery run exited successfully without publishing because Lerna reported `from-git No tagged release found`. The existing `v4.2.2` packages need to be selected by comparing local package versions with npm, which is what `from-package` does.

## Verification
- `bash -n scripts/publish.sh`
- workflow YAML parse check
- `git diff --check`
