### PR TITLE
fix(deps): make security upgrades compatible

### DIFF
--- a/packages/axios/package.json
+++ b/packages/axios/package.json
@@ -15,7 +15,7 @@
     "nock": "13.5.6"
   },
   "dependencies": {
-    "axios": "1.13.5"
+    "axios": "1.18.0"
   },
   "keywords": [
     "http client",

--- a/packages/axios/test/index.test.ts
+++ b/packages/axios/test/index.test.ts
@@ -69,7 +69,7 @@ describe('/test/index.test.ts', () => {
 
   it('should test defaults and interceptors', () => {
     expect(Axios.get).toBeDefined();
-    expect(httpService.defaults).toStrictEqual(Axios.defaults);
+    expect(httpService.defaults).toEqual(Axios.defaults);
     expect(httpService.interceptors.response).toStrictEqual(
       Axios.interceptors.response
     );

--- a/packages/busboy/package.json
+++ b/packages/busboy/package.json
@@ -6,7 +6,7 @@
   "typings": "index.d.ts",
   "scripts": {
     "build": "tsc",
-    "test": "node -r ts-node/register ../../node_modules/jest/bin/jest.js --runInBand",
+    "test": "node --experimental-vm-modules -r ts-node/register ../../node_modules/jest/bin/jest.js --runInBand",
     "cov": "node -r ts-node/register ../../node_modules/jest/bin/jest.js --runInBand --coverage --forceExit",
     "ci": "npm run test"
   },
@@ -28,7 +28,7 @@
   "dependencies": {
     "@types/busboy": "1.5.4",
     "busboy": "1.6.0",
-    "file-type": "16.5.4"
+    "file-type": "21.3.1"
   },
   "devDependencies": {
     "@midwayjs/core": "workspace:^",

--- a/packages/busboy/src/middleware.ts
+++ b/packages/busboy/src/middleware.ts
@@ -29,7 +29,6 @@ import {
   UploadMode,
 } from './interface';
 import { parseMultipart } from './parse';
-import { fromBuffer } from 'file-type';
 import { formatExt, streamToAsyncIterator } from './utils';
 import * as busboy from 'busboy';
 import { BusboyConfig } from 'busboy';
@@ -548,7 +547,12 @@ export class UploadMiddleware implements IMiddleware<any, any> {
     if (!mime.length) {
       return { passed: true };
     }
-    const typeInfo = await fromBuffer(data);
+    // file-type v21 exposes a synchronous CommonJS bridge for supported Node versions.
+    const nodeRequire = process
+      .getBuiltinModule('module')
+      .createRequire(__filename);
+    const { fileTypeFromBuffer } = nodeRequire('file-type');
+    const typeInfo = await fileTypeFromBuffer(data);
     if (!typeInfo) {
       return { passed: false, mime: mime.join('、') };
     }

--- a/packages/http-proxy/package.json
+++ b/packages/http-proxy/package.json
@@ -30,7 +30,7 @@
     "url": "https://github.com/midwayjs/midway.git"
   },
   "dependencies": {
-    "axios": "1.13.5"
+    "axios": "1.18.0"
   },
   "devDependencies": {
     "@midwayjs/core": "workspace:^",

--- a/packages/mikro/package.json
+++ b/packages/mikro/package.json
@@ -16,9 +16,9 @@
     "@midwayjs/core": "workspace:^",
     "@midwayjs/koa": "workspace:^",
     "@midwayjs/mock": "workspace:^",
-    "@mikro-orm/core": "6.4.5",
-    "@mikro-orm/entity-generator": "6.4.5",
-    "@mikro-orm/sqlite": "6.4.5"
+    "@mikro-orm/core": "6.6.10",
+    "@mikro-orm/entity-generator": "6.6.10",
+    "@mikro-orm/sqlite": "6.6.10"
   },
   "author": {
     "name": "czy88840616",

--- a/packages/upload/package.json
+++ b/packages/upload/package.json
@@ -6,7 +6,7 @@
   "typings": "index.d.ts",
   "scripts": {
     "build": "tsc",
-    "test": "node -r ts-node/register ../../node_modules/jest/bin/jest.js --runInBand",
+    "test": "node --experimental-vm-modules -r ts-node/register ../../node_modules/jest/bin/jest.js --runInBand",
     "cov": "node -r ts-node/register ../../node_modules/jest/bin/jest.js --runInBand --coverage --forceExit",
     "ci": "npm run test"
   },
@@ -26,7 +26,7 @@
     "url": "https://github.com/midwayjs/midway.git"
   },
   "dependencies": {
-    "file-type": "16.5.4",
+    "file-type": "21.3.1",
     "raw-body": "2.5.2"
   },
   "devDependencies": {

--- a/packages/upload/src/middleware.ts
+++ b/packages/upload/src/middleware.ts
@@ -19,7 +19,6 @@ import {
 } from '.';
 import { parseFromReadableStream, parseMultipart } from './parse';
 import * as getRawBody from 'raw-body';
-import { fromBuffer } from 'file-type';
 import { formatExt } from './utils';
 
 const { unlink, writeFile } = promises;
@@ -297,7 +296,12 @@ export class UploadMiddleware implements IMiddleware<any, any> {
     if (!mime.length) {
       return { passed: true };
     }
-    const typeInfo = await fromBuffer(data);
+    // file-type v21 exposes a synchronous CommonJS bridge for supported Node versions.
+    const nodeRequire = process
+      .getBuiltinModule('module')
+      .createRequire(__filename);
+    const { fileTypeFromBuffer } = nodeRequire('file-type');
+    const typeInfo = await fileTypeFromBuffer(data);
     if (!typeInfo) {
       return { passed: false, mime: mime.join('、') };
     }

--- a/packages/validate/package.json
+++ b/packages/validate/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@midwayjs/i18n": "workspace:^",
-    "joi": "17.13.3"
+    "joi": "17.13.4"
   },
   "devDependencies": {
     "@midwayjs/core": "workspace:^",

--- a/packages/validation-joi/package.json
+++ b/packages/validation-joi/package.json
@@ -45,7 +45,7 @@
     "@midwayjs/core": "workspace:^",
     "@midwayjs/koa": "workspace:^",
     "@midwayjs/mock": "workspace:^",
-    "joi": "17.13.3",
+    "joi": "17.13.4",
     "tsup": "8.5.1"
   }
 }

--- a/packages/web-express/package.json
+++ b/packages/web-express/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@midwayjs/express-session": "workspace:^",
-    "body-parser": "2.2.2",
+    "body-parser": "2.3.0",
     "cookie-parser": "^1.4.6",
     "express": "4.22.2"
   },

--- a/packages/web-koa/package.json
+++ b/packages/web-koa/package.json
@@ -27,7 +27,7 @@
     "@midwayjs/core": "workspace:^",
     "@midwayjs/mock": "workspace:^",
     "@types/koa-router": "7.4.9",
-    "axios": "1.13.5",
+    "axios": "1.18.0",
     "fs-extra": "11.3.4"
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,10 +10,10 @@ importers:
     devDependencies:
       '@babel/plugin-proposal-decorators':
         specifier: 7.25.9
-        version: 7.25.9(@babel/core@7.28.5(supports-color@7.2.0))(supports-color@7.2.0)
+        version: 7.25.9(@babel/core@7.28.5)
       '@nrwl/tao':
         specifier: 16.10.0
-        version: 16.10.0(debug@4.4.3(supports-color@7.2.0))
+        version: 16.10.0
       '@types/jest':
         specifier: 29.5.14
         version: 29.5.14
@@ -34,25 +34,25 @@ importers:
         version: 11.3.4
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@22.12.0)(supports-color@7.2.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3))
+        version: 29.7.0(@types/node@22.12.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3))
       lerna:
         specifier: 9.0.7
-        version: 9.0.7(@types/node@22.12.0)(supports-color@7.2.0)
+        version: 9.0.7(@types/node@22.12.0)
       lerna-changelog:
         specifier: 2.2.0
-        version: 2.2.0(supports-color@7.2.0)
+        version: 2.2.0
       madge:
         specifier: 6.1.0
-        version: 6.1.0(supports-color@7.2.0)(typescript@5.6.3)
+        version: 6.1.0(typescript@5.6.3)
       mwts:
         specifier: 2.0.4
-        version: 2.0.4(@types/eslint@9.6.1)(supports-color@7.2.0)(typescript@5.6.3)
+        version: 2.0.4(@types/eslint@9.6.1)(typescript@5.6.3)
       tree-kill:
         specifier: 1.2.2
         version: 1.2.2
       ts-jest:
         specifier: 29.2.5
-        version: 29.2.5(@babel/core@7.28.5(supports-color@7.2.0))(@jest/transform@29.7.0(supports-color@7.2.0))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5(supports-color@7.2.0))(supports-color@7.2.0))(esbuild@0.27.3)(jest@29.7.0(@types/node@22.12.0)(supports-color@7.2.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3)))(typescript@5.6.3)
+        version: 29.2.5(@babel/core@7.28.5)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(jest@29.7.0(@types/node@22.12.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3)))(typescript@5.6.3)
       ts-node:
         specifier: 10.9.2
         version: 10.9.2(@types/node@22.12.0)(typescript@5.6.3)
@@ -144,13 +144,13 @@ importers:
     devDependencies:
       tsup:
         specifier: 8.5.1
-        version: 8.5.1(postcss@8.5.6)(supports-color@7.2.0)(tsx@4.21.0)(typescript@5.6.3)(yaml@2.9.0)
+        version: 8.5.1(postcss@8.5.6)(tsx@4.21.0)(typescript@5.6.3)(yaml@2.9.0)
 
   packages/apollo:
     dependencies:
       '@apollo/server':
         specifier: 5.5.1
-        version: 5.5.1(graphql@16.14.2)(supports-color@7.2.0)
+        version: 5.5.1(graphql@16.14.2)
       '@graphql-tools/schema':
         specifier: 10.0.38
         version: 10.0.38(graphql@16.14.2)
@@ -189,8 +189,8 @@ importers:
   packages/axios:
     dependencies:
       axios:
-        specifier: 1.13.5
-        version: 1.13.5(debug@4.4.3(supports-color@8.1.1))
+        specifier: 1.18.0
+        version: 1.18.0
     devDependencies:
       '@midwayjs/core':
         specifier: workspace:^
@@ -200,7 +200,7 @@ importers:
         version: link:../mock
       nock:
         specifier: 13.5.6
-        version: 13.5.6(supports-color@7.2.0)
+        version: 13.5.6
 
   packages/bootstrap:
     dependencies:
@@ -219,13 +219,13 @@ importers:
         version: 2.88.2
       socket.io-client:
         specifier: 4.8.1
-        version: 4.8.1(supports-color@7.2.0)
+        version: 4.8.1
 
   packages/bull:
     dependencies:
       bull:
         specifier: 4.16.5
-        version: 4.16.5(supports-color@7.2.0)
+        version: 4.16.5
     devDependencies:
       '@midwayjs/core':
         specifier: workspace:^
@@ -269,7 +269,7 @@ importers:
     dependencies:
       bullmq:
         specifier: 5.71.0
-        version: 5.71.0(supports-color@8.1.1)
+        version: 5.71.0
     devDependencies:
       '@midwayjs/core':
         specifier: workspace:^
@@ -287,8 +287,8 @@ importers:
         specifier: 1.6.0
         version: 1.6.0
       file-type:
-        specifier: 16.5.4
-        version: 16.5.4
+        specifier: 21.3.1
+        version: 21.3.1
     devDependencies:
       '@midwayjs/core':
         specifier: workspace:^
@@ -347,7 +347,7 @@ importers:
         version: 6.0.0
       cache-manager-ioredis-yet:
         specifier: 2.1.2
-        version: 2.1.2(supports-color@7.2.0)
+        version: 2.1.2
 
   packages/captcha:
     dependencies:
@@ -413,7 +413,7 @@ importers:
         version: 5.38.0
       ioredis:
         specifier: 5.4.2
-        version: 5.4.2(supports-color@7.2.0)
+        version: 5.4.2
 
   packages/casbin-typeorm-adapter:
     dependencies:
@@ -441,7 +441,7 @@ importers:
         version: 5.38.0
       typeorm:
         specifier: 1.1.0
-        version: 1.1.0(better-sqlite3@12.9.0)(ioredis@5.9.3(supports-color@8.1.1))(mysql2@3.16.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3))
+        version: 1.1.0(better-sqlite3@12.9.0)(ioredis@5.9.3)(mysql2@3.16.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3))
 
   packages/code-dye:
     devDependencies:
@@ -503,7 +503,7 @@ importers:
         version: 17.0.4
       nock:
         specifier: 13.5.6
-        version: 13.5.6(supports-color@8.1.1)
+        version: 13.5.6
 
   packages/core:
     dependencies:
@@ -622,19 +622,19 @@ importers:
         version: link:../typeorm
       mongoose:
         specifier: 8.9.5
-        version: 8.9.5(socks@2.8.7)(supports-color@7.2.0)
+        version: 8.9.5(socks@2.8.7)
       sequelize:
         specifier: 6.37.8
-        version: 6.37.8(mysql2@3.16.0)(sqlite3@5.1.7(supports-color@8.1.1))(supports-color@7.2.0)
+        version: 6.37.8(mysql2@3.16.0)(sqlite3@5.1.7)
       sequelize-typescript:
         specifier: 2.1.6
-        version: 2.1.6(@types/node@22.12.0)(@types/validator@13.15.10)(reflect-metadata@0.2.2)(sequelize@6.37.8(mysql2@3.16.0)(sqlite3@5.1.7(supports-color@8.1.1))(supports-color@7.2.0))
+        version: 2.1.6(@types/node@22.12.0)(@types/validator@13.15.10)(reflect-metadata@0.2.2)(sequelize@6.37.8(sqlite3@5.1.7))
       sqlite3:
         specifier: 5.1.7
-        version: 5.1.7(supports-color@8.1.1)
+        version: 5.1.7
       typeorm:
         specifier: 1.1.0
-        version: 1.1.0(better-sqlite3@12.9.0)(ioredis@5.9.3(supports-color@8.1.1))(mysql2@3.16.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3))
+        version: 1.1.0(better-sqlite3@12.9.0)(ioredis@5.9.3)(mysql2@3.16.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3))
 
   packages/etcd:
     dependencies:
@@ -666,10 +666,10 @@ importers:
     dependencies:
       cookie-session:
         specifier: ^2.0.0
-        version: 2.1.1(supports-color@8.1.1)
+        version: 2.1.1
       express-session:
         specifier: 1.18.1
-        version: 1.18.1(supports-color@8.1.1)
+        version: 1.18.1
     devDependencies:
       '@midwayjs/core':
         specifier: workspace:^
@@ -682,7 +682,7 @@ importers:
         version: 1.18.1
       memorystore:
         specifier: 1.6.7
-        version: 1.6.7(supports-color@7.2.0)
+        version: 1.6.7
 
   packages/faas:
     dependencies:
@@ -691,7 +691,7 @@ importers:
         version: link:../core
       '@midwayjs/serverless-http-parser':
         specifier: ^4.0.2
-        version: 4.0.2
+        version: link:../../packages-serverless/serverless-http-parser
       '@midwayjs/simple-lock':
         specifier: ^1.1.4
         version: 1.2.2
@@ -737,8 +737,8 @@ importers:
   packages/http-proxy:
     dependencies:
       axios:
-        specifier: 1.13.5
-        version: 1.13.5(debug@4.4.3(supports-color@8.1.1))
+        specifier: 1.18.0
+        version: 1.18.0
     devDependencies:
       '@midwayjs/core':
         specifier: workspace:^
@@ -760,7 +760,7 @@ importers:
         version: link:../web
       nock:
         specifier: 13.5.6
-        version: 13.5.6(supports-color@8.1.1)
+        version: 13.5.6
 
   packages/i18n:
     dependencies:
@@ -842,7 +842,7 @@ importers:
     dependencies:
       leoric:
         specifier: 2.14.0
-        version: 2.14.0(mysql2@3.16.0)(sqlite3@5.1.7(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 2.14.0(mysql2@3.16.0)(sqlite3@5.1.7)
     devDependencies:
       '@midwayjs/core':
         specifier: workspace:^
@@ -855,7 +855,7 @@ importers:
         version: link:../mock
       sqlite3:
         specifier: 5.1.7
-        version: 5.1.7(supports-color@8.1.1)
+        version: 5.1.7
 
   packages/mcp:
     dependencies:
@@ -874,7 +874,7 @@ importers:
         version: link:../mock
       '@modelcontextprotocol/sdk':
         specifier: 1.26.0
-        version: 1.26.0(supports-color@8.1.1)(zod@3.25.76)
+        version: 1.26.0(zod@3.25.76)
       zod:
         specifier: 3.25.76
         version: 3.25.76
@@ -891,14 +891,14 @@ importers:
         specifier: workspace:^
         version: link:../mock
       '@mikro-orm/core':
-        specifier: 6.4.5
-        version: 6.4.5
+        specifier: 6.6.10
+        version: 6.6.10
       '@mikro-orm/entity-generator':
-        specifier: 6.4.5
-        version: 6.4.5(@mikro-orm/core@6.4.5)(better-sqlite3@12.9.0)(mysql2@3.16.0)(sqlite3@5.1.7(supports-color@8.1.1))(supports-color@8.1.1)
+        specifier: 6.6.10
+        version: 6.6.10(@mikro-orm/core@6.6.10)(better-sqlite3@12.9.0)
       '@mikro-orm/sqlite':
-        specifier: 6.4.5
-        version: 6.4.5(@mikro-orm/core@6.4.5)(better-sqlite3@12.9.0)(mysql2@3.16.0)(supports-color@8.1.1)
+        specifier: 6.6.10
+        version: 6.6.10(@mikro-orm/core@6.6.10)(better-sqlite3@12.9.0)
 
   packages/mikro7:
     devDependencies:
@@ -940,7 +940,7 @@ importers:
         version: 2.5.2
       supertest:
         specifier: 6.3.4
-        version: 6.3.4(supports-color@7.2.0)
+        version: 6.3.4
     devDependencies:
       '@midwayjs/core':
         specifier: workspace:^
@@ -959,10 +959,10 @@ importers:
         version: 2.2.4
       socket.io:
         specifier: 4.8.1
-        version: 4.8.1(supports-color@7.2.0)
+        version: 4.8.1
       socket.io-client:
         specifier: 4.8.1
-        version: 4.8.1(supports-color@8.1.1)
+        version: 4.8.1
       ws:
         specifier: 8.21.0
         version: 8.21.0
@@ -977,13 +977,13 @@ importers:
         version: link:../mock
       mongoose:
         specifier: 8.9.5
-        version: 8.9.5(socks@2.8.7)(supports-color@8.1.1)
+        version: 8.9.5(socks@2.8.7)
 
   packages/mqtt:
     dependencies:
       mqtt:
         specifier: 5.15.2
-        version: 5.15.2(supports-color@7.2.0)
+        version: 5.15.2
     devDependencies:
       '@midwayjs/core':
         specifier: workspace:^
@@ -1012,13 +1012,13 @@ importers:
         version: 18.3.27
       babel-loader:
         specifier: ^9.2.1
-        version: 9.2.1(@babel/core@7.28.5(supports-color@8.1.1))(webpack@5.104.1(esbuild@0.27.3)(uglify-js@3.19.3))
+        version: 9.2.1(@babel/core@7.28.5)(webpack@5.104.1)
       next:
         specifier: ~16.2.0
-        version: 16.2.12(@babel/core@7.28.5(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 16.2.12(@babel/core@7.28.5)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       null-loader:
         specifier: ^4.0.1
-        version: 4.0.1(webpack@5.104.1(esbuild@0.27.3)(uglify-js@3.19.3))
+        version: 4.0.1(webpack@5.104.1)
       react:
         specifier: ^18
         version: 18.3.1
@@ -1043,7 +1043,7 @@ importers:
         version: 6.23.3
       ali-oss:
         specifier: 6.23.0
-        version: 6.23.0(supports-color@7.2.0)
+        version: 6.23.0
     devDependencies:
       '@midwayjs/core':
         specifier: workspace:^
@@ -1083,7 +1083,7 @@ importers:
         version: 0.8.2
       express-session:
         specifier: 1.18.1
-        version: 1.18.1(supports-color@8.1.1)
+        version: 1.18.1
       passport-http-bearer:
         specifier: 1.0.1
         version: 1.0.1
@@ -1176,7 +1176,7 @@ importers:
         version: link:../web
       egg:
         specifier: ^2.28.0
-        version: 2.37.0(supports-color@8.1.1)
+        version: 2.37.0
 
   packages/rabbitmq:
     dependencies:
@@ -1220,13 +1220,13 @@ importers:
         version: 18.3.1(react@18.3.1)
       tsup:
         specifier: 8.5.1
-        version: 8.5.1(postcss@8.5.6)(supports-color@8.1.1)(tsx@4.21.0)(typescript@5.6.3)(yaml@2.9.0)
+        version: 8.5.1(postcss@8.5.6)(tsx@4.21.0)(typescript@5.6.3)(yaml@2.9.0)
 
   packages/redis:
     dependencies:
       ioredis:
         specifier: 5.4.2
-        version: 5.4.2(supports-color@8.1.1)
+        version: 5.4.2
     devDependencies:
       '@midwayjs/core':
         specifier: workspace:^
@@ -1285,13 +1285,13 @@ importers:
         version: link:../mock
       sequelize:
         specifier: 6.37.8
-        version: 6.37.8(mysql2@3.16.0)(sqlite3@5.1.7(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 6.37.8(mysql2@3.16.0)(sqlite3@5.1.7)
       sequelize-typescript:
         specifier: 2.1.6
-        version: 2.1.6(@types/node@22.12.0)(@types/validator@13.15.10)(reflect-metadata@0.2.2)(sequelize@6.37.8(mysql2@3.16.0)(sqlite3@5.1.7(supports-color@8.1.1))(supports-color@8.1.1))
+        version: 2.1.6(@types/node@22.12.0)(@types/validator@13.15.10)(reflect-metadata@0.2.2)(sequelize@6.37.8(sqlite3@5.1.7))
       sqlite3:
         specifier: 5.1.7
-        version: 5.1.7(supports-color@8.1.1)
+        version: 5.1.7
 
   packages/session:
     dependencies:
@@ -1326,7 +1326,7 @@ importers:
     dependencies:
       socket.io:
         specifier: 4.8.1
-        version: 4.8.1(supports-color@8.1.1)
+        version: 4.8.1
     devDependencies:
       '@midwayjs/core':
         specifier: workspace:^
@@ -1336,7 +1336,7 @@ importers:
         version: 11.3.4
       socket.io-client:
         specifier: 4.8.1
-        version: 4.8.1(supports-color@8.1.1)
+        version: 4.8.1
 
   packages/static-file:
     dependencies:
@@ -1345,7 +1345,7 @@ importers:
         version: 0.3.0
       koa-static-cache:
         specifier: 5.1.4
-        version: 5.1.4(supports-color@8.1.1)
+        version: 5.1.4
       ylru:
         specifier: 1.4.0
         version: 1.4.0
@@ -1447,10 +1447,10 @@ importers:
         version: link:../mock
       '@typegoose/typegoose':
         specifier: 12.10.1
-        version: 12.10.1(mongoose@8.9.5(socks@2.8.7)(supports-color@8.1.1))
+        version: 12.10.1(mongoose@8.9.5(socks@2.8.7))
       mongoose:
         specifier: 8.9.5
-        version: 8.9.5(socks@2.8.7)(supports-color@8.1.1)
+        version: 8.9.5(socks@2.8.7)
 
   packages/typeorm:
     devDependencies:
@@ -1465,13 +1465,13 @@ importers:
         version: 12.9.0
       typeorm:
         specifier: 1.1.0
-        version: 1.1.0(better-sqlite3@12.9.0)(ioredis@5.9.3(supports-color@8.1.1))(mysql2@3.16.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3))
+        version: 1.1.0(better-sqlite3@12.9.0)(ioredis@5.9.3)(mysql2@3.16.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3))
 
   packages/upload:
     dependencies:
       file-type:
-        specifier: 16.5.4
-        version: 16.5.4
+        specifier: 21.3.1
+        version: 21.3.1
       raw-body:
         specifier: 2.5.2
         version: 2.5.2
@@ -1501,8 +1501,8 @@ importers:
         specifier: workspace:^
         version: link:../i18n
       joi:
-        specifier: 17.13.3
-        version: 17.13.3
+        specifier: 17.13.4
+        version: 17.13.4
     devDependencies:
       '@midwayjs/core':
         specifier: workspace:^
@@ -1565,7 +1565,7 @@ importers:
         version: 0.14.3
       tsup:
         specifier: 8.5.1
-        version: 8.5.1(postcss@8.5.6)(supports-color@8.1.1)(tsx@4.21.0)(typescript@5.6.3)(yaml@2.9.0)
+        version: 8.5.1(postcss@8.5.6)(tsx@4.21.0)(typescript@5.6.3)(yaml@2.9.0)
 
   packages/validation-joi:
     dependencies:
@@ -1586,11 +1586,11 @@ importers:
         specifier: workspace:^
         version: link:../mock
       joi:
-        specifier: 17.13.3
-        version: 17.13.3
+        specifier: 17.13.4
+        version: 17.13.4
       tsup:
         specifier: 8.5.1
-        version: 8.5.1(postcss@8.5.6)(supports-color@8.1.1)(tsx@4.21.0)(typescript@5.6.3)(yaml@2.9.0)
+        version: 8.5.1(postcss@8.5.6)(tsx@4.21.0)(typescript@5.6.3)(yaml@2.9.0)
 
   packages/validation-zod:
     dependencies:
@@ -1615,7 +1615,7 @@ importers:
         version: link:../core
       tsup:
         specifier: 8.5.1
-        version: 8.5.1(postcss@8.5.6)(supports-color@8.1.1)(tsx@4.21.0)(typescript@5.6.3)(yaml@2.9.0)
+        version: 8.5.1(postcss@8.5.6)(tsx@4.21.0)(typescript@5.6.3)(yaml@2.9.0)
       zod:
         specifier: 3.25.76
         version: 3.25.76
@@ -1643,7 +1643,7 @@ importers:
         version: link:../core
       tsup:
         specifier: 8.5.1
-        version: 8.5.1(postcss@8.5.6)(supports-color@8.1.1)(tsx@4.21.0)(typescript@5.6.3)(yaml@2.9.0)
+        version: 8.5.1(postcss@8.5.6)(tsx@4.21.0)(typescript@5.6.3)(yaml@2.9.0)
       zod:
         specifier: 4.2.1
         version: 4.2.1
@@ -1708,7 +1708,7 @@ importers:
     devDependencies:
       tsup:
         specifier: 8.5.1
-        version: 8.5.1(postcss@8.5.6)(supports-color@8.1.1)(tsx@4.21.0)(typescript@5.6.3)(yaml@2.9.0)
+        version: 8.5.1(postcss@8.5.6)(tsx@4.21.0)(typescript@5.6.3)(yaml@2.9.0)
       vue:
         specifier: ^3.5.22
         version: 3.5.28(typescript@5.6.3)
@@ -1723,10 +1723,10 @@ importers:
         version: link:../core
       egg:
         specifier: ^2.28.0
-        version: 2.37.0(supports-color@8.1.1)
+        version: 2.37.0
       egg-cluster:
         specifier: ^1.27.1
-        version: 1.27.1(supports-color@8.1.1)
+        version: 1.27.1
       egg-path-matching:
         specifier: ^2.1.0
         version: 2.1.0
@@ -1757,19 +1757,19 @@ importers:
         version: 3.6.1
       egg-mock:
         specifier: 4.2.1
-        version: 4.2.1(supports-color@8.1.1)
+        version: 4.2.1
       egg-scripts:
         specifier: 3.1.0
-        version: 3.1.0(supports-color@7.2.0)
+        version: 3.1.0
       egg-socket.io:
         specifier: 4.1.6
-        version: 4.1.6(supports-color@8.1.1)
+        version: 4.1.6
       egg-view-nunjucks:
         specifier: 2.3.0
         version: 2.3.0(chokidar@3.6.0)
       fake-egg:
         specifier: 1.0.0
-        version: 1.0.0(supports-color@8.1.1)
+        version: 1.0.0
       fs-extra:
         specifier: 11.3.4
         version: 11.3.4
@@ -1793,7 +1793,7 @@ importers:
         version: 17.0.2(react@17.0.2)
       supertest:
         specifier: 6.3.4
-        version: 6.3.4(supports-color@8.1.1)
+        version: 6.3.4
 
   packages/web-bridge:
     dependencies:
@@ -1803,7 +1803,7 @@ importers:
     devDependencies:
       tsup:
         specifier: 8.5.1
-        version: 8.5.1(postcss@8.5.6)(supports-color@8.1.1)(tsx@4.21.0)(typescript@5.6.3)(yaml@2.9.0)
+        version: 8.5.1(postcss@8.5.6)(tsx@4.21.0)(typescript@5.6.3)(yaml@2.9.0)
 
   packages/web-express:
     dependencies:
@@ -1811,14 +1811,14 @@ importers:
         specifier: workspace:^
         version: link:../express-session
       body-parser:
-        specifier: 2.2.2
-        version: 2.2.2(supports-color@8.1.1)
+        specifier: 2.3.0
+        version: 2.3.0
       cookie-parser:
         specifier: ^1.4.6
         version: 1.4.7
       express:
         specifier: 4.22.2
-        version: 4.22.2(supports-color@8.1.1)
+        version: 4.22.2
     devDependencies:
       '@midwayjs/core':
         specifier: workspace:^
@@ -1840,7 +1840,7 @@ importers:
     dependencies:
       '@koa/router':
         specifier: ^12.0.0
-        version: 12.0.2(supports-color@7.2.0)
+        version: 12.0.2
       '@midwayjs/cookies':
         specifier: ^1.3.0
         version: 1.3.0
@@ -1873,8 +1873,8 @@ importers:
         specifier: 7.4.9
         version: 7.4.9
       axios:
-        specifier: 1.13.5
-        version: 1.13.5(debug@4.4.3(supports-color@8.1.1))
+        specifier: 1.18.0
+        version: 1.18.0
       fs-extra:
         specifier: 11.3.4
         version: 11.3.4
@@ -1982,7 +1982,7 @@ importers:
         version: link:../../packages/validation-joi
       joi:
         specifier: ^17.13.3
-        version: 17.13.3
+        version: 17.13.4
     devDependencies:
       '@midwayjs/mock':
         specifier: workspace:*
@@ -2001,7 +2001,7 @@ importers:
         version: 10.8.2
       mwts:
         specifier: ^1.3.0
-        version: 1.3.0(supports-color@8.1.1)(typescript@5.6.3)
+        version: 1.3.0(typescript@5.6.3)
       mwtsc:
         specifier: ^1.4.0
         version: 1.16.0
@@ -2044,7 +2044,7 @@ importers:
         version: 18.3.7(@types/react@18.3.27)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(supports-color@8.1.1)(vite@6.4.3(@types/node@22.12.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.7.0(vite@6.4.3(@types/node@22.12.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -2077,7 +2077,7 @@ importers:
         version: link:../../packages/web-bridge
       axios:
         specifier: ^1.13.2
-        version: 1.19.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 1.19.0
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -2096,7 +2096,7 @@ importers:
         version: 18.3.7(@types/react@18.3.27)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(supports-color@8.1.1)(vite@6.4.3(@types/node@22.12.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.7.0(vite@6.4.3(@types/node@22.12.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -2139,7 +2139,7 @@ importers:
         version: link:../../packages/mock
       '@rspack/cli':
         specifier: ^1.5.6
-        version: 1.7.11(@rspack/core@1.7.11(@swc/helpers@0.5.15))(@types/express@4.17.25)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(tslib@2.8.1)(webpack@5.104.1(esbuild@0.27.3)(uglify-js@3.19.3))
+        version: 1.7.11(@rspack/core@1.7.11(@swc/helpers@0.5.15))(@types/express@4.17.25)(tslib@2.8.1)(webpack@5.104.1)
       '@rspack/core':
         specifier: ^1.5.6
         version: 1.7.11(@swc/helpers@0.5.15)
@@ -2197,7 +2197,7 @@ importers:
         version: 18.3.7(@types/react@18.3.27)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(supports-color@8.1.1)(vite@6.4.3(@types/node@22.12.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.7.0(vite@6.4.3(@types/node@22.12.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -2606,6 +2606,9 @@ packages:
 
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+
+  '@borewit/text-codec@0.2.2':
+    resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
 
   '@bull-board/api@5.23.0':
     resolution: {integrity: sha512-ZZGsWJ+XBG49GAlNgAL9tTEV6Ms7gMkQnZDbzwUhjGChCKWy62RWuPoZSefNXau9QH9+QzlzHRUeFvt4xr5wiw==}
@@ -3129,105 +3132,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -3661,16 +3648,12 @@ packages:
     resolution: {integrity: sha512-8T+EHVGUhOyNtNZWKWz7we7EFCzGoTp4N0idBl9ggyqODj3A/S+o2xABdRsqq6OAthKzMI8zS9pY+Imgzp0KKQ==}
     engines: {node: '>=20'}
 
-  '@midwayjs/serverless-http-parser@4.0.2':
-    resolution: {integrity: sha512-yuaX6++6tYncqLdWJduaZFFGPGr9tR4vdi5Ss5+YXpQpcz1/5nqB4U+x2tXySoS4fYuoimmlMO15LHokwLrc0Q==}
-    engines: {node: '>=12'}
-
   '@midwayjs/simple-lock@1.2.2':
     resolution: {integrity: sha512-0VwK++J76FlvRUj0zfpD1vjV/PTJf8hnZ/OVsMwEUJWVSm2L4bEbcHa+ERKLiprK9tk+fIrDgeX3JB9K8iuGfw==}
     engines: {node: '>= 10'}
 
-  '@mikro-orm/core@6.4.5':
-    resolution: {integrity: sha512-9/CZ5oSbf4P1oBZA2HHKzuxh5yYKDNUZZq/RvJmzMdJDgV8fpTt26po/7J6UytABqZp9yXj1jXc+Kqv73vGGOA==}
+  '@mikro-orm/core@6.6.10':
+    resolution: {integrity: sha512-XdnipWmZ0BG+lzMBv6TykSKGLgBtNwqdJqh4Er+n1kTP0IZmXCtgluzHB66sNXkcYHomuIn2olIVbcVb0m/jDw==}
     engines: {node: '>= 18.12.0'}
 
   '@mikro-orm/core@7.0.13':
@@ -3692,8 +3675,8 @@ packages:
       reflect-metadata:
         optional: true
 
-  '@mikro-orm/entity-generator@6.4.5':
-    resolution: {integrity: sha512-lGTA8lOGmEJvFHJL65RMNbwx8AS36tGuCTjb3+uHk5ADX6xe6bBcd6eB7yXTGAsIX9lzMFvxGZDeqm5tAOc2jw==}
+  '@mikro-orm/entity-generator@6.6.10':
+    resolution: {integrity: sha512-IvpXK32sXo4LW5efK4k/PhGe0Y71JNJuLTvqp6EmmAe1mL9xCJy/7zkRd/DoII7JtLaBe8GXXpV1god/1lGnjQ==}
     engines: {node: '>= 18.12.0'}
     peerDependencies:
       '@mikro-orm/core': ^6.0.0
@@ -3704,8 +3687,8 @@ packages:
     peerDependencies:
       '@mikro-orm/core': 7.0.13
 
-  '@mikro-orm/knex@6.4.5':
-    resolution: {integrity: sha512-5D4NGD9bxmROUf8MVhR4mmZjzQtuM/Sg+eOnfOPzVaIkvuQItE4zR0Bg7gRr1XSgZ/OcJ/6q2ZoXH1HxSjykkw==}
+  '@mikro-orm/knex@6.6.10':
+    resolution: {integrity: sha512-FOGkanJcHhKofjlc63YTpNtlB/7gdFRCfmbsBe2A1r36lx2aFdu2lqEAqFr8mUbOiwfTAQEBH8P9DGhd0T1j8g==}
     engines: {node: '>= 18.12.0'}
     peerDependencies:
       '@mikro-orm/core': ^6.0.0
@@ -3726,8 +3709,8 @@ packages:
     peerDependencies:
       '@mikro-orm/core': 7.0.13
 
-  '@mikro-orm/sqlite@6.4.5':
-    resolution: {integrity: sha512-v/t10BxvMVxCIaqXjytGSZMTc/6YJzNRjUfBe81S4kzAE/YUv7ptWulFaQ2JNoXN7he6+K0JcjYEERlWOgSuIQ==}
+  '@mikro-orm/sqlite@6.6.10':
+    resolution: {integrity: sha512-IYv93QZ4MtuiqUTDkE3Xg9IxDDgDVbHyFwYy8mOdVNAL3lykYWXKibOkmmZ1K+H6sB2QLg7eBcuW9miPer2u0g==}
     engines: {node: '>= 18.12.0'}
     peerDependencies:
       '@mikro-orm/core': ^6.0.0
@@ -3844,49 +3827,42 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/nice-linux-arm64-musl@1.1.1':
     resolution: {integrity: sha512-+2Rzdb3nTIYZ0YJF43qf2twhqOCkiSrHx2Pg6DJaCPYhhaxbLcdlV8hCRMHghQ+EtZQWGNcS2xF4KxBhSGeutg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/nice-linux-ppc64-gnu@1.1.1':
     resolution: {integrity: sha512-4FS8oc0GeHpwvv4tKciKkw3Y4jKsL7FRhaOeiPei0X9T4Jd619wHNe4xCLmN2EMgZoeGg+Q7GY7BsvwKpL22Tg==}
     engines: {node: '>= 10'}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/nice-linux-riscv64-gnu@1.1.1':
     resolution: {integrity: sha512-HU0nw9uD4FO/oGCCk409tCi5IzIZpH2agE6nN4fqpwVlCn5BOq0MS1dXGjXaG17JaAvrlpV5ZeyZwSon10XOXw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/nice-linux-s390x-gnu@1.1.1':
     resolution: {integrity: sha512-2YqKJWWl24EwrX0DzCQgPLKQBxYDdBxOHot1KWEq7aY2uYeX+Uvtv4I8xFVVygJDgf6/92h9N3Y43WPx8+PAgQ==}
     engines: {node: '>= 10'}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/nice-linux-x64-gnu@1.1.1':
     resolution: {integrity: sha512-/gaNz3R92t+dcrfCw/96pDopcmec7oCcAQ3l/M+Zxr82KT4DljD37CpgrnXV+pJC263JkW572pdbP3hP+KjcIg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/nice-linux-x64-musl@1.1.1':
     resolution: {integrity: sha512-xScCGnyj/oppsNPMnevsBe3pvNaoK7FGvMjT35riz9YdhB2WtTG47ZlbxtOLpjeO9SqqQ2J2igCmz6IJOD5JYw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/nice-openharmony-arm64@1.1.1':
     resolution: {integrity: sha512-6uJPRVwVCLDeoOaNyeiW0gp2kFIM4r7PL2MczdZQHkFi9gVlgm+Vn+V6nTWRcu856mJ2WjYJiumEajfSm7arPQ==}
@@ -3942,28 +3918,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.12':
     resolution: {integrity: sha512-0qjhiYBaKAqF63LA1ZWAAnKTzFUguAaZiRa5etMLGGPj/B6uEVjtIZldIzFEp3wHlB0koK6aTzqPtSdplTCjoA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.12':
     resolution: {integrity: sha512-7A3q26W+h7gnA15uqBToNuDqBEFZZcqh0mW2mn4AJh/G5pdg2RVE3n4slzLEliASZFG3NmsbEzng/x2Sh09mBg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.12':
     resolution: {integrity: sha512-qSjL/uppm+cbh21s72Ss8gkiOhQ4dExWHNGOWy6eZV7STj5WsKehgxT61beSsOj+YYQuTplL376lOCdMQU5T8w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.12':
     resolution: {integrity: sha512-X6hzsOUJac/e7AWSbn9gQ9nzHld1xWP5iyjHpYWvud8pufB679O1xg4JDyKr8Xd69Jvd+kM2Der6uftiZCmjYA==}
@@ -4150,52 +4122,44 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@nx/nx-linux-arm64-gnu@22.7.8':
     resolution: {integrity: sha512-Kws8e7W4epfqpTWYaV7KLKaj33o+9JtJa2rErx/XFTtMXhfVzOs5hC4oIrZsYpgk1DuT0APp7UDvX06q2kdAVQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@nx/nx-linux-arm64-musl@16.10.0':
     resolution: {integrity: sha512-uO6Gg+irqpVcCKMcEPIQcTFZ+tDI02AZkqkP7koQAjniLEappd8DnUBSQdcn53T086pHpdc264X/ZEpXFfrKWQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@nx/nx-linux-arm64-musl@22.7.8':
     resolution: {integrity: sha512-fpnyVFL+mSqLdKBPk8+n/rHUEXiem7Xwr9cIOd2Dd5zxQ5wcwj4qSYTNRsBPI2qDFo3esHliwaoFJZULbTHldw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@nx/nx-linux-x64-gnu@16.10.0':
     resolution: {integrity: sha512-134PW/u/arNFAQKpqMJniC7irbChMPz+W+qtyKPAUXE0XFKPa7c1GtlI/wK2dvP9qJDZ6bKf0KtA0U/m2HMUOA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@nx/nx-linux-x64-gnu@22.7.8':
     resolution: {integrity: sha512-KRbkSthClEwkbpt/LLJmBJhIOvOsyrp9OICisF9p3mOODjaxAuYmyOgrVreg09BT2F4hXN3JXpvt9eIZpTCRsw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@nx/nx-linux-x64-musl@16.10.0':
     resolution: {integrity: sha512-q8sINYLdIJxK/iUx9vRk5jWAWb/2O0PAbOJFwv4qkxBv4rLoN7y+otgCZ5v0xfx/zztFgk/oNY4lg5xYjIso2Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@nx/nx-linux-x64-musl@22.7.8':
     resolution: {integrity: sha512-pdPMWko1yZI5ZNI6/t2Y5rQPGgV/ah5DW+mlHo2aFKav4lnxvgisEh9e4HtOsYBfK/9PyYZ5u3M9hLSaMiJ75w==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@nx/nx-win32-arm64-msvc@16.10.0':
     resolution: {integrity: sha512-moJkL9kcqxUdJSRpG7dET3UeLIciwrfP08mzBQ12ewo8K8FzxU8ZUsTIVVdNrwt01CXOdXoweGfdQLjJ4qTURA==}
@@ -4371,67 +4335,56 @@ packages:
     resolution: {integrity: sha512-EHMUcDwhtdRGlXZsGSIuXSYwD5kOT9NVnx9sqzYiwAc91wfYOE1g1djOEDseZJKKqtHAHGwnGPQu3kytmfaXLQ==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.54.0':
     resolution: {integrity: sha512-+pBrqEjaakN2ySv5RVrj/qLytYhPKEUwk+e3SFU5jTLHIcAtqh2rLrd/OkbNuHJpsBgxsD8ccJt5ga/SeG0JmA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.54.0':
     resolution: {integrity: sha512-NSqc7rE9wuUaRBsBp5ckQ5CVz5aIRKCwsoa6WMF7G01sX3/qHUw/z4pv+D+ahL1EIKy6Enpcnz1RY8pf7bjwng==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.54.0':
     resolution: {integrity: sha512-gr5vDbg3Bakga5kbdpqx81m2n9IX8M6gIMlQQIXiLTNeQW6CucvuInJ91EuCJ/JYvc+rcLLsDFcfAD1K7fMofg==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.54.0':
     resolution: {integrity: sha512-gsrtB1NA3ZYj2vq0Rzkylo9ylCtW/PhpLEivlgWe0bpgtX5+9j9EZa0wtZiCjgu6zmSeZWyI/e2YRX1URozpIw==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.54.0':
     resolution: {integrity: sha512-y3qNOfTBStmFNq+t4s7Tmc9hW2ENtPg8FeUD/VShI7rKxNW7O4fFeaYbMsd3tpFlIg1Q8IapFgy7Q9i2BqeBvA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.54.0':
     resolution: {integrity: sha512-89sepv7h2lIVPsFma8iwmccN7Yjjtgz0Rj/Ou6fEqg3HDhpCa+Et+YSufy27i6b0Wav69Qv4WBNl3Rs6pwhebQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.54.0':
     resolution: {integrity: sha512-ZcU77ieh0M2Q8Ur7D5X7KvK+UxbXeDHwiOt/CPSBTI1fBmeDMivW0dPkdqkT4rOgDjrDDBUed9x4EgraIKoR2A==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.54.0':
     resolution: {integrity: sha512-2AdWy5RdDF5+4YfG/YesGDDtbyJlC9LHmL6rZw6FurBJ5n4vFGupsOBGfwMRjBYH7qRQowT8D/U4LoSvVwOhSQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.54.0':
     resolution: {integrity: sha512-WGt5J8Ij/rvyqpFexxk3ffKqqbLf9AqrTBbWDk7ApGUzaIs6V+s2s84kAxklFwmMF/vBNGrVdYgbblCOFFezMQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.54.0':
     resolution: {integrity: sha512-JzQmb38ATzHjxlPHuTH6tE7ojnMKM2kYNzt44LO/jJi8BpceEC8QuXYA908n8r3CNuG/B3BV8VR3Hi1rYtmPiw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.54.0':
     resolution: {integrity: sha512-huT3fd0iC7jigGh7n3q/+lfPcXxBi+om/Rs3yiFxjvSxbSB6aohDFXbWvlspaqjeOh+hx7DDHS+5Es5qRkWkZg==}
@@ -4472,25 +4425,21 @@ packages:
     resolution: {integrity: sha512-P0QrGRPbTWu6RKWfN0bDtbnEps3rXH0MWIMreZABoUrVmNQKtXR6e73J3ub6a+di5s2+K0M2LJ9Bh2/H4UsDUA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rspack/binding-linux-arm64-musl@1.7.11':
     resolution: {integrity: sha512-6ky7R43VMjWwmx3Yx7Jl7faLBBMAgMDt+/bN35RgwjiPgsIByz65EwytUVuW9rikB43BGHvA/eqlnjLrUzNBqw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rspack/binding-linux-x64-gnu@1.7.11':
     resolution: {integrity: sha512-cuOJMfCOvb2Wgsry5enXJ3iT1FGUjdPqtGUBVupQlEG4ntSYsQ2PtF4wIDVasR3wdxC5nQbipOrDiN/u6fYsdQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rspack/binding-linux-x64-musl@1.7.11':
     resolution: {integrity: sha512-CoK37hva4AmHGh3VCsQXmGr40L36m1/AdnN5LEjUX6kx5rEH7/1nEBN6Ii72pejqDVvk9anEROmPDiPw10tpFg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rspack/binding-wasm32-wasi@1.7.11':
     resolution: {integrity: sha512-OtrmnPUVJMxjNa3eDMfHyPdtlLRmmp/aIm0fQHlAOATbZvlGm12q7rhPW5BXTu1yh+1rQ1/uqvz+SzKEZXuJaQ==}
@@ -4660,6 +4609,10 @@ packages:
   '@szmarczak/http-timer@5.0.1':
     resolution: {integrity: sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==}
     engines: {node: '>=14.16'}
+
+  '@tokenizer/inflate@0.4.1':
+    resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
+    engines: {node: '>=18'}
 
   '@tokenizer/token@0.3.0':
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
@@ -5625,8 +5578,8 @@ packages:
   aws4@1.13.2:
     resolution: {integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==}
 
-  axios@1.13.5:
-    resolution: {integrity: sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==}
+  axios@1.18.0:
+    resolution: {integrity: sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==}
 
   axios@1.18.1:
     resolution: {integrity: sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==}
@@ -5747,6 +5700,10 @@ packages:
 
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
 
   bonjour-service@1.3.0:
@@ -6337,6 +6294,10 @@ packages:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
 
+  content-type@2.1.0:
+    resolution: {integrity: sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==}
+    engines: {node: '>=18'}
+
   conventional-changelog-angular@7.0.0:
     resolution: {integrity: sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==}
     engines: {node: '>=16'}
@@ -6919,6 +6880,10 @@ packages:
 
   dotenv@16.4.7:
     resolution: {integrity: sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==}
+    engines: {node: '>=12'}
+
+  dotenv@17.3.1:
+    resolution: {integrity: sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==}
     engines: {node: '>=12'}
 
   dottie@2.0.6:
@@ -7590,9 +7555,9 @@ packages:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
 
-  file-type@16.5.4:
-    resolution: {integrity: sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==}
-    engines: {node: '>=10'}
+  file-type@21.3.1:
+    resolution: {integrity: sha512-SrzXX46I/zsRDjTb82eucsGg0ODq2NpGDp4HcsFKApPy8P8vACjpJRDoGGMfEzhFC0ry61ajd7f72J3603anBA==}
+    engines: {node: '>=20'}
 
   file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
@@ -7670,15 +7635,6 @@ packages:
     resolution: {integrity: sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==}
     deprecated: flatten is deprecated in favor of utility frameworks such as lodash.
 
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-
   follow-redirects@1.16.0:
     resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
@@ -7755,8 +7711,8 @@ packages:
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
-  fs-extra@11.3.0:
-    resolution: {integrity: sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==}
+  fs-extra@11.3.3:
+    resolution: {integrity: sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==}
     engines: {node: '>=14.14'}
 
   fs-extra@11.3.4:
@@ -8987,8 +8943,8 @@ packages:
       node-notifier:
         optional: true
 
-  joi@17.13.3:
-    resolution: {integrity: sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==}
+  joi@17.13.4:
+    resolution: {integrity: sha512-1RuuER6kmt8K8I3nIWvPZKi5RQCb568ZPyY4Pwjlua+yo+63ZTmIwxLZH0heBmiKN4uxjvCiarDrjaeH84xicQ==}
 
   jose@6.1.3:
     resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
@@ -9658,8 +9614,8 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
-  mikro-orm@6.4.5:
-    resolution: {integrity: sha512-CFQf87MG4c1N3J/3ELtmwFKXHBzp62o/da7dt43V9cGXygBs65KSk3EBCAdyd5VYNtu/09mt/rztanQSWNWzog==}
+  mikro-orm@6.6.10:
+    resolution: {integrity: sha512-9z+F31IYQx4sDOO+2gtTS9JUz8SxoSrMQte0p300RIzWj+KByBYkpPZLhAToyIkuUCXHf2sGah8HSpExToCm6Q==}
     engines: {node: '>= 18.12.0'}
 
   mime-db@1.52.0:
@@ -10698,10 +10654,6 @@ packages:
   pedding@1.1.0:
     resolution: {integrity: sha512-/+AoumWfszt77NmVjo4/GcJpQ7fUM1Ovlabd1p3mecjLHkL7qsSH1XJWqyk4wca1q74VwdnaW/K464iWT2XZhw==}
 
-  peek-readable@4.1.0:
-    resolution: {integrity: sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==}
-    engines: {node: '>=8'}
-
   performance-now@2.1.0:
     resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
 
@@ -11001,9 +10953,6 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
-  proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
-
   proxy-from-env@2.1.0:
     resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
     engines: {node: '>=10'}
@@ -11053,6 +11002,10 @@ packages:
 
   qs@6.15.1:
     resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+    engines: {node: '>=0.6'}
+
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
     engines: {node: '>=0.6'}
 
   qs@6.5.3:
@@ -11176,10 +11129,6 @@ packages:
   readable-stream@4.7.0:
     resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-
-  readable-web-to-node-stream@3.0.4:
-    resolution: {integrity: sha512-9nX56alTf5bwXQ3ZDipHJhusu9NTQJ/CVPtb/XHAJCXihZeitfJvIRS4GqQ/mfIoOE3IelHMrpayVrosdHBuLw==}
-    engines: {node: '>=8'}
 
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
@@ -11677,6 +11626,10 @@ packages:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
     engines: {node: '>= 0.4'}
 
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
   side-channel-map@1.0.1:
     resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
     engines: {node: '>= 0.4'}
@@ -11687,6 +11640,10 @@ packages:
 
   side-channel@1.1.0:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
   sift@17.1.3:
@@ -12076,9 +12033,9 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
-  strtok3@6.3.0:
-    resolution: {integrity: sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==}
-    engines: {node: '>=10'}
+  strtok3@10.3.5:
+    resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
+    engines: {node: '>=18'}
 
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
@@ -12331,9 +12288,9 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
-  token-types@4.2.1:
-    resolution: {integrity: sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==}
-    engines: {node: '>=10'}
+  token-types@6.1.2:
+    resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
+    engines: {node: '>=14.16'}
 
   toposort-class@1.0.1:
     resolution: {integrity: sha512-OsLcGGbYF3rMjPUf8oKktyvCiUxSbqMMS39m33MAjLTC1DVIH6x3WSt63/M77ihI09+Sdfk1AXvfhCEeUmC7mg==}
@@ -12544,6 +12501,10 @@ packages:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
 
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
+
   type-name@2.0.2:
     resolution: {integrity: sha512-kkgkuqR/jKdKO5oh/I2SMu2dGbLXoJq0zkdgbxaqYK+hr9S9edwVVGf+tMUFTx2gH9TN2+Zu9JZ/Njonb3cjhA==}
 
@@ -12671,6 +12632,10 @@ packages:
 
   uid2@0.0.3:
     resolution: {integrity: sha512-5gSP1liv10Gjp8cMEnFd6shzkL/D6W1uhXSFNCxDC+YI8+L8wkCYCbJ7n77Ezb4wE/xzMogecE+DtamEe9PZjg==}
+
+  uint8array-extras@1.5.0:
+    resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
+    engines: {node: '>=18'}
 
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
@@ -13399,7 +13364,7 @@ snapshots:
       '@apollo/utils.logger': 3.0.0
       graphql: 16.14.2
 
-  '@apollo/server@5.5.1(graphql@16.14.2)(supports-color@7.2.0)':
+  '@apollo/server@5.5.1(graphql@16.14.2)':
     dependencies:
       '@apollo/cache-control-types': 1.0.3(graphql@16.14.2)
       '@apollo/server-gateway-interface': 2.0.0(graphql@16.14.2)
@@ -13413,10 +13378,10 @@ snapshots:
       '@apollo/utils.withrequired': 3.0.0
       '@graphql-tools/schema': 10.0.38(graphql@16.14.2)
       async-retry: 1.3.3
-      body-parser: 2.2.2(supports-color@8.1.1)
+      body-parser: 2.2.2
       content-type: 1.0.5
       cors: 2.8.5
-      finalhandler: 2.1.1(supports-color@7.2.0)
+      finalhandler: 2.1.1
       graphql: 16.14.2
       loglevel: 1.9.2
       lru-cache: 11.3.6
@@ -13492,40 +13457,20 @@ snapshots:
 
   '@babel/compat-data@7.28.5': {}
 
-  '@babel/core@7.28.5(supports-color@7.2.0)':
+  '@babel/core@7.28.5':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/generator': 7.28.5
       '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
       '@babel/helpers': 7.28.4
       '@babel/parser': 7.29.0
       '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.5(supports-color@7.2.0)
+      '@babel/traverse': 7.28.5
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
       debug: 4.4.3(supports-color@7.2.0)
-      gensync: 1.0.0-beta.2
-      json5: 2.2.3
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/core@7.28.5(supports-color@8.1.1)':
-    dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.28.5
-      '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/helpers': 7.28.4
-      '@babel/parser': 7.29.0
-      '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.5(supports-color@8.1.1)
-      '@babel/types': 7.29.0
-      '@jridgewell/remapping': 2.3.5
-      convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -13552,57 +13497,41 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-create-class-features-plugin@7.28.5(@babel/core@7.28.5(supports-color@7.2.0))(supports-color@7.2.0)':
+  '@babel/helper-create-class-features-plugin@7.28.5(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-member-expression-to-functions': 7.28.5(supports-color@7.2.0)
+      '@babel/helper-member-expression-to-functions': 7.28.5
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.5(supports-color@7.2.0))(supports-color@7.2.0)
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1(supports-color@7.2.0)
-      '@babel/traverse': 7.28.5(supports-color@7.2.0)
+      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.5)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/traverse': 7.28.5
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-globals@7.28.0': {}
 
-  '@babel/helper-member-expression-to-functions@7.28.5(supports-color@7.2.0)':
+  '@babel/helper-member-expression-to-functions@7.28.5':
     dependencies:
-      '@babel/traverse': 7.28.5(supports-color@7.2.0)
+      '@babel/traverse': 7.28.5
       '@babel/types': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-imports@7.27.1(supports-color@7.2.0)':
+  '@babel/helper-module-imports@7.27.1':
     dependencies:
-      '@babel/traverse': 7.28.5(supports-color@7.2.0)
+      '@babel/traverse': 7.28.5
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-imports@7.27.1(supports-color@8.1.1)':
+  '@babel/helper-module-transforms@7.28.3(@babel/core@7.28.5)':
     dependencies:
-      '@babel/traverse': 7.28.5(supports-color@8.1.1)
-      '@babel/types': 7.29.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-module-transforms@7.28.3(@babel/core@7.28.5(supports-color@7.2.0))(supports-color@7.2.0)':
-    dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
-      '@babel/helper-module-imports': 7.27.1(supports-color@7.2.0)
+      '@babel/core': 7.28.5
+      '@babel/helper-module-imports': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.28.5(supports-color@7.2.0)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-module-transforms@7.28.3(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)':
-    dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
-      '@babel/helper-module-imports': 7.27.1(supports-color@8.1.1)
-      '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.28.5(supports-color@8.1.1)
+      '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
@@ -13612,18 +13541,18 @@ snapshots:
 
   '@babel/helper-plugin-utils@7.27.1': {}
 
-  '@babel/helper-replace-supers@7.27.1(@babel/core@7.28.5(supports-color@7.2.0))(supports-color@7.2.0)':
+  '@babel/helper-replace-supers@7.27.1(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
-      '@babel/helper-member-expression-to-functions': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
+      '@babel/helper-member-expression-to-functions': 7.28.5
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/traverse': 7.28.5(supports-color@7.2.0)
+      '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-skip-transparent-expression-wrappers@7.27.1(supports-color@7.2.0)':
+  '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
     dependencies:
-      '@babel/traverse': 7.28.5(supports-color@7.2.0)
+      '@babel/traverse': 7.28.5
       '@babel/types': 7.28.5
     transitivePeerDependencies:
       - supports-color
@@ -13654,113 +13583,113 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
-  '@babel/plugin-proposal-decorators@7.25.9(@babel/core@7.28.5(supports-color@7.2.0))(supports-color@7.2.0)':
+  '@babel/plugin-proposal-decorators@7.25.9(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
-      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/core': 7.28.5
+      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5)
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-syntax-decorators': 7.27.1(@babel/core@7.28.5(supports-color@7.2.0))
+      '@babel/plugin-syntax-decorators': 7.27.1(@babel/core@7.28.5)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.28.5(supports-color@7.2.0))':
+  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.28.5(supports-color@7.2.0))':
+  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.28.5(supports-color@7.2.0))':
+  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.28.5(supports-color@7.2.0))':
+  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-decorators@7.27.1(@babel/core@7.28.5(supports-color@7.2.0))':
+  '@babel/plugin-syntax-decorators@7.27.1(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-import-attributes@7.27.1(@babel/core@7.28.5(supports-color@7.2.0))':
+  '@babel/plugin-syntax-import-attributes@7.27.1(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.28.5(supports-color@7.2.0))':
+  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.28.5(supports-color@7.2.0))':
+  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.28.5(supports-color@7.2.0))':
+  '@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.28.5(supports-color@7.2.0))':
+  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.28.5(supports-color@7.2.0))':
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.28.5(supports-color@7.2.0))':
+  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.28.5(supports-color@7.2.0))':
+  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.28.5(supports-color@7.2.0))':
+  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.28.5(supports-color@7.2.0))':
+  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.28.5(supports-color@7.2.0))':
+  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.28.5(supports-color@7.2.0))':
+  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-typescript@7.27.1(@babel/core@7.28.5(supports-color@7.2.0))':
+  '@babel/plugin-syntax-typescript@7.27.1(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))':
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))':
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/runtime@7.28.4': {}
@@ -13771,7 +13700,7 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/types': 7.29.0
 
-  '@babel/traverse@7.28.5(supports-color@7.2.0)':
+  '@babel/traverse@7.28.5':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/generator': 7.28.5
@@ -13780,18 +13709,6 @@ snapshots:
       '@babel/template': 7.27.2
       '@babel/types': 7.29.0
       debug: 4.4.3(supports-color@7.2.0)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/traverse@7.28.5(supports-color@8.1.1)':
-    dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.28.5
-      '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.29.0
-      '@babel/template': 7.27.2
-      '@babel/types': 7.29.0
-      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -13806,6 +13723,8 @@ snapshots:
       '@babel/helper-validator-identifier': 7.28.5
 
   '@bcoe/v8-coverage@0.2.3': {}
+
+  '@borewit/text-codec@0.2.2': {}
 
   '@bull-board/api@5.23.0(@bull-board/ui@5.23.0)':
     dependencies:
@@ -14028,19 +13947,19 @@ snapshots:
   '@esbuild/win32-x64@0.27.3':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@10.0.0(supports-color@7.2.0))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.0.0)':
     dependencies:
-      eslint: 10.0.0(supports-color@7.2.0)
+      eslint: 10.0.0
       eslint-visitor-keys: 3.4.3
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@7.32.0(supports-color@7.2.0))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@7.32.0)':
     dependencies:
-      eslint: 7.32.0(supports-color@7.2.0)
+      eslint: 7.32.0
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/config-array@0.23.1(supports-color@7.2.0)':
+  '@eslint/config-array@0.23.1':
     dependencies:
       '@eslint/object-schema': 3.0.1
       debug: 4.4.3(supports-color@7.2.0)
@@ -14056,7 +13975,7 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/eslintrc@0.4.3(supports-color@7.2.0)':
+  '@eslint/eslintrc@0.4.3':
     dependencies:
       ajv: 6.12.6
       debug: 4.4.3(supports-color@7.2.0)
@@ -14070,9 +13989,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/js@10.0.1(eslint@10.0.0(supports-color@7.2.0))':
+  '@eslint/js@10.0.1(eslint@10.0.0)':
     optionalDependencies:
-      eslint: 10.0.0(supports-color@7.2.0)
+      eslint: 10.0.0
 
   '@eslint/object-schema@3.0.1': {}
 
@@ -14148,7 +14067,7 @@ snapshots:
       '@humanfs/core': 0.19.1
       '@humanwhocodes/retry': 0.4.3
 
-  '@humanwhocodes/config-array@0.5.0(supports-color@7.2.0)':
+  '@humanwhocodes/config-array@0.5.0':
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
       debug: 4.4.3(supports-color@7.2.0)
@@ -14415,12 +14334,12 @@ snapshots:
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(supports-color@7.2.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3))':
+  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3))':
     dependencies:
       '@jest/console': 29.7.0
-      '@jest/reporters': 29.7.0(supports-color@7.2.0)
+      '@jest/reporters': 29.7.0
       '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0(supports-color@7.2.0)
+      '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@types/node': 20.19.39
       ansi-escapes: 4.3.2
@@ -14429,15 +14348,15 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.19.39)(supports-color@7.2.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3))
+      jest-config: 29.7.0(@types/node@20.19.39)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
       jest-resolve: 29.7.0
-      jest-resolve-dependencies: 29.7.0(supports-color@7.2.0)
-      jest-runner: 29.7.0(supports-color@7.2.0)
-      jest-runtime: 29.7.0(supports-color@7.2.0)
-      jest-snapshot: 29.7.0(supports-color@7.2.0)
+      jest-resolve-dependencies: 29.7.0
+      jest-runner: 29.7.0
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
       jest-util: 29.7.0
       jest-validate: 29.7.0
       jest-watcher: 29.7.0
@@ -14465,10 +14384,10 @@ snapshots:
     dependencies:
       jest-get-type: 29.6.3
 
-  '@jest/expect@29.7.0(supports-color@7.2.0)':
+  '@jest/expect@29.7.0':
     dependencies:
       expect: 29.7.0
-      jest-snapshot: 29.7.0(supports-color@7.2.0)
+      jest-snapshot: 29.7.0
     transitivePeerDependencies:
       - supports-color
 
@@ -14483,21 +14402,21 @@ snapshots:
 
   '@jest/get-type@30.1.0': {}
 
-  '@jest/globals@29.7.0(supports-color@7.2.0)':
+  '@jest/globals@29.7.0':
     dependencies:
       '@jest/environment': 29.7.0
-      '@jest/expect': 29.7.0(supports-color@7.2.0)
+      '@jest/expect': 29.7.0
       '@jest/types': 29.6.3
       jest-mock: 29.7.0
     transitivePeerDependencies:
       - supports-color
 
-  '@jest/reporters@29.7.0(supports-color@7.2.0)':
+  '@jest/reporters@29.7.0':
     dependencies:
       '@bcoe/v8-coverage': 0.2.3
       '@jest/console': 29.7.0
       '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0(supports-color@7.2.0)
+      '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.31
       '@types/node': 22.12.0
@@ -14507,9 +14426,9 @@ snapshots:
       glob: 7.2.3
       graceful-fs: 4.2.11
       istanbul-lib-coverage: 3.2.2
-      istanbul-lib-instrument: 6.0.3(supports-color@7.2.0)
+      istanbul-lib-instrument: 6.0.3
       istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 4.0.1(supports-color@7.2.0)
+      istanbul-lib-source-maps: 4.0.1
       istanbul-reports: 3.2.0
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -14549,12 +14468,12 @@ snapshots:
       jest-haste-map: 29.7.0
       slash: 3.0.0
 
-  '@jest/transform@29.7.0(supports-color@7.2.0)':
+  '@jest/transform@29.7.0':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.31
-      babel-plugin-istanbul: 6.1.1(supports-color@7.2.0)
+      babel-plugin-istanbul: 6.1.1
       chalk: 4.1.2
       convert-source-map: 2.0.0
       fast-json-stable-stringify: 2.1.0
@@ -14738,7 +14657,7 @@ snapshots:
 
   '@keyv/serialize@1.1.1': {}
 
-  '@koa/router@12.0.2(supports-color@7.2.0)':
+  '@koa/router@12.0.2':
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
       http-errors: 2.0.1
@@ -14766,30 +14685,16 @@ snapshots:
       dayjs: 1.11.19
       safe-stable-stringify: 2.5.0
 
-  '@midwayjs/serverless-http-parser@4.0.2':
-    dependencies:
-      '@midwayjs/cookies': 1.3.0
-      accepts: 1.3.8
-      cache-content-type: 1.0.1
-      encodeurl: 1.0.2
-      escape-html: 1.0.3
-      http-errors: 2.0.1
-      only: 0.0.2
-      parseurl: 1.3.3
-      statuses: 2.0.2
-      type-is: 1.6.18
-      vary: 1.1.2
-
   '@midwayjs/simple-lock@1.2.2': {}
 
-  '@mikro-orm/core@6.4.5':
+  '@mikro-orm/core@6.6.10':
     dependencies:
       dataloader: 2.2.3
-      dotenv: 16.4.7
+      dotenv: 17.3.1
       esprima: 4.0.1
-      fs-extra: 11.3.0
+      fs-extra: 11.3.3
       globby: 11.1.0
-      mikro-orm: 6.4.5
+      mikro-orm: 6.6.10
       reflect-metadata: 0.2.2
 
   '@mikro-orm/core@7.0.13(dataloader@2.2.3)':
@@ -14802,11 +14707,11 @@ snapshots:
     optionalDependencies:
       reflect-metadata: 0.2.2
 
-  '@mikro-orm/entity-generator@6.4.5(@mikro-orm/core@6.4.5)(better-sqlite3@12.9.0)(mysql2@3.16.0)(sqlite3@5.1.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@mikro-orm/entity-generator@6.6.10(@mikro-orm/core@6.6.10)(better-sqlite3@12.9.0)':
     dependencies:
-      '@mikro-orm/core': 6.4.5
-      '@mikro-orm/knex': 6.4.5(@mikro-orm/core@6.4.5)(better-sqlite3@12.9.0)(mysql2@3.16.0)(sqlite3@5.1.7(supports-color@8.1.1))(supports-color@8.1.1)
-      fs-extra: 11.3.0
+      '@mikro-orm/core': 6.6.10
+      '@mikro-orm/knex': 6.6.10(@mikro-orm/core@6.6.10)(better-sqlite3@12.9.0)(sqlite3@5.1.7)
+      fs-extra: 11.3.3
     transitivePeerDependencies:
       - better-sqlite3
       - libsql
@@ -14824,11 +14729,11 @@ snapshots:
       '@mikro-orm/core': 7.0.13(dataloader@2.2.3)
       '@mikro-orm/sql': 7.0.13(@mikro-orm/core@7.0.13(dataloader@2.2.3))
 
-  '@mikro-orm/knex@6.4.5(@mikro-orm/core@6.4.5)(better-sqlite3@12.9.0)(mysql2@3.16.0)(sqlite3@5.1.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@mikro-orm/knex@6.6.10(@mikro-orm/core@6.6.10)(better-sqlite3@12.9.0)(sqlite3@5.1.7)':
     dependencies:
-      '@mikro-orm/core': 6.4.5
-      fs-extra: 11.3.0
-      knex: 3.1.0(better-sqlite3@12.9.0)(mysql2@3.16.0)(sqlite3@5.1.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@mikro-orm/core': 6.6.10
+      fs-extra: 11.3.3
+      knex: 3.1.0(better-sqlite3@12.9.0)(sqlite3@5.1.7)
       sqlstring: 2.3.3
     optionalDependencies:
       better-sqlite3: 12.9.0
@@ -14846,12 +14751,12 @@ snapshots:
       '@mikro-orm/core': 7.0.13(dataloader@2.2.3)
       kysely: 0.28.16
 
-  '@mikro-orm/sqlite@6.4.5(@mikro-orm/core@6.4.5)(better-sqlite3@12.9.0)(mysql2@3.16.0)(supports-color@8.1.1)':
+  '@mikro-orm/sqlite@6.6.10(@mikro-orm/core@6.6.10)(better-sqlite3@12.9.0)':
     dependencies:
-      '@mikro-orm/core': 6.4.5
-      '@mikro-orm/knex': 6.4.5(@mikro-orm/core@6.4.5)(better-sqlite3@12.9.0)(mysql2@3.16.0)(sqlite3@5.1.7(supports-color@8.1.1))(supports-color@8.1.1)
-      fs-extra: 11.3.0
-      sqlite3: 5.1.7(supports-color@8.1.1)
+      '@mikro-orm/core': 6.6.10
+      '@mikro-orm/knex': 6.6.10(@mikro-orm/core@6.6.10)(better-sqlite3@12.9.0)(sqlite3@5.1.7)
+      fs-extra: 11.3.3
+      sqlite3: 5.1.7
       sqlstring-sqlite: 0.1.1
     transitivePeerDependencies:
       - better-sqlite3
@@ -14872,7 +14777,7 @@ snapshots:
       better-sqlite3: 12.9.0
       kysely: 0.28.16
 
-  '@modelcontextprotocol/sdk@1.26.0(supports-color@8.1.1)(zod@3.25.76)':
+  '@modelcontextprotocol/sdk@1.26.0(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 1.19.11(hono@4.12.8)
       ajv: 8.17.1
@@ -14882,8 +14787,8 @@ snapshots:
       cross-spawn: 7.0.6
       eventsource: 3.0.7
       eventsource-parser: 3.0.6
-      express: 5.2.1(supports-color@8.1.1)
-      express-rate-limit: 8.3.1(express@5.2.1(supports-color@8.1.1))
+      express: 5.2.1
+      express-rate-limit: 8.3.1(express@5.2.1)
       hono: 4.12.8
       jose: 6.1.3
       json-schema-typed: 8.0.2
@@ -15073,23 +14978,23 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@npmcli/agent@4.0.2(supports-color@7.2.0)':
+  '@npmcli/agent@4.0.2':
     dependencies:
       agent-base: 7.1.4
-      http-proxy-agent: 7.0.2(supports-color@7.2.0)
-      https-proxy-agent: 7.0.6(supports-color@7.2.0)
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
       lru-cache: 11.3.6
-      socks-proxy-agent: 8.0.5(supports-color@7.2.0)
+      socks-proxy-agent: 8.0.5
     transitivePeerDependencies:
       - supports-color
 
-  '@npmcli/arborist@9.1.6(supports-color@7.2.0)':
+  '@npmcli/arborist@9.1.6':
     dependencies:
       '@isaacs/string-locale-compare': 1.1.0
       '@npmcli/fs': 4.0.0
       '@npmcli/installed-package-contents': 3.0.0
       '@npmcli/map-workspaces': 5.0.3
-      '@npmcli/metavuln-calculator': 9.0.3(supports-color@7.2.0)
+      '@npmcli/metavuln-calculator': 9.0.3
       '@npmcli/name-from-folder': 3.0.0
       '@npmcli/node-gyp': 4.0.0
       '@npmcli/package-json': 7.0.2
@@ -15107,8 +15012,8 @@ snapshots:
       npm-install-checks: 7.1.2
       npm-package-arg: 13.0.1
       npm-pick-manifest: 11.0.3
-      npm-registry-fetch: 19.1.0(supports-color@7.2.0)
-      pacote: 21.5.1(supports-color@7.2.0)
+      npm-registry-fetch: 19.1.0
+      pacote: 21.5.1
       parse-conflict-json: 4.0.0
       proc-log: 5.0.0
       proggy: 3.0.0
@@ -15173,11 +15078,11 @@ snapshots:
       glob: 13.0.6
       minimatch: 10.2.4
 
-  '@npmcli/metavuln-calculator@9.0.3(supports-color@7.2.0)':
+  '@npmcli/metavuln-calculator@9.0.3':
     dependencies:
       cacache: 20.0.4
       json-parse-even-better-errors: 5.0.0
-      pacote: 21.5.1(supports-color@7.2.0)
+      pacote: 21.5.1
       proc-log: 6.1.0
       semver: 7.7.4
     transitivePeerDependencies:
@@ -15231,14 +15136,15 @@ snapshots:
       proc-log: 6.1.0
       which: 6.0.1
 
-  '@nrwl/tao@16.10.0(debug@4.4.3(supports-color@7.2.0))':
+  '@nrwl/tao@16.10.0':
     dependencies:
-      nx: 16.10.0(debug@4.4.3(supports-color@7.2.0))
+      nx: 16.10.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@swc-node/register'
       - '@swc/core'
       - debug
+      - supports-color
 
   '@nx/devkit@22.7.8(nx@22.7.8)':
     dependencies:
@@ -15539,11 +15445,11 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 1.7.11
       '@rspack/binding-win32-x64-msvc': 1.7.11
 
-  '@rspack/cli@1.7.11(@rspack/core@1.7.11(@swc/helpers@0.5.15))(@types/express@4.17.25)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(tslib@2.8.1)(webpack@5.104.1(esbuild@0.27.3)(uglify-js@3.19.3))':
+  '@rspack/cli@1.7.11(@rspack/core@1.7.11(@swc/helpers@0.5.15))(@types/express@4.17.25)(tslib@2.8.1)(webpack@5.104.1)':
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
       '@rspack/core': 1.7.11(@swc/helpers@0.5.15)
-      '@rspack/dev-server': 1.1.5(@rspack/core@1.7.11(@swc/helpers@0.5.15))(@types/express@4.17.25)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(tslib@2.8.1)(webpack@5.104.1(esbuild@0.27.3)(uglify-js@3.19.3))
+      '@rspack/dev-server': 1.1.5(@rspack/core@1.7.11(@swc/helpers@0.5.15))(@types/express@4.17.25)(tslib@2.8.1)(webpack@5.104.1)
       exit-hook: 4.0.0
       webpack-bundle-analyzer: 4.10.2
     transitivePeerDependencies:
@@ -15564,13 +15470,13 @@ snapshots:
     optionalDependencies:
       '@swc/helpers': 0.5.15
 
-  '@rspack/dev-server@1.1.5(@rspack/core@1.7.11(@swc/helpers@0.5.15))(@types/express@4.17.25)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(tslib@2.8.1)(webpack@5.104.1(esbuild@0.27.3)(uglify-js@3.19.3))':
+  '@rspack/dev-server@1.1.5(@rspack/core@1.7.11(@swc/helpers@0.5.15))(@types/express@4.17.25)(tslib@2.8.1)(webpack@5.104.1)':
     dependencies:
       '@rspack/core': 1.7.11(@swc/helpers@0.5.15)
       chokidar: 3.6.0
-      http-proxy-middleware: 2.0.9(@types/express@4.17.25)(debug@4.4.3(supports-color@8.1.1))
+      http-proxy-middleware: 2.0.9(@types/express@4.17.25)
       p-retry: 6.2.1
-      webpack-dev-server: 5.2.2(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(tslib@2.8.1)(webpack@5.104.1(esbuild@0.27.3)(uglify-js@3.19.3))
+      webpack-dev-server: 5.2.2(tslib@2.8.1)(webpack@5.104.1)
       ws: 8.21.0
     transitivePeerDependencies:
       - '@types/express'
@@ -15644,21 +15550,21 @@ snapshots:
 
   '@sigstore/protobuf-specs@0.5.2': {}
 
-  '@sigstore/sign@4.1.1(supports-color@7.2.0)':
+  '@sigstore/sign@4.1.1':
     dependencies:
       '@gar/promise-retry': 1.0.3
       '@sigstore/bundle': 4.0.0
       '@sigstore/core': 3.2.1
       '@sigstore/protobuf-specs': 0.5.2
-      make-fetch-happen: 15.0.6(supports-color@7.2.0)
+      make-fetch-happen: 15.0.6
       proc-log: 6.1.0
     transitivePeerDependencies:
       - supports-color
 
-  '@sigstore/tuf@4.0.2(supports-color@7.2.0)':
+  '@sigstore/tuf@4.0.2':
     dependencies:
       '@sigstore/protobuf-specs': 0.5.2
-      tuf-js: 4.1.0(supports-color@7.2.0)
+      tuf-js: 4.1.0
     transitivePeerDependencies:
       - supports-color
 
@@ -15713,6 +15619,13 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
+  '@tokenizer/inflate@0.4.1':
+    dependencies:
+      debug: 4.4.3(supports-color@7.2.0)
+      token-types: 6.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@tokenizer/token@0.3.0': {}
 
   '@tootallnate/once@1.1.2': {}
@@ -15741,11 +15654,11 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@typegoose/typegoose@12.10.1(mongoose@8.9.5(socks@2.8.7)(supports-color@8.1.1))':
+  '@typegoose/typegoose@12.10.1(mongoose@8.9.5(socks@2.8.7))':
     dependencies:
       lodash: 4.17.21
       loglevel: 1.9.2
-      mongoose: 8.9.5(socks@2.8.7)(supports-color@8.1.1)
+      mongoose: 8.9.5(socks@2.8.7)
       reflect-metadata: 0.2.2
       semver: 7.7.3
       tslib: 2.8.1
@@ -16117,15 +16030,15 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0(supports-color@7.2.0))(supports-color@8.1.1)(typescript@5.6.3))(eslint@7.32.0(supports-color@7.2.0))(supports-color@8.1.1)(typescript@5.6.3)':
+  '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.6.3))(eslint@7.32.0)(typescript@5.6.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 5.62.0(eslint@7.32.0(supports-color@7.2.0))(supports-color@8.1.1)(typescript@5.6.3)
+      '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@5.6.3)
       '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/type-utils': 5.62.0(eslint@7.32.0(supports-color@7.2.0))(supports-color@8.1.1)(typescript@5.6.3)
-      '@typescript-eslint/utils': 5.62.0(eslint@7.32.0(supports-color@7.2.0))(supports-color@8.1.1)(typescript@5.6.3)
+      '@typescript-eslint/type-utils': 5.62.0(eslint@7.32.0)(typescript@5.6.3)
+      '@typescript-eslint/utils': 5.62.0(eslint@7.32.0)(typescript@5.6.3)
       debug: 4.4.3(supports-color@7.2.0)
-      eslint: 7.32.0(supports-color@7.2.0)
+      eslint: 7.32.0
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare-lite: 1.4.0
@@ -16136,15 +16049,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.56.0(@typescript-eslint/parser@8.56.0(eslint@10.0.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.6.3))(eslint@10.0.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.6.3)':
+  '@typescript-eslint/eslint-plugin@8.56.0(@typescript-eslint/parser@8.56.0(eslint@10.0.0)(typescript@5.6.3))(eslint@10.0.0)(typescript@5.6.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.56.0(eslint@10.0.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.6.3)
+      '@typescript-eslint/parser': 8.56.0(eslint@10.0.0)(typescript@5.6.3)
       '@typescript-eslint/scope-manager': 8.56.0
-      '@typescript-eslint/type-utils': 8.56.0(eslint@10.0.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.6.3)
-      '@typescript-eslint/utils': 8.56.0(eslint@10.0.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.6.3)
+      '@typescript-eslint/type-utils': 8.56.0(eslint@10.0.0)(typescript@5.6.3)
+      '@typescript-eslint/utils': 8.56.0(eslint@10.0.0)(typescript@5.6.3)
       '@typescript-eslint/visitor-keys': 8.56.0
-      eslint: 10.0.0(supports-color@7.2.0)
+      eslint: 10.0.0
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.4.0(typescript@5.6.3)
@@ -16152,31 +16065,31 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@5.62.0(eslint@7.32.0(supports-color@7.2.0))(supports-color@8.1.1)(typescript@5.6.3)':
+  '@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.6.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(supports-color@8.1.1)(typescript@5.6.3)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.6.3)
       debug: 4.4.3(supports-color@7.2.0)
-      eslint: 7.32.0(supports-color@7.2.0)
+      eslint: 7.32.0
     optionalDependencies:
       typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.56.0(eslint@10.0.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.6.3)':
+  '@typescript-eslint/parser@8.56.0(eslint@10.0.0)(typescript@5.6.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.56.0
       '@typescript-eslint/types': 8.56.0
-      '@typescript-eslint/typescript-estree': 8.56.0(supports-color@7.2.0)(typescript@5.6.3)
+      '@typescript-eslint/typescript-estree': 8.56.0(typescript@5.6.3)
       '@typescript-eslint/visitor-keys': 8.56.0
       debug: 4.4.3(supports-color@7.2.0)
-      eslint: 10.0.0(supports-color@7.2.0)
+      eslint: 10.0.0
       typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.56.0(supports-color@7.2.0)(typescript@5.6.3)':
+  '@typescript-eslint/project-service@8.56.0(typescript@5.6.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.56.0(typescript@5.6.3)
       '@typescript-eslint/types': 8.56.0
@@ -16199,25 +16112,25 @@ snapshots:
     dependencies:
       typescript: 5.6.3
 
-  '@typescript-eslint/type-utils@5.62.0(eslint@7.32.0(supports-color@7.2.0))(supports-color@8.1.1)(typescript@5.6.3)':
+  '@typescript-eslint/type-utils@5.62.0(eslint@7.32.0)(typescript@5.6.3)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.62.0(supports-color@8.1.1)(typescript@5.6.3)
-      '@typescript-eslint/utils': 5.62.0(eslint@7.32.0(supports-color@7.2.0))(supports-color@8.1.1)(typescript@5.6.3)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.6.3)
+      '@typescript-eslint/utils': 5.62.0(eslint@7.32.0)(typescript@5.6.3)
       debug: 4.4.3(supports-color@7.2.0)
-      eslint: 7.32.0(supports-color@7.2.0)
+      eslint: 7.32.0
       tsutils: 3.21.0(typescript@5.6.3)
     optionalDependencies:
       typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@8.56.0(eslint@10.0.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.6.3)':
+  '@typescript-eslint/type-utils@8.56.0(eslint@10.0.0)(typescript@5.6.3)':
     dependencies:
       '@typescript-eslint/types': 8.56.0
-      '@typescript-eslint/typescript-estree': 8.56.0(supports-color@7.2.0)(typescript@5.6.3)
-      '@typescript-eslint/utils': 8.56.0(eslint@10.0.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.6.3)
+      '@typescript-eslint/typescript-estree': 8.56.0(typescript@5.6.3)
+      '@typescript-eslint/utils': 8.56.0(eslint@10.0.0)(typescript@5.6.3)
       debug: 4.4.3(supports-color@7.2.0)
-      eslint: 10.0.0(supports-color@7.2.0)
+      eslint: 10.0.0
       ts-api-utils: 2.4.0(typescript@5.6.3)
       typescript: 5.6.3
     transitivePeerDependencies:
@@ -16229,7 +16142,7 @@ snapshots:
 
   '@typescript-eslint/types@8.56.0': {}
 
-  '@typescript-eslint/typescript-estree@4.33.0(supports-color@7.2.0)(typescript@3.9.10)':
+  '@typescript-eslint/typescript-estree@4.33.0(typescript@3.9.10)':
     dependencies:
       '@typescript-eslint/types': 4.33.0
       '@typescript-eslint/visitor-keys': 4.33.0
@@ -16243,7 +16156,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@5.62.0(supports-color@7.2.0)(typescript@4.9.5)':
+  '@typescript-eslint/typescript-estree@5.62.0(typescript@4.9.5)':
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
@@ -16257,11 +16170,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@5.62.0(supports-color@8.1.1)(typescript@5.6.3)':
+  '@typescript-eslint/typescript-estree@5.62.0(typescript@5.6.3)':
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@7.2.0)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.7.4
@@ -16271,9 +16184,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.56.0(supports-color@7.2.0)(typescript@5.6.3)':
+  '@typescript-eslint/typescript-estree@8.56.0(typescript@5.6.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.56.0(supports-color@7.2.0)(typescript@5.6.3)
+      '@typescript-eslint/project-service': 8.56.0(typescript@5.6.3)
       '@typescript-eslint/tsconfig-utils': 8.56.0(typescript@5.6.3)
       '@typescript-eslint/types': 8.56.0
       '@typescript-eslint/visitor-keys': 8.56.0
@@ -16286,28 +16199,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@5.62.0(eslint@7.32.0(supports-color@7.2.0))(supports-color@8.1.1)(typescript@5.6.3)':
+  '@typescript-eslint/utils@5.62.0(eslint@7.32.0)(typescript@5.6.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@7.32.0(supports-color@7.2.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@7.32.0)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.7.1
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(supports-color@8.1.1)(typescript@5.6.3)
-      eslint: 7.32.0(supports-color@7.2.0)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.6.3)
+      eslint: 7.32.0
       eslint-scope: 5.1.1
       semver: 7.7.4
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@8.56.0(eslint@10.0.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.6.3)':
+  '@typescript-eslint/utils@8.56.0(eslint@10.0.0)(typescript@5.6.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.0.0(supports-color@7.2.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.0.0)
       '@typescript-eslint/scope-manager': 8.56.0
       '@typescript-eslint/types': 8.56.0
-      '@typescript-eslint/typescript-estree': 8.56.0(supports-color@7.2.0)(typescript@5.6.3)
-      eslint: 10.0.0(supports-color@7.2.0)
+      '@typescript-eslint/typescript-estree': 8.56.0(typescript@5.6.3)
+      eslint: 10.0.0
       typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
@@ -16331,11 +16244,11 @@ snapshots:
 
   '@vercel/ncc@0.38.4': {}
 
-  '@vitejs/plugin-react@4.7.0(supports-color@8.1.1)(vite@6.4.3(@types/node@22.12.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))':
+  '@vitejs/plugin-react@4.7.0(vite@6.4.3(@types/node@22.12.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/core': 7.28.5
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.5)
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
@@ -16571,12 +16484,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  agent-base@6.0.2(supports-color@8.1.1):
-    dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - supports-color
-
   agent-base@7.1.4: {}
 
   agentkeepalive@3.5.3:
@@ -16638,7 +16545,7 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
-  ali-oss@6.23.0(supports-color@7.2.0):
+  ali-oss@6.23.0:
     dependencies:
       address: 1.2.2
       agentkeepalive: 3.5.3
@@ -16858,21 +16765,15 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  axios@1.13.5(debug@4.4.3(supports-color@7.2.0)):
+  axios@1.18.0:
     dependencies:
-      follow-redirects: 1.15.11(debug@4.4.3(supports-color@7.2.0))
-      form-data: 4.0.5
-      proxy-from-env: 1.1.0
+      follow-redirects: 1.16.0(debug@4.4.3(supports-color@7.2.0))
+      form-data: 4.0.6
+      https-proxy-agent: 5.0.1(supports-color@7.2.0)
+      proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
-
-  axios@1.13.5(debug@4.4.3(supports-color@8.1.1)):
-    dependencies:
-      follow-redirects: 1.15.11(debug@4.4.3(supports-color@8.1.1))
-      form-data: 4.0.5
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
+      - supports-color
 
   axios@1.18.1(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0):
     dependencies:
@@ -16884,42 +16785,42 @@ snapshots:
       - debug
       - supports-color
 
-  axios@1.19.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1):
+  axios@1.19.0:
     dependencies:
-      follow-redirects: 1.16.0(debug@4.4.3(supports-color@8.1.1))
+      follow-redirects: 1.16.0(debug@4.4.3(supports-color@7.2.0))
       form-data: 4.0.6
-      https-proxy-agent: 5.0.1(supports-color@8.1.1)
+      https-proxy-agent: 5.0.1(supports-color@7.2.0)
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  babel-jest@29.7.0(@babel/core@7.28.5(supports-color@7.2.0))(supports-color@7.2.0):
+  babel-jest@29.7.0(@babel/core@7.28.5):
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
-      '@jest/transform': 29.7.0(supports-color@7.2.0)
+      '@babel/core': 7.28.5
+      '@jest/transform': 29.7.0
       '@types/babel__core': 7.20.5
-      babel-plugin-istanbul: 6.1.1(supports-color@7.2.0)
-      babel-preset-jest: 29.6.3(@babel/core@7.28.5(supports-color@7.2.0))
+      babel-plugin-istanbul: 6.1.1
+      babel-preset-jest: 29.6.3(@babel/core@7.28.5)
       chalk: 4.1.2
       graceful-fs: 4.2.11
       slash: 3.0.0
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@9.2.1(@babel/core@7.28.5(supports-color@8.1.1))(webpack@5.104.1(esbuild@0.27.3)(uglify-js@3.19.3)):
+  babel-loader@9.2.1(@babel/core@7.28.5)(webpack@5.104.1):
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       find-cache-dir: 4.0.0
       schema-utils: 4.3.3
-      webpack: 5.104.1(esbuild@0.27.3)(uglify-js@3.19.3)
+      webpack: 5.104.1
 
-  babel-plugin-istanbul@6.1.1(supports-color@7.2.0):
+  babel-plugin-istanbul@6.1.1:
     dependencies:
       '@babel/helper-plugin-utils': 7.27.1
       '@istanbuljs/load-nyc-config': 1.1.0
       '@istanbuljs/schema': 0.1.3
-      istanbul-lib-instrument: 5.2.1(supports-color@7.2.0)
+      istanbul-lib-instrument: 5.2.1
       test-exclude: 6.0.0
     transitivePeerDependencies:
       - supports-color
@@ -16931,30 +16832,30 @@ snapshots:
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.28.0
 
-  babel-preset-current-node-syntax@1.2.0(@babel/core@7.28.5(supports-color@7.2.0)):
+  babel-preset-current-node-syntax@1.2.0(@babel/core@7.28.5):
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.28.5(supports-color@7.2.0))
-      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.28.5(supports-color@7.2.0))
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.28.5(supports-color@7.2.0))
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.28.5(supports-color@7.2.0))
-      '@babel/plugin-syntax-import-attributes': 7.27.1(@babel/core@7.28.5(supports-color@7.2.0))
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.28.5(supports-color@7.2.0))
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.28.5(supports-color@7.2.0))
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.28.5(supports-color@7.2.0))
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.28.5(supports-color@7.2.0))
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.28.5(supports-color@7.2.0))
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.28.5(supports-color@7.2.0))
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.28.5(supports-color@7.2.0))
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.28.5(supports-color@7.2.0))
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.28.5(supports-color@7.2.0))
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.28.5(supports-color@7.2.0))
+      '@babel/core': 7.28.5
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.28.5)
+      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.28.5)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.28.5)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.28.5)
+      '@babel/plugin-syntax-import-attributes': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.28.5)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.28.5)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.28.5)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.28.5)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.28.5)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.28.5)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.28.5)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.28.5)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.28.5)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.28.5)
 
-  babel-preset-jest@29.6.3(@babel/core@7.28.5(supports-color@7.2.0)):
+  babel-preset-jest@29.6.3(@babel/core@7.28.5):
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
       babel-plugin-jest-hoist: 29.6.3
-      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.28.5(supports-color@7.2.0))
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.28.5)
 
   backo2@1.0.2: {}
 
@@ -17030,11 +16931,11 @@ snapshots:
 
   blob@0.0.5: {}
 
-  body-parser@1.20.6(supports-color@8.1.1):
+  body-parser@1.20.6:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       depd: 2.0.0
       destroy: 1.2.0
       http-errors: 2.0.1
@@ -17047,17 +16948,31 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  body-parser@2.2.2(supports-color@8.1.1):
+  body-parser@2.2.2:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@7.2.0)
       http-errors: 2.0.1
       iconv-lite: 0.7.1
       on-finished: 2.4.1
       qs: 6.15.1
       raw-body: 3.0.2
       type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  body-parser@2.3.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.1.0
+      debug: 4.4.3(supports-color@7.2.0)
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      on-finished: 2.4.1
+      qs: 6.15.3
+      raw-body: 3.0.2
+      type-is: 2.1.0
     transitivePeerDependencies:
       - supports-color
 
@@ -17111,7 +17026,7 @@ snapshots:
     dependencies:
       balanced-match: 4.0.3
 
-  braces@2.3.2(supports-color@8.1.1):
+  braces@2.3.2:
     dependencies:
       arr-flatten: 1.1.0
       array-unique: 0.3.2
@@ -17119,7 +17034,7 @@ snapshots:
       fill-range: 4.0.0
       isobject: 3.0.1
       repeat-element: 1.1.4
-      snapdragon: 0.8.2(supports-color@8.1.1)
+      snapdragon: 0.8.2
       snapdragon-node: 2.1.1
       split-string: 3.1.0
       to-regex: 3.0.2
@@ -17181,11 +17096,11 @@ snapshots:
 
   builtin-status-codes@3.0.0: {}
 
-  bull@4.16.5(supports-color@7.2.0):
+  bull@4.16.5:
     dependencies:
       cron-parser: 4.9.0
       get-port: 5.1.1
-      ioredis: 5.4.2(supports-color@7.2.0)
+      ioredis: 5.4.2
       lodash: 4.17.21
       msgpackr: 1.11.8
       semver: 7.7.3
@@ -17193,10 +17108,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  bullmq@5.71.0(supports-color@8.1.1):
+  bullmq@5.71.0:
     dependencies:
       cron-parser: 4.9.0
-      ioredis: 5.9.3(supports-color@8.1.1)
+      ioredis: 5.9.3
       msgpackr: 1.11.5
       node-abort-controller: 3.1.1
       semver: 7.7.4
@@ -17225,9 +17140,9 @@ snapshots:
 
   byte-size@8.1.1: {}
 
-  byte@2.0.0(supports-color@8.1.1):
+  byte@2.0.0:
     dependencies:
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7
       long: 4.0.0
       utility: 1.18.0
     transitivePeerDependencies:
@@ -17292,10 +17207,10 @@ snapshots:
       mime-types: 2.1.35
       ylru: 1.4.0
 
-  cache-manager-ioredis-yet@2.1.2(supports-color@7.2.0):
+  cache-manager-ioredis-yet@2.1.2:
     dependencies:
       cache-manager: 6.0.0
-      ioredis: 5.4.2(supports-color@7.2.0)
+      ioredis: 5.4.2
       telejson: 7.2.0
     transitivePeerDependencies:
       - supports-color
@@ -17557,16 +17472,16 @@ snapshots:
 
   clone@1.0.4: {}
 
-  cluster-client@3.7.0(supports-color@8.1.1):
+  cluster-client@3.7.0:
     dependencies:
-      byte: 2.0.0(supports-color@8.1.1)
+      byte: 2.0.0
       co: 4.6.0
       egg-logger: 3.6.1
       is-type-of: 1.4.0
       json-stringify-safe: 5.0.1
       long: 4.0.0
       sdk-base: 4.2.1
-      serialize-json: 1.0.3(supports-color@8.1.1)
+      serialize-json: 1.0.3
       tcp-base: 3.2.0
       utility: 2.5.0
     transitivePeerDependencies:
@@ -17599,7 +17514,7 @@ snapshots:
 
   cockatiel@3.2.1: {}
 
-  coffee@5.5.1(supports-color@7.2.0):
+  coffee@5.5.1:
     dependencies:
       cross-spawn: 6.0.6
       debug: 4.4.3(supports-color@7.2.0)
@@ -17661,7 +17576,7 @@ snapshots:
 
   common-ancestor-path@1.0.1: {}
 
-  common-bin@3.0.1(supports-color@7.2.0):
+  common-bin@3.0.1:
     dependencies:
       chalk: 4.1.2
       change-case: 4.1.2
@@ -17697,11 +17612,11 @@ snapshots:
     dependencies:
       mime-db: 1.54.0
 
-  compression@1.8.1(supports-color@8.1.1):
+  compression@1.8.1:
     dependencies:
       bytes: 3.1.2
       compressible: 2.0.18
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       negotiator: 0.6.4
       on-headers: 1.1.0
       safe-buffer: 5.2.1
@@ -17781,6 +17696,8 @@ snapshots:
 
   content-type@1.0.5: {}
 
+  content-type@2.1.0: {}
+
   conventional-changelog-angular@7.0.0:
     dependencies:
       compare-func: 2.0.0
@@ -17840,10 +17757,10 @@ snapshots:
       cookie: 0.7.2
       cookie-signature: 1.0.6
 
-  cookie-session@2.1.1(supports-color@8.1.1):
+  cookie-session@2.1.1:
     dependencies:
       cookies: 0.9.1
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7
       on-headers: 1.1.0
       safe-buffer: 5.2.1
     transitivePeerDependencies:
@@ -17901,13 +17818,13 @@ snapshots:
     dependencies:
       buffer: 5.7.1
 
-  create-jest@29.7.0(@types/node@22.12.0)(supports-color@7.2.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3)):
+  create-jest@29.7.0(@types/node@22.12.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@22.12.0)(supports-color@7.2.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3))
+      jest-config: 29.7.0(@types/node@22.12.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -18018,41 +17935,29 @@ snapshots:
 
   debounce@1.2.1: {}
 
-  debug@2.6.9(supports-color@8.1.1):
+  debug@2.6.9:
     dependencies:
       ms: 2.0.0
-    optionalDependencies:
-      supports-color: 8.1.1
 
-  debug@3.1.0(supports-color@8.1.1):
+  debug@3.1.0:
     dependencies:
       ms: 2.0.0
-    optionalDependencies:
-      supports-color: 8.1.1
 
-  debug@3.2.7(supports-color@8.1.1):
+  debug@3.2.7:
     dependencies:
       ms: 2.1.3
-    optionalDependencies:
-      supports-color: 8.1.1
 
-  debug@4.1.1(supports-color@8.1.1):
+  debug@4.1.1:
     dependencies:
       ms: 2.1.3
-    optionalDependencies:
-      supports-color: 8.1.1
 
-  debug@4.3.4(supports-color@8.1.1):
+  debug@4.3.4:
     dependencies:
       ms: 2.1.2
-    optionalDependencies:
-      supports-color: 8.1.1
 
-  debug@4.3.7(supports-color@8.1.1):
+  debug@4.3.7:
     dependencies:
       ms: 2.1.3
-    optionalDependencies:
-      supports-color: 8.1.1
 
   debug@4.4.3(supports-color@7.2.0):
     dependencies:
@@ -18178,12 +18083,12 @@ snapshots:
 
   depd@2.0.0: {}
 
-  dependency-tree@9.0.0(supports-color@7.2.0):
+  dependency-tree@9.0.0:
     dependencies:
       commander: 2.20.3
       debug: 4.4.3(supports-color@7.2.0)
-      filing-cabinet: 3.3.1(supports-color@7.2.0)
-      precinct: 9.2.1(supports-color@7.2.0)
+      filing-cabinet: 3.3.1
+      precinct: 9.2.1
       typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
@@ -18200,10 +18105,10 @@ snapshots:
 
   detect-node@2.1.0: {}
 
-  detect-port@1.6.1(supports-color@8.1.1):
+  detect-port@1.6.1:
     dependencies:
       address: 1.2.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -18239,7 +18144,7 @@ snapshots:
     dependencies:
       node-source-walk: 5.0.2
 
-  detective-less@1.0.2(supports-color@7.2.0):
+  detective-less@1.0.2:
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
       gonzales-pe: 4.3.0
@@ -18247,7 +18152,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  detective-postcss@4.0.0(supports-color@7.2.0):
+  detective-postcss@4.0.0:
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
       is-url: 1.2.4
@@ -18288,18 +18193,18 @@ snapshots:
 
   detective-stylus@3.0.0: {}
 
-  detective-typescript@7.0.2(supports-color@7.2.0):
+  detective-typescript@7.0.2:
     dependencies:
-      '@typescript-eslint/typescript-estree': 4.33.0(supports-color@7.2.0)(typescript@3.9.10)
+      '@typescript-eslint/typescript-estree': 4.33.0(typescript@3.9.10)
       ast-module-types: 2.7.1
       node-source-walk: 4.3.0
       typescript: 3.9.10
     transitivePeerDependencies:
       - supports-color
 
-  detective-typescript@9.1.1(supports-color@7.2.0):
+  detective-typescript@9.1.1:
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.62.0(supports-color@7.2.0)(typescript@4.9.5)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.9.5)
       ast-module-types: 4.0.0
       node-source-walk: 5.0.2
       typescript: 4.9.5
@@ -18369,6 +18274,8 @@ snapshots:
 
   dotenv@16.4.7: {}
 
+  dotenv@17.3.1: {}
+
   dottie@2.0.6: {}
 
   dunder-proto@1.0.1:
@@ -18401,16 +18308,16 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  egg-cluster@1.27.1(supports-color@8.1.1):
+  egg-cluster@1.27.1:
     dependencies:
       await-event: 2.1.0
       cfork: 1.11.0
       cluster-reload: 1.1.0
       co: 4.6.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@7.2.0)
       depd: 2.0.0
-      detect-port: 1.6.1(supports-color@8.1.1)
-      egg-logger: 2.9.1(supports-color@8.1.1)
+      detect-port: 1.6.1
+      egg-logger: 2.9.1
       egg-utils: 2.5.0
       get-ready: 2.0.1
       graceful-process: 1.3.0
@@ -18429,7 +18336,7 @@ snapshots:
       should-send-same-site-none: 2.0.5
       utility: 1.18.0
 
-  egg-core@4.31.0(supports-color@8.1.1):
+  egg-core@4.31.0:
     dependencies:
       '@eggjs/router': 2.2.0
       '@types/depd': 1.1.37
@@ -18437,17 +18344,17 @@ snapshots:
       co: 4.6.0
       debug: 4.4.3(supports-color@7.2.0)
       depd: 2.0.0
-      egg-logger: 2.9.1(supports-color@8.1.1)
+      egg-logger: 2.9.1
       egg-path-matching: 1.2.0
       extend2: 1.0.1
       gals: 1.0.2
       get-ready: 2.0.1
       globby: 10.0.2
       is-type-of: 1.4.0
-      koa: 2.16.3(supports-color@7.2.0)
+      koa: 2.16.3
       koa-convert: 1.2.0
       node-homedir: 1.1.1
-      ready-callback: 2.1.0(supports-color@8.1.1)
+      ready-callback: 2.1.0
       tsconfig-paths: 4.2.0
       utility: 1.18.0
     transitivePeerDependencies:
@@ -18463,10 +18370,10 @@ snapshots:
 
   egg-errors@2.3.2: {}
 
-  egg-i18n@2.1.1(supports-color@8.1.1):
+  egg-i18n@2.1.1:
     dependencies:
-      debug: 3.2.7(supports-color@8.1.1)
-      koa-locales: 1.12.0(supports-color@8.1.1)
+      debug: 3.2.7
+      koa-locales: 1.12.0
     transitivePeerDependencies:
       - supports-color
 
@@ -18475,11 +18382,11 @@ snapshots:
       is-type-of: 1.4.0
       jsonp-body: 1.1.0
 
-  egg-logger@2.9.1(supports-color@8.1.1):
+  egg-logger@2.9.1:
     dependencies:
       chalk: 2.4.2
       circular-json-for-egg: 1.0.0
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       depd: 2.0.0
       egg-errors: 2.3.2
       iconv-lite: 0.4.24
@@ -18502,20 +18409,20 @@ snapshots:
       moment: 2.30.1
       mz: 2.7.0
 
-  egg-mock@4.2.1(supports-color@8.1.1):
+  egg-mock@4.2.1:
     dependencies:
       '@types/power-assert': 1.5.12
       '@types/supertest': 2.0.16
       await-event: 2.1.0
       co: 4.6.0
-      coffee: 5.5.1(supports-color@7.2.0)
+      coffee: 5.5.1
       debug: 4.4.3(supports-color@7.2.0)
-      detect-port: 1.6.1(supports-color@8.1.1)
-      egg-logger: 2.9.1(supports-color@8.1.1)
+      detect-port: 1.6.1
+      egg-logger: 2.9.1
       egg-utils: 2.5.0
       extend2: 1.0.1
       get-ready: 2.0.1
-      globby: 9.2.0(supports-color@8.1.1)
+      globby: 9.2.0
       is-type-of: 1.4.0
       ko-sleep: 1.1.4
       merge-descriptors: 1.0.3
@@ -18523,7 +18430,7 @@ snapshots:
       mm: 3.4.0
       mz-modules: 2.1.0
       power-assert: 1.6.1
-      supertest: 4.0.2(supports-color@8.1.1)
+      supertest: 4.0.2
       urllib: 2.44.0
     transitivePeerDependencies:
       - proxy-agent
@@ -18563,10 +18470,10 @@ snapshots:
       safe-timers: 1.1.0
       utility: 1.18.0
 
-  egg-scripts@3.1.0(supports-color@7.2.0):
+  egg-scripts@3.1.0:
     dependencies:
       await-event: 2.1.0
-      common-bin: 3.0.1(supports-color@7.2.0)
+      common-bin: 3.0.1
       egg-utils: 2.5.0
       mz: 2.7.0
       mz-modules: 2.1.0
@@ -18578,7 +18485,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  egg-security@2.11.0(supports-color@7.2.0):
+  egg-security@2.11.0:
     dependencies:
       csrf: 3.1.0
       debug: 4.4.3(supports-color@7.2.0)
@@ -18598,31 +18505,31 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  egg-session@3.3.0(supports-color@7.2.0):
+  egg-session@3.3.0:
     dependencies:
-      koa-session: 6.4.0(supports-color@7.2.0)
+      koa-session: 6.4.0
     transitivePeerDependencies:
       - supports-color
 
-  egg-socket.io@4.1.6(supports-color@8.1.1):
+  egg-socket.io@4.1.6:
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
       delegates: 1.0.0
       is-type-of: 1.4.0
       koa-compose: 4.1.0
-      socket.io: 2.5.1(supports-color@8.1.1)
-      socket.io-redis: 5.4.0(supports-color@8.1.1)
+      socket.io: 2.5.1
+      socket.io-redis: 5.4.0
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  egg-static@2.3.1(supports-color@8.1.1):
+  egg-static@2.3.1:
     dependencies:
       is-type-of: 1.4.0
       koa-compose: 4.1.0
       koa-range: 0.3.0
-      koa-static-cache: 5.1.4(supports-color@8.1.1)
+      koa-static-cache: 5.1.4
       ylru: 1.4.0
     transitivePeerDependencies:
       - supports-color
@@ -18642,15 +18549,15 @@ snapshots:
     dependencies:
       mz: 2.7.0
 
-  egg-watcher@3.1.1(supports-color@8.1.1):
+  egg-watcher@3.1.1:
     dependencies:
       camelcase: 5.3.1
       sdk-base: 3.6.0
-      wt: 1.2.0(supports-color@8.1.1)
+      wt: 1.2.0
     transitivePeerDependencies:
       - supports-color
 
-  egg@2.37.0(supports-color@8.1.1):
+  egg@2.37.0:
     dependencies:
       '@types/accepts': 1.3.7
       '@types/koa': 2.15.0
@@ -18659,26 +18566,26 @@ snapshots:
       agentkeepalive: 4.6.0
       cache-content-type: 1.0.1
       circular-json-for-egg: 1.0.0
-      cluster-client: 3.7.0(supports-color@8.1.1)
+      cluster-client: 3.7.0
       debug: 4.4.3(supports-color@7.2.0)
       delegates: 1.0.0
-      egg-cluster: 1.27.1(supports-color@8.1.1)
+      egg-cluster: 1.27.1
       egg-cookies: 2.10.1
-      egg-core: 4.31.0(supports-color@8.1.1)
+      egg-core: 4.31.0
       egg-development: 2.7.0
       egg-errors: 2.3.2
-      egg-i18n: 2.1.1(supports-color@8.1.1)
+      egg-i18n: 2.1.1
       egg-jsonp: 2.0.0
-      egg-logger: 2.9.1(supports-color@8.1.1)
+      egg-logger: 2.9.1
       egg-logrotator: 3.2.0
       egg-multipart: 2.13.1
       egg-onerror: 2.4.0
       egg-schedule: 3.7.0
-      egg-security: 2.11.0(supports-color@7.2.0)
-      egg-session: 3.3.0(supports-color@7.2.0)
-      egg-static: 2.3.1(supports-color@8.1.1)
+      egg-security: 2.11.0
+      egg-session: 3.3.0
+      egg-static: 2.3.1
       egg-view: 2.1.4
-      egg-watcher: 3.1.1(supports-color@8.1.1)
+      egg-watcher: 3.1.1
       extend2: 1.0.1
       graceful: 1.1.0
       humanize-ms: 1.2.1
@@ -18745,11 +18652,11 @@ snapshots:
 
   end-or-error@1.0.1: {}
 
-  engine.io-client@3.5.6(supports-color@8.1.1):
+  engine.io-client@3.5.6:
     dependencies:
       component-emitter: 1.3.1
       component-inherit: 0.0.3
-      debug: 3.1.0(supports-color@8.1.1)
+      debug: 3.1.0
       engine.io-parser: 2.2.1
       has-cors: 1.1.0
       indexof: 0.0.1
@@ -18763,22 +18670,10 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  engine.io-client@6.6.4(supports-color@7.2.0):
+  engine.io-client@6.6.4:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
       debug: 4.4.3(supports-color@7.2.0)
-      engine.io-parser: 5.2.3
-      ws: 8.18.3
-      xmlhttprequest-ssl: 2.1.2
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  engine.io-client@6.6.4(supports-color@8.1.1):
-    dependencies:
-      '@socket.io/component-emitter': 3.1.2
-      debug: 4.4.3(supports-color@8.1.1)
       engine.io-parser: 5.2.3
       ws: 8.18.3
       xmlhttprequest-ssl: 2.1.2
@@ -18797,12 +18692,12 @@ snapshots:
 
   engine.io-parser@5.2.3: {}
 
-  engine.io@3.6.2(supports-color@8.1.1):
+  engine.io@3.6.2:
     dependencies:
       accepts: 1.3.8
       base64id: 2.0.0
       cookie: 0.4.2
-      debug: 4.1.1(supports-color@8.1.1)
+      debug: 4.1.1
       engine.io-parser: 2.2.1
       ws: 7.5.10
     transitivePeerDependencies:
@@ -18810,7 +18705,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  engine.io@6.6.5(supports-color@7.2.0):
+  engine.io@6.6.5:
     dependencies:
       '@types/cors': 2.8.19
       '@types/node': 20.19.39
@@ -18819,22 +18714,6 @@ snapshots:
       cookie: 0.7.2
       cors: 2.8.5
       debug: 4.4.3(supports-color@7.2.0)
-      engine.io-parser: 5.2.3
-      ws: 8.18.3
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  engine.io@6.6.5(supports-color@8.1.1):
-    dependencies:
-      '@types/cors': 2.8.19
-      '@types/node': 20.19.39
-      accepts: 1.3.8
-      base64id: 2.0.0
-      cookie: 0.7.2
-      cors: 2.8.5
-      debug: 4.4.3(supports-color@8.1.1)
       engine.io-parser: 5.2.3
       ws: 8.18.3
     transitivePeerDependencies:
@@ -18904,7 +18783,7 @@ snapshots:
       has-property-descriptors: 1.0.2
       has-proto: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       internal-slot: 1.1.0
       is-array-buffer: 3.0.5
       is-callable: 1.2.7
@@ -18964,7 +18843,7 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   es-to-primitive@1.3.0:
     dependencies:
@@ -19052,38 +18931,38 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-compat-utils@0.5.1(eslint@10.0.0(supports-color@7.2.0)):
+  eslint-compat-utils@0.5.1(eslint@10.0.0):
     dependencies:
-      eslint: 10.0.0(supports-color@7.2.0)
+      eslint: 10.0.0
       semver: 7.7.4
 
-  eslint-config-prettier@10.1.8(eslint@10.0.0(supports-color@7.2.0)):
+  eslint-config-prettier@10.1.8(eslint@10.0.0):
     dependencies:
-      eslint: 10.0.0(supports-color@7.2.0)
+      eslint: 10.0.0
 
-  eslint-config-prettier@8.10.2(eslint@7.32.0(supports-color@7.2.0)):
+  eslint-config-prettier@8.10.2(eslint@7.32.0):
     dependencies:
-      eslint: 7.32.0(supports-color@7.2.0)
+      eslint: 7.32.0
 
-  eslint-plugin-es-x@7.8.0(eslint@10.0.0(supports-color@7.2.0)):
+  eslint-plugin-es-x@7.8.0(eslint@10.0.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.0.0(supports-color@7.2.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.0.0)
       '@eslint-community/regexpp': 4.12.2
-      eslint: 10.0.0(supports-color@7.2.0)
-      eslint-compat-utils: 0.5.1(eslint@10.0.0(supports-color@7.2.0))
+      eslint: 10.0.0
+      eslint-compat-utils: 0.5.1(eslint@10.0.0)
 
-  eslint-plugin-es@3.0.1(eslint@7.32.0(supports-color@7.2.0)):
+  eslint-plugin-es@3.0.1(eslint@7.32.0):
     dependencies:
-      eslint: 7.32.0(supports-color@7.2.0)
+      eslint: 7.32.0
       eslint-utils: 2.1.0
       regexpp: 3.2.0
 
-  eslint-plugin-n@17.24.0(eslint@10.0.0(supports-color@7.2.0))(typescript@5.6.3):
+  eslint-plugin-n@17.24.0(eslint@10.0.0)(typescript@5.6.3):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.0.0(supports-color@7.2.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.0.0)
       enhanced-resolve: 5.19.0
-      eslint: 10.0.0(supports-color@7.2.0)
-      eslint-plugin-es-x: 7.8.0(eslint@10.0.0(supports-color@7.2.0))
+      eslint: 10.0.0
+      eslint-plugin-es-x: 7.8.0(eslint@10.0.0)
       get-tsconfig: 4.13.6
       globals: 15.15.0
       globrex: 0.1.2
@@ -19093,33 +18972,33 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  eslint-plugin-node@11.1.0(eslint@7.32.0(supports-color@7.2.0)):
+  eslint-plugin-node@11.1.0(eslint@7.32.0):
     dependencies:
-      eslint: 7.32.0(supports-color@7.2.0)
-      eslint-plugin-es: 3.0.1(eslint@7.32.0(supports-color@7.2.0))
+      eslint: 7.32.0
+      eslint-plugin-es: 3.0.1(eslint@7.32.0)
       eslint-utils: 2.1.0
       ignore: 5.3.2
       minimatch: 3.1.5
       resolve: 1.22.11
       semver: 6.3.1
 
-  eslint-plugin-prettier@3.4.1(eslint-config-prettier@8.10.2(eslint@7.32.0(supports-color@7.2.0)))(eslint@7.32.0(supports-color@7.2.0))(prettier@2.8.8):
+  eslint-plugin-prettier@3.4.1(eslint-config-prettier@8.10.2(eslint@7.32.0))(eslint@7.32.0)(prettier@2.8.8):
     dependencies:
-      eslint: 7.32.0(supports-color@7.2.0)
+      eslint: 7.32.0
       prettier: 2.8.8
       prettier-linter-helpers: 1.0.1
     optionalDependencies:
-      eslint-config-prettier: 8.10.2(eslint@7.32.0(supports-color@7.2.0))
+      eslint-config-prettier: 8.10.2(eslint@7.32.0)
 
-  eslint-plugin-prettier@5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@10.0.0(supports-color@7.2.0)))(eslint@10.0.0(supports-color@7.2.0))(prettier@3.8.1):
+  eslint-plugin-prettier@5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@10.0.0))(eslint@10.0.0)(prettier@3.8.1):
     dependencies:
-      eslint: 10.0.0(supports-color@7.2.0)
+      eslint: 10.0.0
       prettier: 3.8.1
       prettier-linter-helpers: 1.0.1
       synckit: 0.11.12
     optionalDependencies:
       '@types/eslint': 9.6.1
-      eslint-config-prettier: 10.1.8(eslint@10.0.0(supports-color@7.2.0))
+      eslint-config-prettier: 10.1.8(eslint@10.0.0)
 
   eslint-scope@5.1.1:
     dependencies:
@@ -19145,11 +19024,11 @@ snapshots:
 
   eslint-visitor-keys@5.0.0: {}
 
-  eslint@10.0.0(supports-color@7.2.0):
+  eslint@10.0.0:
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.0.0(supports-color@7.2.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.0.0)
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.23.1(supports-color@7.2.0)
+      '@eslint/config-array': 0.23.1
       '@eslint/config-helpers': 0.5.2
       '@eslint/core': 1.1.0
       '@eslint/plugin-kit': 0.6.0
@@ -19180,11 +19059,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint@7.32.0(supports-color@7.2.0):
+  eslint@7.32.0:
     dependencies:
       '@babel/code-frame': 7.12.11
-      '@eslint/eslintrc': 0.4.3(supports-color@7.2.0)
-      '@humanwhocodes/config-array': 0.5.0(supports-color@7.2.0)
+      '@eslint/eslintrc': 0.4.3
+      '@humanwhocodes/config-array': 0.5.0
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
@@ -19339,14 +19218,14 @@ snapshots:
 
   exit@0.1.2: {}
 
-  expand-brackets@2.1.4(supports-color@8.1.1):
+  expand-brackets@2.1.4:
     dependencies:
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       define-property: 0.2.5
       extend-shallow: 2.0.1
       posix-character-classes: 0.1.1
       regex-not: 1.0.2
-      snapdragon: 0.8.2(supports-color@8.1.1)
+      snapdragon: 0.8.2
       to-regex: 3.0.2
     transitivePeerDependencies:
       - supports-color
@@ -19363,16 +19242,16 @@ snapshots:
 
   exponential-backoff@3.1.3: {}
 
-  express-rate-limit@8.3.1(express@5.2.1(supports-color@8.1.1)):
+  express-rate-limit@8.3.1(express@5.2.1):
     dependencies:
-      express: 5.2.1(supports-color@8.1.1)
+      express: 5.2.1
       ip-address: 10.1.0
 
-  express-session@1.18.1(supports-color@8.1.1):
+  express-session@1.18.1:
     dependencies:
       cookie: 0.7.2
       cookie-signature: 1.0.7
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       depd: 2.0.0
       on-headers: 1.0.2
       parseurl: 1.3.3
@@ -19381,21 +19260,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  express@4.22.2(supports-color@8.1.1):
+  express@4.22.2:
     dependencies:
       accepts: 1.3.8
       array-flatten: 1.1.1
-      body-parser: 1.20.6(supports-color@8.1.1)
+      body-parser: 1.20.6
       content-disposition: 0.5.4
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.0.7
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 1.3.1(supports-color@8.1.1)
+      finalhandler: 1.3.1
       fresh: 0.5.2
       http-errors: 2.0.1
       merge-descriptors: 1.0.3
@@ -19407,8 +19286,8 @@ snapshots:
       qs: 6.15.1
       range-parser: 1.2.1
       safe-buffer: 5.2.1
-      send: 0.19.0(supports-color@8.1.1)
-      serve-static: 1.16.2(supports-color@8.1.1)
+      send: 0.19.0
+      serve-static: 1.16.2
       setprototypeof: 1.2.0
       statuses: 2.0.2
       type-is: 1.6.18
@@ -19417,10 +19296,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  express@5.2.1(supports-color@8.1.1):
+  express@5.2.1:
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.2.2(supports-color@8.1.1)
+      body-parser: 2.3.0
       content-disposition: 1.0.1
       content-type: 1.0.5
       cookie: 0.7.2
@@ -19430,7 +19309,7 @@ snapshots:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 2.1.1(supports-color@8.1.1)
+      finalhandler: 2.1.1
       fresh: 2.0.0
       http-errors: 2.0.1
       merge-descriptors: 2.0.0
@@ -19441,9 +19320,9 @@ snapshots:
       proxy-addr: 2.0.7
       qs: 6.15.1
       range-parser: 1.2.1
-      router: 2.2.0(supports-color@7.2.0)
-      send: 1.2.1(supports-color@7.2.0)
-      serve-static: 2.2.1(supports-color@8.1.1)
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
       statuses: 2.0.2
       type-is: 2.0.1
       vary: 1.1.2
@@ -19469,24 +19348,24 @@ snapshots:
       iconv-lite: 0.4.24
       tmp: 0.0.33
 
-  extglob@2.0.4(supports-color@8.1.1):
+  extglob@2.0.4:
     dependencies:
       array-unique: 0.3.2
       define-property: 1.0.0
-      expand-brackets: 2.1.4(supports-color@8.1.1)
+      expand-brackets: 2.1.4
       extend-shallow: 2.0.1
       fragment-cache: 0.2.1
       regex-not: 1.0.2
-      snapdragon: 0.8.2(supports-color@8.1.1)
+      snapdragon: 0.8.2
       to-regex: 3.0.2
     transitivePeerDependencies:
       - supports-color
 
   extsprintf@1.3.0: {}
 
-  fake-egg@1.0.0(supports-color@8.1.1):
+  fake-egg@1.0.0:
     dependencies:
-      egg: 2.37.0(supports-color@8.1.1)
+      egg: 2.37.0
     transitivePeerDependencies:
       - proxy-agent
       - supports-color
@@ -19495,14 +19374,14 @@ snapshots:
 
   fast-diff@1.3.0: {}
 
-  fast-glob@2.2.7(supports-color@8.1.1):
+  fast-glob@2.2.7:
     dependencies:
       '@mrmlnc/readdir-enhanced': 2.2.1
       '@nodelib/fs.stat': 1.1.3
       glob-parent: 3.1.0
       is-glob: 4.0.3
       merge2: 1.4.1
-      micromatch: 3.1.10(supports-color@8.1.1)
+      micromatch: 3.1.10
     transitivePeerDependencies:
       - supports-color
 
@@ -19567,11 +19446,14 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
-  file-type@16.5.4:
+  file-type@21.3.1:
     dependencies:
-      readable-web-to-node-stream: 3.0.4
-      strtok3: 6.3.0
-      token-types: 4.2.1
+      '@tokenizer/inflate': 0.4.1
+      strtok3: 10.3.5
+      token-types: 6.1.2
+      uint8array-extras: 1.5.0
+    transitivePeerDependencies:
+      - supports-color
 
   file-uri-to-path@1.0.0: {}
 
@@ -19579,7 +19461,7 @@ snapshots:
     dependencies:
       minimatch: 5.1.9
 
-  filing-cabinet@3.3.1(supports-color@7.2.0):
+  filing-cabinet@3.3.1:
     dependencies:
       app-module-path: 2.2.0
       commander: 2.20.3
@@ -19587,11 +19469,11 @@ snapshots:
       enhanced-resolve: 5.18.4
       is-relative-path: 1.0.2
       module-definition: 3.4.0
-      module-lookup-amd: 7.0.1(supports-color@7.2.0)
+      module-lookup-amd: 7.0.1
       resolve: 1.22.11
       resolve-dependency-path: 2.0.0
       sass-lookup: 3.0.0
-      stylus-lookup: 3.0.2(supports-color@7.2.0)
+      stylus-lookup: 3.0.2
       tsconfig-paths: 3.15.0
       typescript: 3.9.10
     transitivePeerDependencies:
@@ -19608,9 +19490,9 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  finalhandler@1.3.1(supports-color@8.1.1):
+  finalhandler@1.3.1:
     dependencies:
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -19620,20 +19502,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  finalhandler@2.1.1(supports-color@7.2.0):
+  finalhandler@2.1.1:
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      on-finished: 2.4.1
-      parseurl: 1.3.3
-      statuses: 2.0.2
-    transitivePeerDependencies:
-      - supports-color
-
-  finalhandler@2.1.1(supports-color@8.1.1):
-    dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -19695,21 +19566,9 @@ snapshots:
 
   flatten@1.0.3: {}
 
-  follow-redirects@1.15.11(debug@4.4.3(supports-color@7.2.0)):
-    optionalDependencies:
-      debug: 4.4.3(supports-color@7.2.0)
-
-  follow-redirects@1.15.11(debug@4.4.3(supports-color@8.1.1)):
-    optionalDependencies:
-      debug: 4.4.3(supports-color@8.1.1)
-
   follow-redirects@1.16.0(debug@4.4.3(supports-color@7.2.0)):
     optionalDependencies:
       debug: 4.4.3(supports-color@7.2.0)
-
-  follow-redirects@1.16.0(debug@4.4.3(supports-color@8.1.1)):
-    optionalDependencies:
-      debug: 4.4.3(supports-color@8.1.1)
 
   for-each@0.3.5:
     dependencies:
@@ -19787,7 +19646,7 @@ snapshots:
 
   fs-constants@1.0.0: {}
 
-  fs-extra@11.3.0:
+  fs-extra@11.3.3:
     dependencies:
       graceful-fs: 4.2.11
       jsonfile: 6.2.0
@@ -19822,7 +19681,7 @@ snapshots:
       call-bound: 1.0.4
       define-properties: 1.2.1
       functions-have-names: 1.2.3
-      hasown: 2.0.2
+      hasown: 2.0.4
       is-callable: 1.2.7
 
   functional-red-black-tree@1.0.1: {}
@@ -20076,12 +19935,12 @@ snapshots:
       merge2: 1.4.1
       slash: 3.0.0
 
-  globby@9.2.0(supports-color@8.1.1):
+  globby@9.2.0:
     dependencies:
       '@types/glob': 7.2.0
       array-union: 1.0.2
       dir-glob: 2.2.2
-      fast-glob: 2.2.7(supports-color@8.1.1)
+      fast-glob: 2.2.7
       glob: 7.2.3
       ignore: 4.0.6
       pify: 4.0.1
@@ -20337,7 +20196,7 @@ snapshots:
 
   http-parser-js@0.5.10: {}
 
-  http-proxy-agent@4.0.1(supports-color@7.2.0):
+  http-proxy-agent@4.0.1:
     dependencies:
       '@tootallnate/once': 1.1.2
       agent-base: 6.0.2(supports-color@7.2.0)
@@ -20345,26 +20204,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  http-proxy-agent@4.0.1(supports-color@8.1.1):
-    dependencies:
-      '@tootallnate/once': 1.1.2
-      agent-base: 6.0.2(supports-color@8.1.1)
-      debug: 4.4.3(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
-  http-proxy-agent@7.0.2(supports-color@7.2.0):
+  http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  http-proxy-middleware@2.0.9(@types/express@4.17.25)(debug@4.4.3(supports-color@8.1.1)):
+  http-proxy-middleware@2.0.9(@types/express@4.17.25):
     dependencies:
       '@types/http-proxy': 1.17.17
-      http-proxy: 1.18.1(debug@4.4.3(supports-color@8.1.1))
+      http-proxy: 1.18.1
       is-glob: 4.0.3
       is-plain-obj: 3.0.0
       micromatch: 4.0.8
@@ -20373,10 +20223,10 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  http-proxy@1.18.1(debug@4.4.3(supports-color@8.1.1)):
+  http-proxy@1.18.1:
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.11(debug@4.4.3(supports-color@8.1.1))
+      follow-redirects: 1.16.0(debug@4.4.3(supports-color@7.2.0))
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -20399,14 +20249,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@5.0.1(supports-color@8.1.1):
-    dependencies:
-      agent-base: 6.0.2(supports-color@8.1.1)
-      debug: 4.4.3(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - supports-color
-
-  https-proxy-agent@7.0.6(supports-color@7.2.0):
+  https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@7.2.0)
@@ -20560,12 +20403,12 @@ snapshots:
   internal-slot@1.1.0:
     dependencies:
       es-errors: 1.3.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       side-channel: 1.1.0
 
   interpret@2.2.0: {}
 
-  ioredis@5.4.2(supports-color@7.2.0):
+  ioredis@5.4.2:
     dependencies:
       '@ioredis/commands': 1.5.0
       cluster-key-slot: 1.1.2
@@ -20579,25 +20422,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ioredis@5.4.2(supports-color@8.1.1):
+  ioredis@5.9.3:
     dependencies:
       '@ioredis/commands': 1.5.0
       cluster-key-slot: 1.1.2
-      debug: 4.4.3(supports-color@8.1.1)
-      denque: 2.1.0
-      lodash.defaults: 4.2.0
-      lodash.isarguments: 3.1.0
-      redis-errors: 1.2.0
-      redis-parser: 3.0.0
-      standard-as-callback: 2.1.0
-    transitivePeerDependencies:
-      - supports-color
-
-  ioredis@5.9.3(supports-color@8.1.1):
-    dependencies:
-      '@ioredis/commands': 1.5.0
-      cluster-key-slot: 1.1.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@7.2.0)
       denque: 2.1.0
       lodash.defaults: 4.2.0
       lodash.isarguments: 3.1.0
@@ -20617,7 +20446,7 @@ snapshots:
 
   is-accessor-descriptor@1.0.1:
     dependencies:
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   is-arguments@1.2.0:
     dependencies:
@@ -20669,11 +20498,11 @@ snapshots:
 
   is-core-module@2.16.1:
     dependencies:
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   is-data-descriptor@1.0.1:
     dependencies:
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   is-data-view@1.0.2:
     dependencies:
@@ -20906,9 +20735,9 @@ snapshots:
 
   istanbul-lib-coverage@3.2.2: {}
 
-  istanbul-lib-instrument@5.2.1(supports-color@7.2.0):
+  istanbul-lib-instrument@5.2.1:
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
       '@babel/parser': 7.29.0
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
@@ -20916,9 +20745,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  istanbul-lib-instrument@6.0.3(supports-color@7.2.0):
+  istanbul-lib-instrument@6.0.3:
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
       '@babel/parser': 7.28.5
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
@@ -20932,7 +20761,7 @@ snapshots:
       make-dir: 4.0.0
       supports-color: 7.2.0
 
-  istanbul-lib-source-maps@4.0.1(supports-color@7.2.0):
+  istanbul-lib-source-maps@4.0.1:
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
       istanbul-lib-coverage: 3.2.2
@@ -20961,10 +20790,10 @@ snapshots:
       jest-util: 29.7.0
       p-limit: 3.1.0
 
-  jest-circus@29.7.0(supports-color@7.2.0):
+  jest-circus@29.7.0:
     dependencies:
       '@jest/environment': 29.7.0
-      '@jest/expect': 29.7.0(supports-color@7.2.0)
+      '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       '@types/node': 22.12.0
@@ -20975,8 +20804,8 @@ snapshots:
       jest-each: 29.7.0
       jest-matcher-utils: 29.7.0
       jest-message-util: 29.7.0
-      jest-runtime: 29.7.0(supports-color@7.2.0)
-      jest-snapshot: 29.7.0(supports-color@7.2.0)
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
       jest-util: 29.7.0
       p-limit: 3.1.0
       pretty-format: 29.7.0
@@ -20987,16 +20816,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@22.12.0)(supports-color@7.2.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3)):
+  jest-cli@29.7.0(@types/node@22.12.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3)):
     dependencies:
-      '@jest/core': 29.7.0(supports-color@7.2.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@22.12.0)(supports-color@7.2.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3))
+      create-jest: 29.7.0(@types/node@22.12.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@22.12.0)(supports-color@7.2.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3))
+      jest-config: 29.7.0(@types/node@22.12.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -21006,23 +20835,23 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@20.19.39)(supports-color@7.2.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3)):
+  jest-config@29.7.0(@types/node@20.19.39)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3)):
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
       '@jest/test-sequencer': 29.7.0
       '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.28.5(supports-color@7.2.0))(supports-color@7.2.0)
+      babel-jest: 29.7.0(@babel/core@7.28.5)
       chalk: 4.1.2
       ci-info: 3.9.0
       deepmerge: 4.3.1
       glob: 7.2.3
       graceful-fs: 4.2.11
-      jest-circus: 29.7.0(supports-color@7.2.0)
+      jest-circus: 29.7.0
       jest-environment-node: 29.7.0
       jest-get-type: 29.6.3
       jest-regex-util: 29.6.3
       jest-resolve: 29.7.0
-      jest-runner: 29.7.0(supports-color@7.2.0)
+      jest-runner: 29.7.0
       jest-util: 29.7.0
       jest-validate: 29.7.0
       micromatch: 4.0.8
@@ -21037,23 +20866,23 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@22.12.0)(supports-color@7.2.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3)):
+  jest-config@29.7.0(@types/node@22.12.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3)):
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
       '@jest/test-sequencer': 29.7.0
       '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.28.5(supports-color@7.2.0))(supports-color@7.2.0)
+      babel-jest: 29.7.0(@babel/core@7.28.5)
       chalk: 4.1.2
       ci-info: 3.9.0
       deepmerge: 4.3.1
       glob: 7.2.3
       graceful-fs: 4.2.11
-      jest-circus: 29.7.0(supports-color@7.2.0)
+      jest-circus: 29.7.0
       jest-environment-node: 29.7.0
       jest-get-type: 29.6.3
       jest-regex-util: 29.6.3
       jest-resolve: 29.7.0
-      jest-runner: 29.7.0(supports-color@7.2.0)
+      jest-runner: 29.7.0
       jest-util: 29.7.0
       jest-validate: 29.7.0
       micromatch: 4.0.8
@@ -21157,10 +20986,10 @@ snapshots:
 
   jest-regex-util@29.6.3: {}
 
-  jest-resolve-dependencies@29.7.0(supports-color@7.2.0):
+  jest-resolve-dependencies@29.7.0:
     dependencies:
       jest-regex-util: 29.6.3
-      jest-snapshot: 29.7.0(supports-color@7.2.0)
+      jest-snapshot: 29.7.0
     transitivePeerDependencies:
       - supports-color
 
@@ -21176,12 +21005,12 @@ snapshots:
       resolve.exports: 2.0.3
       slash: 3.0.0
 
-  jest-runner@29.7.0(supports-color@7.2.0):
+  jest-runner@29.7.0:
     dependencies:
       '@jest/console': 29.7.0
       '@jest/environment': 29.7.0
       '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0(supports-color@7.2.0)
+      '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@types/node': 22.12.0
       chalk: 4.1.2
@@ -21193,7 +21022,7 @@ snapshots:
       jest-leak-detector: 29.7.0
       jest-message-util: 29.7.0
       jest-resolve: 29.7.0
-      jest-runtime: 29.7.0(supports-color@7.2.0)
+      jest-runtime: 29.7.0
       jest-util: 29.7.0
       jest-watcher: 29.7.0
       jest-worker: 29.7.0
@@ -21202,14 +21031,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  jest-runtime@29.7.0(supports-color@7.2.0):
+  jest-runtime@29.7.0:
     dependencies:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
-      '@jest/globals': 29.7.0(supports-color@7.2.0)
+      '@jest/globals': 29.7.0
       '@jest/source-map': 29.6.3
       '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0(supports-color@7.2.0)
+      '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@types/node': 22.12.0
       chalk: 4.1.2
@@ -21222,24 +21051,24 @@ snapshots:
       jest-mock: 29.7.0
       jest-regex-util: 29.6.3
       jest-resolve: 29.7.0
-      jest-snapshot: 29.7.0(supports-color@7.2.0)
+      jest-snapshot: 29.7.0
       jest-util: 29.7.0
       slash: 3.0.0
       strip-bom: 4.0.0
     transitivePeerDependencies:
       - supports-color
 
-  jest-snapshot@29.7.0(supports-color@7.2.0):
+  jest-snapshot@29.7.0:
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
       '@babel/generator': 7.28.5
-      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.5(supports-color@7.2.0))
-      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.5(supports-color@7.2.0))
+      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.5)
       '@babel/types': 7.28.5
       '@jest/expect-utils': 29.7.0
-      '@jest/transform': 29.7.0(supports-color@7.2.0)
+      '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.28.5(supports-color@7.2.0))
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.28.5)
       chalk: 4.1.2
       expect: 29.7.0
       graceful-fs: 4.2.11
@@ -21285,7 +21114,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 22.12.0
+      '@types/node': 20.19.39
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -21296,19 +21125,19 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@22.12.0)(supports-color@7.2.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3)):
+  jest@29.7.0(@types/node@22.12.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3)):
     dependencies:
-      '@jest/core': 29.7.0(supports-color@7.2.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@22.12.0)(supports-color@7.2.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3))
+      jest-cli: 29.7.0(@types/node@22.12.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
       - supports-color
       - ts-node
 
-  joi@17.13.3:
+  joi@17.13.4:
     dependencies:
       '@hapi/hoek': 9.3.0
       '@hapi/topo': 5.1.0
@@ -21471,11 +21300,11 @@ snapshots:
 
   kleur@3.0.3: {}
 
-  knex@3.1.0(better-sqlite3@12.9.0)(mysql2@3.16.0)(sqlite3@5.1.7(supports-color@8.1.1))(supports-color@8.1.1):
+  knex@3.1.0(better-sqlite3@12.9.0)(sqlite3@5.1.7):
     dependencies:
       colorette: 2.0.19
       commander: 10.0.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       escalade: 3.2.0
       esm: 3.2.25
       get-package-type: 0.1.0
@@ -21489,8 +21318,7 @@ snapshots:
       tildify: 2.0.0
     optionalDependencies:
       better-sqlite3: 12.9.0
-      mysql2: 3.16.0
-      sqlite3: 5.1.7(supports-color@8.1.1)
+      sqlite3: 5.1.7
     transitivePeerDependencies:
       - supports-color
 
@@ -21522,9 +21350,9 @@ snapshots:
 
   koa-is-json@1.0.0: {}
 
-  koa-locales@1.12.0(supports-color@8.1.1):
+  koa-locales@1.12.0:
     dependencies:
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       humanize-ms: 1.2.1
       ini: 1.3.8
       object-assign: 4.1.1
@@ -21544,7 +21372,7 @@ snapshots:
     dependencies:
       stream-slice: 0.1.2
 
-  koa-session@6.4.0(supports-color@7.2.0):
+  koa-session@6.4.0:
     dependencies:
       crc: 3.8.0
       debug: 4.4.3(supports-color@7.2.0)
@@ -21553,17 +21381,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  koa-static-cache@5.1.4(supports-color@8.1.1):
+  koa-static-cache@5.1.4:
     dependencies:
       compressible: 2.0.18
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7
       fs-readdir-recursive: 1.1.0
       mime-types: 2.1.35
       mz: 2.7.0
     transitivePeerDependencies:
       - supports-color
 
-  koa@2.16.3(supports-color@7.2.0):
+  koa@2.16.3:
     dependencies:
       accepts: 1.3.8
       cache-content-type: 1.0.1
@@ -21627,10 +21455,10 @@ snapshots:
       picocolors: 1.1.1
       shell-quote: 1.8.3
 
-  leoric@2.14.0(mysql2@3.16.0)(sqlite3@5.1.7(supports-color@8.1.1))(supports-color@8.1.1):
+  leoric@2.14.0(mysql2@3.16.0)(sqlite3@5.1.7):
     dependencies:
       dayjs: 1.11.19
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7
       deep-equal: 2.2.3
       heredoc: 1.3.1
       pluralize: 7.0.0
@@ -21640,17 +21468,17 @@ snapshots:
       validator: 13.15.26
     optionalDependencies:
       mysql2: 3.16.0
-      sqlite3: 5.1.7(supports-color@8.1.1)
+      sqlite3: 5.1.7
     transitivePeerDependencies:
       - supports-color
 
-  lerna-changelog@2.2.0(supports-color@7.2.0):
+  lerna-changelog@2.2.0:
     dependencies:
       chalk: 4.1.2
       cli-highlight: 2.1.11
       execa: 5.1.1
       hosted-git-info: 4.1.0
-      make-fetch-happen: 9.1.0(supports-color@7.2.0)
+      make-fetch-happen: 9.1.0
       p-map: 3.0.0
       progress: 2.0.3
       yargs: 17.7.2
@@ -21658,9 +21486,9 @@ snapshots:
       - bluebird
       - supports-color
 
-  lerna@9.0.7(@types/node@22.12.0)(supports-color@7.2.0):
+  lerna@9.0.7(@types/node@22.12.0):
     dependencies:
-      '@npmcli/arborist': 9.1.6(supports-color@7.2.0)
+      '@npmcli/arborist': 9.1.6
       '@npmcli/package-json': 7.0.2
       '@npmcli/run-script': 10.0.3
       '@nx/devkit': 22.7.8(nx@22.7.8)
@@ -21693,14 +21521,14 @@ snapshots:
       is-ci: 3.0.1
       jest-diff: 30.4.1
       js-yaml: 4.1.1
-      libnpmaccess: 10.0.3(supports-color@7.2.0)
-      libnpmpublish: 11.1.2(supports-color@7.2.0)
+      libnpmaccess: 10.0.3
+      libnpmpublish: 11.1.2
       load-json-file: 6.2.0
-      make-fetch-happen: 15.0.2(supports-color@7.2.0)
+      make-fetch-happen: 15.0.2
       minimatch: 3.1.4
       npm-package-arg: 13.0.1
       npm-packlist: 10.0.3
-      npm-registry-fetch: 19.1.0(supports-color@7.2.0)
+      npm-registry-fetch: 19.1.0
       nx: 22.7.8
       p-map: 4.0.0
       p-map-series: 2.1.0
@@ -21708,7 +21536,7 @@ snapshots:
       p-queue: 6.6.2
       p-reduce: 2.1.0
       p-waterfall: 2.1.1
-      pacote: 21.0.1(supports-color@7.2.0)
+      pacote: 21.0.1
       read-cmd-shim: 4.0.0
       semver: 7.7.2
       signal-exit: 3.0.7
@@ -21740,22 +21568,22 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
-  libnpmaccess@10.0.3(supports-color@7.2.0):
+  libnpmaccess@10.0.3:
     dependencies:
       npm-package-arg: 13.0.1
-      npm-registry-fetch: 19.1.0(supports-color@7.2.0)
+      npm-registry-fetch: 19.1.0
     transitivePeerDependencies:
       - supports-color
 
-  libnpmpublish@11.1.2(supports-color@7.2.0):
+  libnpmpublish@11.1.2:
     dependencies:
       '@npmcli/package-json': 7.0.2
       ci-info: 4.3.1
       npm-package-arg: 13.0.1
-      npm-registry-fetch: 19.1.0(supports-color@7.2.0)
+      npm-registry-fetch: 19.1.0
       proc-log: 5.0.0
       semver: 7.7.4
-      sigstore: 4.1.1(supports-color@7.2.0)
+      sigstore: 4.1.1
       ssri: 12.0.0
     transitivePeerDependencies:
       - supports-color
@@ -21912,25 +21740,25 @@ snapshots:
 
   luxon@3.7.2: {}
 
-  madge@6.1.0(supports-color@7.2.0)(typescript@5.6.3):
+  madge@6.1.0(typescript@5.6.3):
     dependencies:
       chalk: 4.1.2
       commander: 7.2.0
       commondir: 1.0.1
       debug: 4.4.3(supports-color@7.2.0)
-      dependency-tree: 9.0.0(supports-color@7.2.0)
+      dependency-tree: 9.0.0
       detective-amd: 4.2.0
       detective-cjs: 4.1.0
       detective-es6: 3.0.1
-      detective-less: 1.0.2(supports-color@7.2.0)
+      detective-less: 1.0.2
       detective-postcss: 6.1.3
       detective-sass: 4.1.3
       detective-scss: 3.1.1
       detective-stylus: 2.0.1
-      detective-typescript: 9.1.1(supports-color@7.2.0)
+      detective-typescript: 9.1.1
       ora: 5.4.1
       pluralize: 8.0.0
-      precinct: 8.3.1(supports-color@7.2.0)
+      precinct: 8.3.1
       pretty-ms: 7.0.1
       rc: 1.2.8
       stream-to-array: 2.3.0
@@ -21955,9 +21783,9 @@ snapshots:
 
   make-error@1.3.6: {}
 
-  make-fetch-happen@15.0.2(supports-color@7.2.0):
+  make-fetch-happen@15.0.2:
     dependencies:
-      '@npmcli/agent': 4.0.2(supports-color@7.2.0)
+      '@npmcli/agent': 4.0.2
       cacache: 20.0.4
       http-cache-semantics: 4.2.0
       minipass: 7.1.3
@@ -21971,10 +21799,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  make-fetch-happen@15.0.6(supports-color@7.2.0):
+  make-fetch-happen@15.0.6:
     dependencies:
       '@gar/promise-retry': 1.0.3
-      '@npmcli/agent': 4.0.2(supports-color@7.2.0)
+      '@npmcli/agent': 4.0.2
       '@npmcli/redact': 4.0.0
       cacache: 20.0.4
       http-cache-semantics: 4.2.0
@@ -21988,12 +21816,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  make-fetch-happen@9.1.0(supports-color@7.2.0):
+  make-fetch-happen@9.1.0:
     dependencies:
       agentkeepalive: 4.6.0
       cacache: 15.3.0
       http-cache-semantics: 4.2.0
-      http-proxy-agent: 4.0.1(supports-color@7.2.0)
+      http-proxy-agent: 4.0.1
       https-proxy-agent: 5.0.1(supports-color@7.2.0)
       is-lambda: 1.0.1
       lru-cache: 6.0.0
@@ -22004,34 +21832,11 @@ snapshots:
       minipass-pipeline: 1.2.4
       negotiator: 0.6.4
       promise-retry: 2.0.1
-      socks-proxy-agent: 6.2.1(supports-color@7.2.0)
+      socks-proxy-agent: 6.2.1
       ssri: 8.0.1
     transitivePeerDependencies:
       - bluebird
       - supports-color
-
-  make-fetch-happen@9.1.0(supports-color@8.1.1):
-    dependencies:
-      agentkeepalive: 4.6.0
-      cacache: 15.3.0
-      http-cache-semantics: 4.2.0
-      http-proxy-agent: 4.0.1(supports-color@8.1.1)
-      https-proxy-agent: 5.0.1(supports-color@8.1.1)
-      is-lambda: 1.0.1
-      lru-cache: 6.0.0
-      minipass: 3.3.6
-      minipass-collect: 1.0.2
-      minipass-fetch: 1.4.1
-      minipass-flush: 1.0.5
-      minipass-pipeline: 1.2.4
-      negotiator: 0.6.4
-      promise-retry: 2.0.1
-      socks-proxy-agent: 6.2.1(supports-color@8.1.1)
-      ssri: 8.0.1
-    transitivePeerDependencies:
-      - bluebird
-      - supports-color
-    optional: true
 
   makeerror@1.0.12:
     dependencies:
@@ -22109,7 +21914,7 @@ snapshots:
 
   memory-pager@1.5.0: {}
 
-  memorystore@1.6.7(supports-color@7.2.0):
+  memorystore@1.6.7:
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
       lru-cache: 4.1.5
@@ -22172,20 +21977,20 @@ snapshots:
 
   micromark-util-types@2.0.2: {}
 
-  micromatch@3.1.10(supports-color@8.1.1):
+  micromatch@3.1.10:
     dependencies:
       arr-diff: 4.0.0
       array-unique: 0.3.2
-      braces: 2.3.2(supports-color@8.1.1)
+      braces: 2.3.2
       define-property: 2.0.2
       extend-shallow: 3.0.2
-      extglob: 2.0.4(supports-color@8.1.1)
+      extglob: 2.0.4
       fragment-cache: 0.2.1
       kind-of: 6.0.3
-      nanomatch: 1.2.13(supports-color@8.1.1)
+      nanomatch: 1.2.13
       object.pick: 1.3.0
       regex-not: 1.0.2
-      snapdragon: 0.8.2(supports-color@8.1.1)
+      snapdragon: 0.8.2
       to-regex: 3.0.2
     transitivePeerDependencies:
       - supports-color
@@ -22195,7 +22000,7 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.2
 
-  mikro-orm@6.4.5: {}
+  mikro-orm@6.6.10: {}
 
   mime-db@1.52.0: {}
 
@@ -22409,7 +22214,7 @@ snapshots:
       ast-module-types: 4.0.0
       node-source-walk: 5.0.2
 
-  module-lookup-amd@7.0.1(supports-color@7.2.0):
+  module-lookup-amd@7.0.1:
     dependencies:
       commander: 2.20.3
       debug: 4.4.3(supports-color@7.2.0)
@@ -22438,32 +22243,13 @@ snapshots:
     optionalDependencies:
       socks: 2.8.7
 
-  mongoose@8.9.5(socks@2.8.7)(supports-color@7.2.0):
+  mongoose@8.9.5(socks@2.8.7):
     dependencies:
       bson: 6.10.4
       kareem: 2.6.3
       mongodb: 6.12.0(socks@2.8.7)
       mpath: 0.9.0
-      mquery: 5.0.0(supports-color@7.2.0)
-      ms: 2.1.3
-      sift: 17.1.3
-    transitivePeerDependencies:
-      - '@aws-sdk/credential-providers'
-      - '@mongodb-js/zstd'
-      - gcp-metadata
-      - kerberos
-      - mongodb-client-encryption
-      - snappy
-      - socks
-      - supports-color
-
-  mongoose@8.9.5(socks@2.8.7)(supports-color@8.1.1):
-    dependencies:
-      bson: 6.10.4
-      kareem: 2.6.3
-      mongodb: 6.12.0(socks@2.8.7)
-      mpath: 0.9.0
-      mquery: 5.0.0(supports-color@8.1.1)
+      mquery: 5.0.0
       ms: 2.1.3
       sift: 17.1.3
     transitivePeerDependencies:
@@ -22478,7 +22264,7 @@ snapshots:
 
   mpath@0.9.0: {}
 
-  mqtt-packet@9.0.2(supports-color@7.2.0):
+  mqtt-packet@9.0.2:
     dependencies:
       bl: 6.1.6
       debug: 4.4.3(supports-color@7.2.0)
@@ -22486,7 +22272,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  mqtt@5.15.2(supports-color@7.2.0):
+  mqtt@5.15.2:
     dependencies:
       '@types/readable-stream': 4.0.23
       '@types/ws': 8.18.1
@@ -22496,8 +22282,8 @@ snapshots:
       help-me: 5.0.0
       lru-cache: 10.4.3
       minimist: 1.2.8
-      mqtt-packet: 9.0.2(supports-color@7.2.0)
-      number-allocator: 1.0.14(supports-color@7.2.0)
+      mqtt-packet: 9.0.2
+      number-allocator: 1.0.14
       readable-stream: 4.7.0
       rfdc: 1.4.1
       socks: 2.8.7
@@ -22509,15 +22295,9 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  mquery@5.0.0(supports-color@7.2.0):
+  mquery@5.0.0:
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
-    transitivePeerDependencies:
-      - supports-color
-
-  mquery@5.0.0(supports-color@8.1.1):
-    dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -22569,15 +22349,15 @@ snapshots:
 
   mute-stream@2.0.0: {}
 
-  mwts@1.3.0(supports-color@8.1.1)(typescript@5.6.3):
+  mwts@1.3.0(typescript@5.6.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0(supports-color@7.2.0))(supports-color@8.1.1)(typescript@5.6.3))(eslint@7.32.0(supports-color@7.2.0))(supports-color@8.1.1)(typescript@5.6.3)
-      '@typescript-eslint/parser': 5.62.0(eslint@7.32.0(supports-color@7.2.0))(supports-color@8.1.1)(typescript@5.6.3)
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.6.3))(eslint@7.32.0)(typescript@5.6.3)
+      '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@5.6.3)
       chalk: 4.1.2
-      eslint: 7.32.0(supports-color@7.2.0)
-      eslint-config-prettier: 8.10.2(eslint@7.32.0(supports-color@7.2.0))
-      eslint-plugin-node: 11.1.0(eslint@7.32.0(supports-color@7.2.0))
-      eslint-plugin-prettier: 3.4.1(eslint-config-prettier@8.10.2(eslint@7.32.0(supports-color@7.2.0)))(eslint@7.32.0(supports-color@7.2.0))(prettier@2.8.8)
+      eslint: 7.32.0
+      eslint-config-prettier: 8.10.2(eslint@7.32.0)
+      eslint-plugin-node: 11.1.0(eslint@7.32.0)
+      eslint-plugin-prettier: 3.4.1(eslint-config-prettier@8.10.2(eslint@7.32.0))(eslint@7.32.0)(prettier@2.8.8)
       execa: 5.1.1
       inquirer: 7.3.3
       json5: 2.2.3
@@ -22591,16 +22371,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  mwts@2.0.4(@types/eslint@9.6.1)(supports-color@7.2.0)(typescript@5.6.3):
+  mwts@2.0.4(@types/eslint@9.6.1)(typescript@5.6.3):
     dependencies:
-      '@eslint/js': 10.0.1(eslint@10.0.0(supports-color@7.2.0))
-      '@typescript-eslint/eslint-plugin': 8.56.0(@typescript-eslint/parser@8.56.0(eslint@10.0.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.6.3))(eslint@10.0.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.6.3)
-      '@typescript-eslint/parser': 8.56.0(eslint@10.0.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.6.3)
+      '@eslint/js': 10.0.1(eslint@10.0.0)
+      '@typescript-eslint/eslint-plugin': 8.56.0(@typescript-eslint/parser@8.56.0(eslint@10.0.0)(typescript@5.6.3))(eslint@10.0.0)(typescript@5.6.3)
+      '@typescript-eslint/parser': 8.56.0(eslint@10.0.0)(typescript@5.6.3)
       chalk: 4.1.2
-      eslint: 10.0.0(supports-color@7.2.0)
-      eslint-config-prettier: 10.1.8(eslint@10.0.0(supports-color@7.2.0))
-      eslint-plugin-n: 17.24.0(eslint@10.0.0(supports-color@7.2.0))(typescript@5.6.3)
-      eslint-plugin-prettier: 5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@10.0.0(supports-color@7.2.0)))(eslint@10.0.0(supports-color@7.2.0))(prettier@3.8.1)
+      eslint: 10.0.0
+      eslint-config-prettier: 10.1.8(eslint@10.0.0)
+      eslint-plugin-n: 17.24.0(eslint@10.0.0)(typescript@5.6.3)
+      eslint-plugin-prettier: 5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@10.0.0))(eslint@10.0.0)(prettier@3.8.1)
       execa: 5.1.1
       globals: 16.5.0
       inquirer: 7.3.3
@@ -22610,7 +22390,7 @@ snapshots:
       prettier: 3.8.1
       rimraf: 3.0.2
       typescript: 5.6.3
-      typescript-eslint: 8.56.0(eslint@10.0.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.6.3)
+      typescript-eslint: 8.56.0(eslint@10.0.0)(typescript@5.6.3)
       update-notifier: 6.0.2
       write-file-atomic: 6.0.0
     transitivePeerDependencies:
@@ -22662,7 +22442,7 @@ snapshots:
 
   nanoid@3.3.18: {}
 
-  nanomatch@1.2.13(supports-color@8.1.1):
+  nanomatch@1.2.13:
     dependencies:
       arr-diff: 4.0.0
       array-unique: 0.3.2
@@ -22673,7 +22453,7 @@ snapshots:
       kind-of: 6.0.3
       object.pick: 1.3.0
       regex-not: 1.0.2
-      snapdragon: 0.8.2(supports-color@8.1.1)
+      snapdragon: 0.8.2
       to-regex: 3.0.2
     transitivePeerDependencies:
       - supports-color
@@ -22696,7 +22476,7 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next@16.2.12(@babel/core@7.28.5(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@16.2.12(@babel/core@7.28.5)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 16.2.12
       '@swc/helpers': 0.5.15
@@ -22705,7 +22485,7 @@ snapshots:
       postcss: 8.4.31
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      styled-jsx: 5.1.6(@babel/core@7.28.5(supports-color@8.1.1))(react@18.3.1)
+      styled-jsx: 5.1.6(@babel/core@7.28.5)(react@18.3.1)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.12
       '@next/swc-darwin-x64': 16.2.12
@@ -22736,17 +22516,9 @@ snapshots:
       lower-case: 2.0.2
       tslib: 2.8.1
 
-  nock@13.5.6(supports-color@7.2.0):
+  nock@13.5.6:
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
-      json-stringify-safe: 5.0.1
-      propagate: 2.0.1
-    transitivePeerDependencies:
-      - supports-color
-
-  nock@13.5.6(supports-color@8.1.1):
-    dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
       json-stringify-safe: 5.0.1
       propagate: 2.0.1
     transitivePeerDependencies:
@@ -22784,12 +22556,12 @@ snapshots:
       undici: 6.28.0
       which: 6.0.1
 
-  node-gyp@8.4.1(supports-color@8.1.1):
+  node-gyp@8.4.1:
     dependencies:
       env-paths: 2.2.1
       glob: 7.2.3
       graceful-fs: 4.2.11
-      make-fetch-happen: 9.1.0(supports-color@8.1.1)
+      make-fetch-happen: 9.1.0
       nopt: 5.0.0
       npmlog: 6.0.2
       rimraf: 3.0.2
@@ -22907,11 +22679,11 @@ snapshots:
       npm-package-arg: 13.0.1
       semver: 7.7.4
 
-  npm-registry-fetch@19.1.0(supports-color@7.2.0):
+  npm-registry-fetch@19.1.0:
     dependencies:
       '@npmcli/redact': 3.2.2
       jsonparse: 1.3.1
-      make-fetch-happen: 15.0.2(supports-color@7.2.0)
+      make-fetch-happen: 15.0.2
       minipass: 7.1.3
       minipass-fetch: 4.0.1
       minizlib: 3.1.0
@@ -22937,13 +22709,13 @@ snapshots:
       set-blocking: 2.0.0
     optional: true
 
-  null-loader@4.0.1(webpack@5.104.1(esbuild@0.27.3)(uglify-js@3.19.3)):
+  null-loader@4.0.1(webpack@5.104.1):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.104.1(esbuild@0.27.3)(uglify-js@3.19.3)
+      webpack: 5.104.1
 
-  number-allocator@1.0.14(supports-color@7.2.0):
+  number-allocator@1.0.14:
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
       js-sdsl: 4.3.0
@@ -22958,14 +22730,14 @@ snapshots:
     optionalDependencies:
       chokidar: 3.6.0
 
-  nx@16.10.0(debug@4.4.3(supports-color@7.2.0)):
+  nx@16.10.0:
     dependencies:
-      '@nrwl/tao': 16.10.0(debug@4.4.3(supports-color@7.2.0))
+      '@nrwl/tao': 16.10.0
       '@parcel/watcher': 2.0.4
       '@yarnpkg/lockfile': 1.1.0
       '@yarnpkg/parsers': 3.0.0-rc.46
       '@zkochan/js-yaml': 0.0.6
-      axios: 1.13.5(debug@4.4.3(supports-color@7.2.0))
+      axios: 1.18.0
       chalk: 4.1.2
       cli-cursor: 3.1.0
       cli-spinners: 2.6.1
@@ -23009,6 +22781,7 @@ snapshots:
       '@nx/nx-win32-x64-msvc': 16.10.0
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   nx@22.7.8:
     dependencies:
@@ -23378,7 +23151,7 @@ snapshots:
       registry-url: 6.0.1
       semver: 7.7.4
 
-  pacote@21.0.1(supports-color@7.2.0):
+  pacote@21.0.1:
     dependencies:
       '@npmcli/git': 6.0.3
       '@npmcli/installed-package-contents': 3.0.0
@@ -23391,16 +23164,16 @@ snapshots:
       npm-package-arg: 13.0.1
       npm-packlist: 10.0.3
       npm-pick-manifest: 10.0.0
-      npm-registry-fetch: 19.1.0(supports-color@7.2.0)
+      npm-registry-fetch: 19.1.0
       proc-log: 5.0.0
       promise-retry: 2.0.1
-      sigstore: 4.1.1(supports-color@7.2.0)
+      sigstore: 4.1.1
       ssri: 12.0.0
       tar: 7.5.11
     transitivePeerDependencies:
       - supports-color
 
-  pacote@21.5.1(supports-color@7.2.0):
+  pacote@21.5.1:
     dependencies:
       '@gar/promise-retry': 1.0.3
       '@npmcli/git': 7.0.2
@@ -23414,9 +23187,9 @@ snapshots:
       npm-package-arg: 13.0.1
       npm-packlist: 10.0.3
       npm-pick-manifest: 11.0.3
-      npm-registry-fetch: 19.1.0(supports-color@7.2.0)
+      npm-registry-fetch: 19.1.0
       proc-log: 6.1.0
-      sigstore: 4.1.1(supports-color@7.2.0)
+      sigstore: 4.1.1
       ssri: 13.0.1
       tar: 7.5.11
     transitivePeerDependencies:
@@ -23557,8 +23330,6 @@ snapshots:
       through: 2.3.8
 
   pedding@1.1.0: {}
-
-  peek-readable@4.1.0: {}
 
   performance-now@2.1.0: {}
 
@@ -23739,25 +23510,25 @@ snapshots:
       tar-fs: 2.1.4
       tunnel-agent: 0.6.0
 
-  precinct@8.3.1(supports-color@7.2.0):
+  precinct@8.3.1:
     dependencies:
       commander: 2.20.3
       debug: 4.4.3(supports-color@7.2.0)
       detective-amd: 3.1.2
       detective-cjs: 3.1.3
       detective-es6: 2.2.2
-      detective-less: 1.0.2(supports-color@7.2.0)
-      detective-postcss: 4.0.0(supports-color@7.2.0)
+      detective-less: 1.0.2
+      detective-postcss: 4.0.0
       detective-sass: 3.0.2
       detective-scss: 2.0.2
       detective-stylus: 1.0.3
-      detective-typescript: 7.0.2(supports-color@7.2.0)
+      detective-typescript: 7.0.2
       module-definition: 3.4.0
       node-source-walk: 4.3.0
     transitivePeerDependencies:
       - supports-color
 
-  precinct@9.2.1(supports-color@7.2.0):
+  precinct@9.2.1:
     dependencies:
       '@dependents/detective-less': 3.0.2
       commander: 9.5.0
@@ -23768,7 +23539,7 @@ snapshots:
       detective-sass: 4.1.3
       detective-scss: 3.1.1
       detective-stylus: 3.0.0
-      detective-typescript: 9.1.1(supports-color@7.2.0)
+      detective-typescript: 9.1.1
       module-definition: 4.1.0
       node-source-walk: 5.0.2
     transitivePeerDependencies:
@@ -23891,8 +23662,6 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
-  proxy-from-env@1.1.0: {}
-
   proxy-from-env@2.1.0: {}
 
   ps-tree@1.2.0:
@@ -23942,6 +23711,11 @@ snapshots:
   qs@6.15.1:
     dependencies:
       side-channel: 1.1.0
+
+  qs@6.15.3:
+    dependencies:
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
 
   qs@6.5.3: {}
 
@@ -24084,19 +23858,15 @@ snapshots:
       process: 0.11.10
       string_decoder: 1.3.0
 
-  readable-web-to-node-stream@3.0.4:
-    dependencies:
-      readable-stream: 4.7.0
-
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.2
 
   readdirp@4.1.2: {}
 
-  ready-callback@2.1.0(supports-color@8.1.1):
+  ready-callback@2.1.0:
     dependencies:
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       get-ready: 2.0.1
       once: 1.4.0
       uuid: 3.4.0
@@ -24322,7 +24092,7 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.54.0
       fsevents: 2.3.3
 
-  router@2.2.0(supports-color@7.2.0):
+  router@2.2.0:
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
       depd: 2.0.0
@@ -24464,9 +24234,9 @@ snapshots:
 
   semver@7.7.4: {}
 
-  send@0.19.0(supports-color@8.1.1):
+  send@0.19.0:
     dependencies:
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       depd: 2.0.0
       destroy: 1.2.0
       encodeurl: 1.0.2
@@ -24482,25 +24252,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  send@1.2.1(supports-color@7.2.0):
+  send@1.2.1:
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      etag: 1.8.1
-      fresh: 2.0.0
-      http-errors: 2.0.1
-      mime-types: 3.0.2
-      ms: 2.1.3
-      on-finished: 2.4.1
-      range-parser: 1.2.1
-      statuses: 2.0.2
-    transitivePeerDependencies:
-      - supports-color
-
-  send@1.2.1(supports-color@8.1.1):
-    dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -24526,23 +24280,15 @@ snapshots:
 
   sequelize-pool@7.1.0: {}
 
-  sequelize-typescript@2.1.6(@types/node@22.12.0)(@types/validator@13.15.10)(reflect-metadata@0.2.2)(sequelize@6.37.8(mysql2@3.16.0)(sqlite3@5.1.7(supports-color@8.1.1))(supports-color@7.2.0)):
+  sequelize-typescript@2.1.6(@types/node@22.12.0)(@types/validator@13.15.10)(reflect-metadata@0.2.2)(sequelize@6.37.8(sqlite3@5.1.7)):
     dependencies:
       '@types/node': 22.12.0
       '@types/validator': 13.15.10
       glob: 7.2.0
       reflect-metadata: 0.2.2
-      sequelize: 6.37.8(mysql2@3.16.0)(sqlite3@5.1.7(supports-color@8.1.1))(supports-color@7.2.0)
+      sequelize: 6.37.8(mysql2@3.16.0)(sqlite3@5.1.7)
 
-  sequelize-typescript@2.1.6(@types/node@22.12.0)(@types/validator@13.15.10)(reflect-metadata@0.2.2)(sequelize@6.37.8(mysql2@3.16.0)(sqlite3@5.1.7(supports-color@8.1.1))(supports-color@8.1.1)):
-    dependencies:
-      '@types/node': 22.12.0
-      '@types/validator': 13.15.10
-      glob: 7.2.0
-      reflect-metadata: 0.2.2
-      sequelize: 6.37.8(mysql2@3.16.0)(sqlite3@5.1.7(supports-color@8.1.1))(supports-color@8.1.1)
-
-  sequelize@6.37.8(mysql2@3.16.0)(sqlite3@5.1.7(supports-color@8.1.1))(supports-color@7.2.0):
+  sequelize@6.37.8(mysql2@3.16.0)(sqlite3@5.1.7):
     dependencies:
       '@types/debug': 4.1.12
       '@types/validator': 13.15.10
@@ -24562,31 +24308,7 @@ snapshots:
       wkx: 0.5.0
     optionalDependencies:
       mysql2: 3.16.0
-      sqlite3: 5.1.7(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - supports-color
-
-  sequelize@6.37.8(mysql2@3.16.0)(sqlite3@5.1.7(supports-color@8.1.1))(supports-color@8.1.1):
-    dependencies:
-      '@types/debug': 4.1.12
-      '@types/validator': 13.15.10
-      debug: 4.4.3(supports-color@8.1.1)
-      dottie: 2.0.6
-      inflection: 1.13.4
-      lodash: 4.17.23
-      moment: 2.30.1
-      moment-timezone: 0.5.48
-      pg-connection-string: 2.9.1
-      retry-as-promised: 7.1.1
-      semver: 7.7.4
-      sequelize-pool: 7.1.0
-      toposort-class: 1.0.1
-      uuid: 8.3.2
-      validator: 13.15.26
-      wkx: 0.5.0
-    optionalDependencies:
-      mysql2: 3.16.0
-      sqlite3: 5.1.7(supports-color@8.1.1)
+      sqlite3: 5.1.7
     transitivePeerDependencies:
       - supports-color
 
@@ -24594,19 +24316,19 @@ snapshots:
     dependencies:
       randombytes: 2.1.0
 
-  serialize-json@1.0.3(supports-color@8.1.1):
+  serialize-json@1.0.3:
     dependencies:
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7
       is-type-of: 1.4.0
       utility: 1.18.0
     transitivePeerDependencies:
       - supports-color
 
-  serve-index@1.9.2(supports-color@8.1.1):
+  serve-index@1.9.2:
     dependencies:
       accepts: 1.3.8
       batch: 0.6.1
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       escape-html: 1.0.3
       http-errors: 1.8.1
       mime-types: 2.1.35
@@ -24614,21 +24336,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  serve-static@1.16.2(supports-color@8.1.1):
+  serve-static@1.16.2:
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 0.19.0(supports-color@8.1.1)
+      send: 0.19.0
     transitivePeerDependencies:
       - supports-color
 
-  serve-static@2.2.1(supports-color@8.1.1):
+  serve-static@2.2.1:
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 1.2.1(supports-color@8.1.1)
+      send: 1.2.1
     transitivePeerDependencies:
       - supports-color
 
@@ -24735,6 +24457,11 @@ snapshots:
       es-errors: 1.3.0
       object-inspect: 1.13.4
 
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
   side-channel-map@1.0.1:
     dependencies:
       call-bound: 1.0.4
@@ -24758,6 +24485,14 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
   sift@17.1.3: {}
 
   siginfo@2.0.0: {}
@@ -24766,13 +24501,13 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  sigstore@4.1.1(supports-color@7.2.0):
+  sigstore@4.1.1:
     dependencies:
       '@sigstore/bundle': 4.0.0
       '@sigstore/core': 3.2.1
       '@sigstore/protobuf-specs': 0.5.2
-      '@sigstore/sign': 4.1.1(supports-color@7.2.0)
-      '@sigstore/tuf': 4.0.2(supports-color@7.2.0)
+      '@sigstore/sign': 4.1.1
+      '@sigstore/tuf': 4.0.2
       '@sigstore/verify': 3.1.1
     transitivePeerDependencies:
       - supports-color
@@ -24831,10 +24566,10 @@ snapshots:
     dependencies:
       kind-of: 3.2.2
 
-  snapdragon@0.8.2(supports-color@8.1.1):
+  snapdragon@0.8.2:
     dependencies:
       base: 0.11.2
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       define-property: 0.2.5
       extend-shallow: 2.0.1
       map-cache: 0.2.2
@@ -24846,7 +24581,7 @@ snapshots:
 
   socket.io-adapter@1.1.2: {}
 
-  socket.io-adapter@2.5.6(supports-color@7.2.0):
+  socket.io-adapter@2.5.6:
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
       ws: 8.18.3
@@ -24855,88 +24590,61 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  socket.io-adapter@2.5.6(supports-color@8.1.1):
-    dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
-      ws: 8.18.3
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  socket.io-client@2.5.0(supports-color@8.1.1):
+  socket.io-client@2.5.0:
     dependencies:
       backo2: 1.0.2
       component-bind: 1.0.0
       component-emitter: 1.3.1
-      debug: 3.1.0(supports-color@8.1.1)
-      engine.io-client: 3.5.6(supports-color@8.1.1)
+      debug: 3.1.0
+      engine.io-client: 3.5.6
       has-binary2: 1.0.3
       indexof: 0.0.1
       parseqs: 0.0.6
       parseuri: 0.0.6
-      socket.io-parser: 3.3.4(supports-color@8.1.1)
+      socket.io-parser: 3.3.4
       to-array: 0.1.4
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  socket.io-client@4.8.1(supports-color@7.2.0):
+  socket.io-client@4.8.1:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
-      debug: 4.3.7(supports-color@8.1.1)
-      engine.io-client: 6.6.4(supports-color@7.2.0)
-      socket.io-parser: 4.2.5(supports-color@7.2.0)
+      debug: 4.3.7
+      engine.io-client: 6.6.4
+      socket.io-parser: 4.2.5
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  socket.io-client@4.8.1(supports-color@8.1.1):
-    dependencies:
-      '@socket.io/component-emitter': 3.1.2
-      debug: 4.3.7(supports-color@8.1.1)
-      engine.io-client: 6.6.4(supports-color@8.1.1)
-      socket.io-parser: 4.2.5(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  socket.io-parser@3.3.4(supports-color@8.1.1):
+  socket.io-parser@3.3.4:
     dependencies:
       component-emitter: 1.3.1
-      debug: 3.1.0(supports-color@8.1.1)
+      debug: 3.1.0
       isarray: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
-  socket.io-parser@3.4.3(supports-color@8.1.1):
+  socket.io-parser@3.4.3:
     dependencies:
       component-emitter: 1.2.1
-      debug: 4.1.1(supports-color@8.1.1)
+      debug: 4.1.1
       isarray: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
-  socket.io-parser@4.2.5(supports-color@7.2.0):
+  socket.io-parser@4.2.5:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
       debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  socket.io-parser@4.2.5(supports-color@8.1.1):
+  socket.io-redis@5.4.0:
     dependencies:
-      '@socket.io/component-emitter': 3.1.2
-      debug: 4.4.3(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - supports-color
-
-  socket.io-redis@5.4.0(supports-color@8.1.1):
-    dependencies:
-      debug: 4.1.1(supports-color@8.1.1)
+      debug: 4.1.1
       notepack.io: 2.2.0
       redis: 3.1.2
       socket.io-adapter: 1.1.2
@@ -24944,42 +24652,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  socket.io@2.5.1(supports-color@8.1.1):
+  socket.io@2.5.1:
     dependencies:
-      debug: 4.1.1(supports-color@8.1.1)
-      engine.io: 3.6.2(supports-color@8.1.1)
+      debug: 4.1.1
+      engine.io: 3.6.2
       has-binary2: 1.0.3
       socket.io-adapter: 1.1.2
-      socket.io-client: 2.5.0(supports-color@8.1.1)
-      socket.io-parser: 3.4.3(supports-color@8.1.1)
+      socket.io-client: 2.5.0
+      socket.io-parser: 3.4.3
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  socket.io@4.8.1(supports-color@7.2.0):
+  socket.io@4.8.1:
     dependencies:
       accepts: 1.3.8
       base64id: 2.0.0
       cors: 2.8.5
-      debug: 4.3.7(supports-color@8.1.1)
-      engine.io: 6.6.5(supports-color@7.2.0)
-      socket.io-adapter: 2.5.6(supports-color@7.2.0)
-      socket.io-parser: 4.2.5(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  socket.io@4.8.1(supports-color@8.1.1):
-    dependencies:
-      accepts: 1.3.8
-      base64id: 2.0.0
-      cors: 2.8.5
-      debug: 4.3.7(supports-color@8.1.1)
-      engine.io: 6.6.5(supports-color@8.1.1)
-      socket.io-adapter: 2.5.6(supports-color@8.1.1)
-      socket.io-parser: 4.2.5(supports-color@8.1.1)
+      debug: 4.3.7
+      engine.io: 6.6.5
+      socket.io-adapter: 2.5.6
+      socket.io-parser: 4.2.5
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -24991,7 +24685,7 @@ snapshots:
       uuid: 8.3.2
       websocket-driver: 0.7.4
 
-  socks-proxy-agent@6.2.1(supports-color@7.2.0):
+  socks-proxy-agent@6.2.1:
     dependencies:
       agent-base: 6.0.2(supports-color@7.2.0)
       debug: 4.4.3(supports-color@7.2.0)
@@ -24999,16 +24693,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  socks-proxy-agent@6.2.1(supports-color@8.1.1):
-    dependencies:
-      agent-base: 6.0.2(supports-color@8.1.1)
-      debug: 4.4.3(supports-color@8.1.1)
-      socks: 2.8.7
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
-  socks-proxy-agent@8.0.5(supports-color@7.2.0):
+  socks-proxy-agent@8.0.5:
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@7.2.0)
@@ -25069,7 +24754,7 @@ snapshots:
 
   spdx-license-ids@3.0.22: {}
 
-  spdy-transport@3.0.0(supports-color@7.2.0):
+  spdy-transport@3.0.0:
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
       detect-node: 2.1.0
@@ -25080,13 +24765,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  spdy@4.0.2(supports-color@7.2.0):
+  spdy@4.0.2:
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
       handle-thing: 2.0.1
       http-deceiver: 1.2.7
       select-hose: 2.0.0
-      spdy-transport: 3.0.0(supports-color@7.2.0)
+      spdy-transport: 3.0.0
     transitivePeerDependencies:
       - supports-color
 
@@ -25116,14 +24801,14 @@ snapshots:
 
   sql-highlight@6.1.0: {}
 
-  sqlite3@5.1.7(supports-color@8.1.1):
+  sqlite3@5.1.7:
     dependencies:
       bindings: 1.5.0
       node-addon-api: 7.1.1
       prebuild-install: 7.1.3
       tar: 6.2.1
     optionalDependencies:
-      node-gyp: 8.4.1(supports-color@8.1.1)
+      node-gyp: 8.4.1
     transitivePeerDependencies:
       - bluebird
       - supports-color
@@ -25323,19 +25008,18 @@ snapshots:
       minimist: 1.2.8
       through: 2.3.8
 
-  strtok3@6.3.0:
+  strtok3@10.3.5:
     dependencies:
       '@tokenizer/token': 0.3.0
-      peek-readable: 4.1.0
 
-  styled-jsx@5.1.6(@babel/core@7.28.5(supports-color@8.1.1))(react@18.3.1):
+  styled-jsx@5.1.6(@babel/core@7.28.5)(react@18.3.1):
     dependencies:
       client-only: 0.0.1
       react: 18.3.1
     optionalDependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
 
-  stylus-lookup@3.0.2(supports-color@7.2.0):
+  stylus-lookup@3.0.2:
     dependencies:
       commander: 2.20.3
       debug: 4.4.3(supports-color@7.2.0)
@@ -25356,11 +25040,11 @@ snapshots:
       tinyglobby: 0.2.15
       ts-interface-checker: 0.1.13
 
-  superagent@3.8.3(supports-color@8.1.1):
+  superagent@3.8.3:
     dependencies:
       component-emitter: 1.3.1
       cookiejar: 2.1.4
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7
       extend: 3.0.2
       form-data: 2.5.5
       formidable: 1.2.6
@@ -25371,13 +25055,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  superagent@8.1.2(supports-color@7.2.0):
+  superagent@8.1.2:
     dependencies:
       component-emitter: 1.3.1
       cookiejar: 2.1.4
       debug: 4.4.3(supports-color@7.2.0)
       fast-safe-stringify: 2.1.1
-      form-data: 4.0.5
+      form-data: 4.0.6
       formidable: 2.1.5
       methods: 1.1.2
       mime: 2.6.0
@@ -25386,39 +25070,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  superagent@8.1.2(supports-color@8.1.1):
+  supertest@4.0.2:
     dependencies:
-      component-emitter: 1.3.1
-      cookiejar: 2.1.4
-      debug: 4.4.3(supports-color@8.1.1)
-      fast-safe-stringify: 2.1.1
-      form-data: 4.0.5
-      formidable: 2.1.5
       methods: 1.1.2
-      mime: 2.6.0
-      qs: 6.15.1
-      semver: 7.7.4
+      superagent: 3.8.3
     transitivePeerDependencies:
       - supports-color
 
-  supertest@4.0.2(supports-color@8.1.1):
+  supertest@6.3.4:
     dependencies:
       methods: 1.1.2
-      superagent: 3.8.3(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - supports-color
-
-  supertest@6.3.4(supports-color@7.2.0):
-    dependencies:
-      methods: 1.1.2
-      superagent: 8.1.2(supports-color@7.2.0)
-    transitivePeerDependencies:
-      - supports-color
-
-  supertest@6.3.4(supports-color@8.1.1):
-    dependencies:
-      methods: 1.1.2
-      superagent: 8.1.2(supports-color@8.1.1)
+      superagent: 8.1.2
     transitivePeerDependencies:
       - supports-color
 
@@ -25522,16 +25184,13 @@ snapshots:
     dependencies:
       memoizerific: 1.11.3
 
-  terser-webpack-plugin@5.4.0(esbuild@0.27.3)(uglify-js@3.19.3)(webpack@5.104.1(esbuild@0.27.3)(uglify-js@3.19.3)):
+  terser-webpack-plugin@5.4.0(webpack@5.104.1):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.46.1
-      webpack: 5.104.1(esbuild@0.27.3)(uglify-js@3.19.3)
-    optionalDependencies:
-      esbuild: 0.27.3
-      uglify-js: 3.19.3
+      webpack: 5.104.1
 
   terser@5.46.1:
     dependencies:
@@ -25638,8 +25297,9 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
-  token-types@4.2.1:
+  token-types@6.1.2:
     dependencies:
+      '@borewit/text-codec': 0.2.2
       '@tokenizer/token': 0.3.0
       ieee754: 1.2.1
 
@@ -25689,12 +25349,12 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-jest@29.2.5(@babel/core@7.28.5(supports-color@7.2.0))(@jest/transform@29.7.0(supports-color@7.2.0))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5(supports-color@7.2.0))(supports-color@7.2.0))(esbuild@0.27.3)(jest@29.7.0(@types/node@22.12.0)(supports-color@7.2.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3)))(typescript@5.6.3):
+  ts-jest@29.2.5(@babel/core@7.28.5)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(jest@29.7.0(@types/node@22.12.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3)))(typescript@5.6.3):
     dependencies:
       bs-logger: 0.2.6
       ejs: 3.1.10
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@22.12.0)(supports-color@7.2.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3))
+      jest: 29.7.0(@types/node@22.12.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3))
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -25703,11 +25363,10 @@ snapshots:
       typescript: 5.6.3
       yargs-parser: 21.1.1
     optionalDependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
-      '@jest/transform': 29.7.0(supports-color@7.2.0)
+      '@babel/core': 7.28.5
+      '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.28.5(supports-color@7.2.0))(supports-color@7.2.0)
-      esbuild: 0.27.3
+      babel-jest: 29.7.0(@babel/core@7.28.5)
 
   ts-node@10.9.2(@types/node@20.19.39)(typescript@5.6.3):
     dependencies:
@@ -25774,41 +25433,13 @@ snapshots:
 
   tsscmp@1.0.6: {}
 
-  tsup@8.5.1(postcss@8.5.6)(supports-color@7.2.0)(tsx@4.21.0)(typescript@5.6.3)(yaml@2.9.0):
+  tsup@8.5.1(postcss@8.5.6)(tsx@4.21.0)(typescript@5.6.3)(yaml@2.9.0):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.3)
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
       debug: 4.4.3(supports-color@7.2.0)
-      esbuild: 0.27.3
-      fix-dts-default-cjs-exports: 1.0.1
-      joycon: 3.1.1
-      picocolors: 1.1.1
-      postcss-load-config: 6.0.1(postcss@8.5.6)(tsx@4.21.0)(yaml@2.9.0)
-      resolve-from: 5.0.0
-      rollup: 4.54.0
-      source-map: 0.7.6
-      sucrase: 3.35.1
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.15
-      tree-kill: 1.2.2
-    optionalDependencies:
-      postcss: 8.5.6
-      typescript: 5.6.3
-    transitivePeerDependencies:
-      - jiti
-      - supports-color
-      - tsx
-      - yaml
-
-  tsup@8.5.1(postcss@8.5.6)(supports-color@8.1.1)(tsx@4.21.0)(typescript@5.6.3)(yaml@2.9.0):
-    dependencies:
-      bundle-require: 5.1.0(esbuild@0.27.3)
-      cac: 6.7.14
-      chokidar: 4.0.3
-      consola: 3.4.2
-      debug: 4.4.3(supports-color@8.1.1)
       esbuild: 0.27.3
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
@@ -25852,11 +25483,11 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  tuf-js@4.1.0(supports-color@7.2.0):
+  tuf-js@4.1.0:
     dependencies:
       '@tufjs/models': 4.1.0
       debug: 4.4.3(supports-color@7.2.0)
-      make-fetch-happen: 15.0.2(supports-color@7.2.0)
+      make-fetch-happen: 15.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -25896,6 +25527,12 @@ snapshots:
   type-is@2.0.1:
     dependencies:
       content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.1.0
       media-typer: 1.1.0
       mime-types: 3.0.2
 
@@ -25960,12 +25597,12 @@ snapshots:
       typescript: 5.6.3
       yaml: 2.8.2
 
-  typeorm@1.1.0(better-sqlite3@12.9.0)(ioredis@5.9.3(supports-color@8.1.1))(mysql2@3.16.0)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3)):
+  typeorm@1.1.0(better-sqlite3@12.9.0)(ioredis@5.9.3)(mysql2@3.16.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3)):
     dependencies:
       '@sqltools/formatter': 1.2.5
       ansis: 4.3.1
       dayjs: 1.11.23
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@7.2.0)
       dedent: 1.7.2
       reflect-metadata: 0.2.2
       sql-highlight: 6.1.0
@@ -25974,20 +25611,20 @@ snapshots:
       yargs: 18.0.0
     optionalDependencies:
       better-sqlite3: 12.9.0
-      ioredis: 5.9.3(supports-color@8.1.1)
+      ioredis: 5.9.3
       mysql2: 3.16.0
       ts-node: 10.9.2(@types/node@22.12.0)(typescript@5.6.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
 
-  typescript-eslint@8.56.0(eslint@10.0.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.6.3):
+  typescript-eslint@8.56.0(eslint@10.0.0)(typescript@5.6.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.56.0(@typescript-eslint/parser@8.56.0(eslint@10.0.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.6.3))(eslint@10.0.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.6.3)
-      '@typescript-eslint/parser': 8.56.0(eslint@10.0.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.6.3)
-      '@typescript-eslint/typescript-estree': 8.56.0(supports-color@7.2.0)(typescript@5.6.3)
-      '@typescript-eslint/utils': 8.56.0(eslint@10.0.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.6.3)
-      eslint: 10.0.0(supports-color@7.2.0)
+      '@typescript-eslint/eslint-plugin': 8.56.0(@typescript-eslint/parser@8.56.0(eslint@10.0.0)(typescript@5.6.3))(eslint@10.0.0)(typescript@5.6.3)
+      '@typescript-eslint/parser': 8.56.0(eslint@10.0.0)(typescript@5.6.3)
+      '@typescript-eslint/typescript-estree': 8.56.0(typescript@5.6.3)
+      '@typescript-eslint/utils': 8.56.0(eslint@10.0.0)(typescript@5.6.3)
+      eslint: 10.0.0
       typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
@@ -26010,6 +25647,8 @@ snapshots:
       random-bytes: 1.0.0
 
   uid2@0.0.3: {}
+
+  uint8array-extras@1.5.0: {}
 
   unbox-primitive@1.1.0:
     dependencies:
@@ -26310,7 +25949,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.104.1(esbuild@0.27.3)(uglify-js@3.19.3)):
+  webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.104.1):
     dependencies:
       colorette: 2.0.20
       memfs: 4.57.1(tslib@2.8.1)
@@ -26319,11 +25958,11 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.104.1(esbuild@0.27.3)(uglify-js@3.19.3)
+      webpack: 5.104.1
     transitivePeerDependencies:
       - tslib
 
-  webpack-dev-server@5.2.2(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(tslib@2.8.1)(webpack@5.104.1(esbuild@0.27.3)(uglify-js@3.19.3)):
+  webpack-dev-server@5.2.2(tslib@2.8.1)(webpack@5.104.1):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -26337,24 +25976,24 @@ snapshots:
       bonjour-service: 1.3.0
       chokidar: 3.6.0
       colorette: 2.0.20
-      compression: 1.8.1(supports-color@8.1.1)
+      compression: 1.8.1
       connect-history-api-fallback: 2.0.0
-      express: 4.22.2(supports-color@8.1.1)
+      express: 4.22.2
       graceful-fs: 4.2.11
-      http-proxy-middleware: 2.0.9(@types/express@4.17.25)(debug@4.4.3(supports-color@8.1.1))
+      http-proxy-middleware: 2.0.9(@types/express@4.17.25)
       ipaddr.js: 2.3.0
       launch-editor: 2.13.2
       open: 10.2.0
       p-retry: 6.2.1
       schema-utils: 4.3.3
       selfsigned: 2.4.1
-      serve-index: 1.9.2(supports-color@8.1.1)
+      serve-index: 1.9.2
       sockjs: 0.3.24
-      spdy: 4.0.2(supports-color@7.2.0)
-      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.104.1(esbuild@0.27.3)(uglify-js@3.19.3))
+      spdy: 4.0.2
+      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.104.1)
       ws: 8.21.0
     optionalDependencies:
-      webpack: 5.104.1(esbuild@0.27.3)(uglify-js@3.19.3)
+      webpack: 5.104.1
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -26364,7 +26003,7 @@ snapshots:
 
   webpack-sources@3.3.4: {}
 
-  webpack@5.104.1(esbuild@0.27.3)(uglify-js@3.19.3):
+  webpack@5.104.1:
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -26388,7 +26027,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.2
-      terser-webpack-plugin: 5.4.0(esbuild@0.27.3)(uglify-js@3.19.3)(webpack@5.104.1(esbuild@0.27.3)(uglify-js@3.19.3))
+      terser-webpack-plugin: 5.4.0(webpack@5.104.1)
       watchpack: 2.5.1
       webpack-sources: 3.3.4
     transitivePeerDependencies:
@@ -26602,9 +26241,9 @@ snapshots:
     dependencies:
       is-wsl: 3.1.1
 
-  wt@1.2.0(supports-color@8.1.1):
+  wt@1.2.0:
     dependencies:
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       ndir: 0.1.5
       sdk-base: 2.0.1
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

- upgrade file-type to v21.3.1 and adapt upload middleware to the renamed API and ESM package boundary
- upgrade axios, body-parser, joi, and align Mikro ORM 6.x packages to 6.6.10
- update the pnpm lockfile and make axios defaults assertions resilient to the newer release

## Validation

- upload and busboy build/test pass
- axios, web-express, validate, and validation-joi checks pass
- Mikro ORM package versions resolve consistently to 6.6.10
- local Mikro integration tests require the sqlite3 native binding to be built on Node 24
