### PR TITLE
fix(core): correct named data source config type

### DIFF
--- a/packages/core/src/interface.ts
+++ b/packages/core/src/interface.ts
@@ -532,7 +532,11 @@ export interface DataSourceManagerConfigOption<
 > extends CreateDataSourceInstanceOptions {
   default?: BaseDataSourceManagerConfigOption<OPTIONS, ENTITY_CONFIG_KEY>;
   defaultDataSourceName?: string;
-  dataSource?: BaseDataSourceManagerConfigOption<OPTIONS, ENTITY_CONFIG_KEY>;
+  /** Named data source configurations. */
+  dataSource?: Record<
+    string,
+    BaseDataSourceManagerConfigOption<OPTIONS, ENTITY_CONFIG_KEY>
+  >;
 }
 
 type ConfigType<T> = T extends (...args: any[]) => any

--- a/packages/core/test/common/dataSourceManager.test.ts
+++ b/packages/core/test/common/dataSourceManager.test.ts
@@ -1,8 +1,33 @@
-import { DataSourceManager, sleep } from '../../src';
+import {
+  DataSourceManager,
+  DataSourceManagerConfigOption,
+  sleep,
+} from '../../src';
 import { join } from 'path';
 import * as assert from 'assert';
 
 describe('test/common/dataSourceManager.test.ts', () => {
+
+  it('should accept named data source configuration', () => {
+    const config: DataSourceManagerConfigOption<{
+      uri: string;
+      options: Record<string, unknown>;
+    }> = {
+      dataSource: {
+        default: {
+          uri: 'mongodb://127.0.0.1:27017/default',
+          options: {},
+          entities: [],
+        },
+        secondary: {
+          uri: 'mongodb://127.0.0.1:27017/secondary',
+          options: {},
+        },
+      },
+    };
+
+    expect(Object.keys(config.dataSource)).toEqual(['default', 'secondary']);
+  });
 
   class CustomDataSourceFactory extends DataSourceManager<any> {
     getName() {


### PR DESCRIPTION
## Summary

- restore the named data source map shape for `DataSourceManagerConfigOption.dataSource`
- fix excess-property errors for all consumers of the shared type, including Mongoose and TypeORM
- add a regression test covering `default` and custom data source names

## Validation

- `pnpm -C packages/core test -- dataSourceManager.test.ts`
- `pnpm -C packages/core build`
- reproduced TS2353 with the published Mongoose and TypeORM packages
- packed the updated core package and verified both generated-demo configurations pass `tsc --noEmit`