### PR TITLE
fix: create github release after publishing

### DIFF
--- a/scripts/create_github_release.js
+++ b/scripts/create_github_release.js
@@ -1,0 +1,123 @@
+const https = require('https');
+const { readFileSync } = require('fs');
+const { join } = require('path');
+
+const currentVersion = require('../lerna.json').version;
+const token = process.env.GITHUB_AUTH || process.env.GITHUB_TOKEN;
+
+if (!token) {
+  console.error('Must provide GITHUB_AUTH or GITHUB_TOKEN');
+  process.exit(1);
+}
+
+function getVersionChangelog() {
+  const changelog = readFileSync(join(__dirname, '../CHANGELOG.md'), 'utf8');
+  const heading = `## v${currentVersion} `;
+  const start = changelog.indexOf(heading);
+
+  if (start === -1) {
+    throw new Error(`Could not find changelog for v${currentVersion}`);
+  }
+
+  const nextHeading = changelog.indexOf('\n## ', start + heading.length);
+  return changelog
+    .slice(start, nextHeading === -1 ? undefined : nextHeading)
+    .trim();
+}
+
+function request(method, path, body) {
+  return new Promise((resolve, reject) => {
+    const payload = body ? JSON.stringify(body) : undefined;
+    const request = https.request(
+      {
+        hostname: 'api.github.com',
+        path,
+        method,
+        headers: {
+          Accept: 'application/vnd.github+json',
+          Authorization: `Bearer ${token}`,
+          'User-Agent': 'midway-release-workflow',
+          'X-GitHub-Api-Version': '2022-11-28',
+          ...(payload
+            ? {
+                'Content-Type': 'application/json',
+                'Content-Length': Buffer.byteLength(payload),
+              }
+            : {}),
+        },
+      },
+      response => {
+        let responseBody = '';
+        response.setEncoding('utf8');
+        response.on('data', chunk => (responseBody += chunk));
+        response.on('end', () => {
+          let parsedBody;
+          try {
+            parsedBody = responseBody ? JSON.parse(responseBody) : undefined;
+          } catch {
+            parsedBody = responseBody;
+          }
+
+          if (response.statusCode < 200 || response.statusCode >= 300) {
+            reject(
+              new Error(
+                `GitHub API ${method} ${path} failed (${response.statusCode}): ${JSON.stringify(parsedBody)}`
+              )
+            );
+            return;
+          }
+          resolve(parsedBody);
+        });
+      }
+    );
+    request.on('error', reject);
+    if (payload) request.write(payload);
+    request.end();
+  });
+}
+
+async function main() {
+  const tag = `v${currentVersion}`;
+  const body = getVersionChangelog();
+  const releaseData = {
+    tag_name: tag,
+    target_commitish: process.env.GITHUB_REF_NAME || 'v4-next',
+    name: currentVersion,
+    body,
+    draft: false,
+    prerelease: false,
+    generate_release_notes: false,
+  };
+
+  let release;
+  try {
+    release = await request(
+      'GET',
+      `/repos/midwayjs/midway/releases/tags/${tag}`
+    );
+    release = await request(
+      'PATCH',
+      `/repos/midwayjs/midway/releases/${release.id}`,
+      releaseData
+    );
+    console.log(`Updated GitHub release ${release.html_url || tag}`);
+    return;
+  } catch (error) {
+    if (!error.message.includes('(404)')) {
+      throw error;
+    }
+  }
+
+  release = await request(
+    'POST',
+    '/repos/midwayjs/midway/releases',
+    releaseData
+  );
+
+  console.log(`Created GitHub release ${release.html_url || tag}`);
+}
+
+main().catch(error => {
+  console.error(error.message);
+  process.exit(1);
+});

--- a/scripts/generate_changelog.js
+++ b/scripts/generate_changelog.js
@@ -4,11 +4,6 @@ const { join } = require('path');
 
 const currentVersion = require('../lerna.json').version;
 
-if (!process.env.GITHUB_AUTH) {
-  console.error('Must provide GITHUB_AUTH');
-  process.exit(1);
-}
-
 try {
   const changelogContent = execSync(
     `npx lerna-changelog --nextVersion=v${currentVersion}`
@@ -23,19 +18,6 @@ try {
       '\n\n' + changelogContent + '\n\n'
     );
     writeFileSync(changelogFile, originContent);
-
-    console.log('start create release for version: ', currentVersion);
-
-    const url = `
-    curl \
-    -X POST \
-    -H "Accept: application/vnd.github+json" \
-    -H "Authorization: Bearer ${process.env.GITHUB_AUTH}" \
-    https://api.github.com/repos/midwayjs/midway/releases \
-    -d '{"tag_name":"v${currentVersion}","target_commitish":"main","name":"${currentVersion}","body":"${changelogContent}","draft":false,"prerelease":false,"generate_release_notes":false}'
-    `;
-
-    execSync(url).toString();
   } else {
     console.log('version not generate and skip changelog');
     process.exit(1);

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -48,5 +48,6 @@ case "$RELEASE_TYPE" in
     # release (default) - 只有这个会执行完整的 version 脚本
     version_if_needed
     publish_packages
+    node scripts/create_github_release.js
     ;;
 esac


### PR DESCRIPTION
## What
- generate changelog without calling GitHub before the tag exists
- create or update the matching GitHub Release after npm publish completes
- use structured JSON requests and fail with the GitHub API error

## Validation
- node --check
- bash -n scripts/publish.sh
- mwts check