### PR TITLE
chore: upgrade pnpm to v10

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -30,7 +30,6 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
           run_install: false
       - name: Cache pnpm modules
         uses: actions/cache@v3

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -31,7 +31,6 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
           run_install: false
 
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/precheck.yml
+++ b/.github/workflows/precheck.yml
@@ -27,7 +27,6 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
           run_install: false
 
       # ✅ 安装最新 docker compose v2.37.1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,7 +54,6 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
           run_install: false
 
       - name: Use Node.js

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -30,7 +30,6 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
           run_install: false
 
       - name: Use Node.js ${{ matrix.node-version }}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "midway_project",
   "description": "a web framework for complex Node.js application",
   "version": "1.0.0",
+  "packageManager": "pnpm@10.33.0",
   "devDependencies": {
     "@babel/plugin-proposal-decorators": "7.25.9",
     "@nrwl/tao": "16.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,10 +10,10 @@ importers:
     devDependencies:
       '@babel/plugin-proposal-decorators':
         specifier: 7.25.9
-        version: 7.25.9(@babel/core@7.28.5(supports-color@7.2.0))(supports-color@7.2.0)
+        version: 7.25.9(@babel/core@7.28.5)
       '@nrwl/tao':
         specifier: 16.10.0
-        version: 16.10.0(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)
+        version: 16.10.0
       '@types/jest':
         specifier: 29.5.14
         version: 29.5.14
@@ -34,25 +34,25 @@ importers:
         version: 11.3.4
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@22.12.0)(supports-color@7.2.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3))
+        version: 29.7.0(@types/node@22.12.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3))
       lerna:
         specifier: 9.0.7
-        version: 9.0.7(@types/node@22.12.0)(supports-color@7.2.0)
+        version: 9.0.7(@types/node@22.12.0)
       lerna-changelog:
         specifier: 2.2.0
-        version: 2.2.0(supports-color@7.2.0)
+        version: 2.2.0
       madge:
         specifier: 6.1.0
-        version: 6.1.0(supports-color@7.2.0)(typescript@5.6.3)
+        version: 6.1.0(typescript@5.6.3)
       mwts:
         specifier: 2.0.4
-        version: 2.0.4(@types/eslint@9.6.1)(supports-color@7.2.0)(typescript@5.6.3)
+        version: 2.0.4(@types/eslint@9.6.1)(typescript@5.6.3)
       tree-kill:
         specifier: 1.2.2
         version: 1.2.2
       ts-jest:
         specifier: 29.2.5
-        version: 29.2.5(@babel/core@7.28.5(supports-color@7.2.0))(@jest/transform@29.7.0(supports-color@7.2.0))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5(supports-color@7.2.0))(supports-color@7.2.0))(esbuild@0.27.3)(jest@29.7.0(@types/node@22.12.0)(supports-color@7.2.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3)))(typescript@5.6.3)
+        version: 29.2.5(@babel/core@7.28.5)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(jest@29.7.0(@types/node@22.12.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3)))(typescript@5.6.3)
       ts-node:
         specifier: 10.9.2
         version: 10.9.2(@types/node@22.12.0)(typescript@5.6.3)
@@ -144,13 +144,13 @@ importers:
     devDependencies:
       tsup:
         specifier: 8.5.1
-        version: 8.5.1(postcss@8.5.6)(supports-color@7.2.0)(tsx@4.21.0)(typescript@5.6.3)(yaml@2.9.0)
+        version: 8.5.1(postcss@8.5.6)(tsx@4.21.0)(typescript@5.6.3)(yaml@2.9.0)
 
   packages/apollo:
     dependencies:
       '@apollo/server':
         specifier: 5.5.1
-        version: 5.5.1(graphql@16.14.2)(supports-color@7.2.0)
+        version: 5.5.1(graphql@16.14.2)
       '@graphql-tools/schema':
         specifier: 10.0.38
         version: 10.0.38(graphql@16.14.2)
@@ -190,7 +190,7 @@ importers:
     dependencies:
       axios:
         specifier: 1.18.0
-        version: 1.18.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 1.18.0
     devDependencies:
       '@midwayjs/core':
         specifier: workspace:^
@@ -200,7 +200,7 @@ importers:
         version: link:../mock
       nock:
         specifier: 13.5.6
-        version: 13.5.6(supports-color@7.2.0)
+        version: 13.5.6
 
   packages/bootstrap:
     dependencies:
@@ -219,13 +219,13 @@ importers:
         version: 2.88.2
       socket.io-client:
         specifier: 4.8.1
-        version: 4.8.1(supports-color@7.2.0)
+        version: 4.8.1
 
   packages/bull:
     dependencies:
       bull:
         specifier: 4.16.5
-        version: 4.16.5(supports-color@7.2.0)
+        version: 4.16.5
     devDependencies:
       '@midwayjs/core':
         specifier: workspace:^
@@ -269,7 +269,7 @@ importers:
     dependencies:
       bullmq:
         specifier: 5.71.0
-        version: 5.71.0(supports-color@8.1.1)
+        version: 5.71.0
     devDependencies:
       '@midwayjs/core':
         specifier: workspace:^
@@ -288,7 +288,7 @@ importers:
         version: 1.6.0
       file-type:
         specifier: 21.3.2
-        version: 21.3.2(supports-color@8.1.1)
+        version: 21.3.2
     devDependencies:
       '@midwayjs/core':
         specifier: workspace:^
@@ -347,7 +347,7 @@ importers:
         version: 6.0.0
       cache-manager-ioredis-yet:
         specifier: 2.1.2
-        version: 2.1.2(supports-color@7.2.0)
+        version: 2.1.2
 
   packages/captcha:
     dependencies:
@@ -413,7 +413,7 @@ importers:
         version: 5.38.0
       ioredis:
         specifier: 5.4.2
-        version: 5.4.2(supports-color@7.2.0)
+        version: 5.4.2
 
   packages/casbin-typeorm-adapter:
     dependencies:
@@ -441,7 +441,7 @@ importers:
         version: 5.38.0
       typeorm:
         specifier: 1.1.0
-        version: 1.1.0(better-sqlite3@12.9.0)(ioredis@5.9.3(supports-color@8.1.1))(mysql2@3.23.1(@types/node@22.12.0))(supports-color@7.2.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3))
+        version: 1.1.0(better-sqlite3@12.9.0)(ioredis@5.9.3)(mysql2@3.23.1(@types/node@22.12.0))(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3))
 
   packages/code-dye:
     devDependencies:
@@ -503,7 +503,7 @@ importers:
         version: 17.0.4
       nock:
         specifier: 13.5.6
-        version: 13.5.6(supports-color@8.1.1)
+        version: 13.5.6
 
   packages/core:
     dependencies:
@@ -622,19 +622,19 @@ importers:
         version: link:../typeorm
       mongoose:
         specifier: 8.24.1
-        version: 8.24.1(socks@2.8.7)(supports-color@7.2.0)
+        version: 8.24.1(socks@2.8.7)
       sequelize:
         specifier: 6.37.8
-        version: 6.37.8(mysql2@3.23.1(@types/node@22.12.0))(sqlite3@5.1.7(supports-color@8.1.1))(supports-color@7.2.0)
+        version: 6.37.8(mysql2@3.23.1(@types/node@22.12.0))(sqlite3@5.1.7)
       sequelize-typescript:
         specifier: 2.1.6
-        version: 2.1.6(@types/node@22.12.0)(@types/validator@13.15.10)(reflect-metadata@0.2.2)(sequelize@6.37.8(mysql2@3.23.1(@types/node@22.12.0))(sqlite3@5.1.7(supports-color@8.1.1))(supports-color@7.2.0))
+        version: 2.1.6(@types/node@22.12.0)(@types/validator@13.15.10)(reflect-metadata@0.2.2)(sequelize@6.37.8(sqlite3@5.1.7))
       sqlite3:
         specifier: 5.1.7
-        version: 5.1.7(supports-color@8.1.1)
+        version: 5.1.7
       typeorm:
         specifier: 1.1.0
-        version: 1.1.0(better-sqlite3@12.9.0)(ioredis@5.9.3(supports-color@8.1.1))(mysql2@3.23.1(@types/node@22.12.0))(supports-color@8.1.1)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3))
+        version: 1.1.0(better-sqlite3@12.9.0)(ioredis@5.9.3)(mysql2@3.23.1(@types/node@22.12.0))(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3))
 
   packages/etcd:
     dependencies:
@@ -666,10 +666,10 @@ importers:
     dependencies:
       cookie-session:
         specifier: ^2.0.0
-        version: 2.1.1(supports-color@8.1.1)
+        version: 2.1.1
       express-session:
         specifier: 1.18.1
-        version: 1.18.1(supports-color@8.1.1)
+        version: 1.18.1
     devDependencies:
       '@midwayjs/core':
         specifier: workspace:^
@@ -682,7 +682,7 @@ importers:
         version: 1.18.1
       memorystore:
         specifier: 1.6.7
-        version: 1.6.7(supports-color@7.2.0)
+        version: 1.6.7
 
   packages/faas:
     dependencies:
@@ -738,7 +738,7 @@ importers:
     dependencies:
       axios:
         specifier: 1.18.0
-        version: 1.18.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 1.18.0
     devDependencies:
       '@midwayjs/core':
         specifier: workspace:^
@@ -760,7 +760,7 @@ importers:
         version: link:../web
       nock:
         specifier: 13.5.6
-        version: 13.5.6(supports-color@8.1.1)
+        version: 13.5.6
 
   packages/i18n:
     dependencies:
@@ -842,7 +842,7 @@ importers:
     dependencies:
       leoric:
         specifier: 2.14.0
-        version: 2.14.0(mysql2@3.23.1(@types/node@22.12.0))(sqlite3@5.1.7(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 2.14.0(mysql2@3.23.1(@types/node@22.12.0))(sqlite3@5.1.7)
     devDependencies:
       '@midwayjs/core':
         specifier: workspace:^
@@ -855,7 +855,7 @@ importers:
         version: link:../mock
       sqlite3:
         specifier: 5.1.7
-        version: 5.1.7(supports-color@8.1.1)
+        version: 5.1.7
 
   packages/mcp:
     dependencies:
@@ -874,7 +874,7 @@ importers:
         version: link:../mock
       '@modelcontextprotocol/sdk':
         specifier: 1.26.0
-        version: 1.26.0(supports-color@8.1.1)(zod@3.25.76)
+        version: 1.26.0(zod@3.25.76)
       zod:
         specifier: 3.25.76
         version: 3.25.76
@@ -895,10 +895,10 @@ importers:
         version: 6.6.10
       '@mikro-orm/entity-generator':
         specifier: 6.6.10
-        version: 6.6.10(@mikro-orm/core@6.6.10)(better-sqlite3@12.9.0)(mysql2@3.23.1(@types/node@22.12.0))(sqlite3@5.1.7(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 6.6.10(@mikro-orm/core@6.6.10)(better-sqlite3@12.9.0)
       '@mikro-orm/sqlite':
         specifier: 6.6.10
-        version: 6.6.10(@mikro-orm/core@6.6.10)(better-sqlite3@12.9.0)(mysql2@3.23.1(@types/node@22.12.0))(supports-color@8.1.1)
+        version: 6.6.10(@mikro-orm/core@6.6.10)(better-sqlite3@12.9.0)
 
   packages/mikro7:
     devDependencies:
@@ -940,7 +940,7 @@ importers:
         version: 2.5.2
       supertest:
         specifier: 6.3.4
-        version: 6.3.4(supports-color@7.2.0)
+        version: 6.3.4
     devDependencies:
       '@midwayjs/core':
         specifier: workspace:^
@@ -959,10 +959,10 @@ importers:
         version: 2.2.4
       socket.io:
         specifier: 4.8.1
-        version: 4.8.1(supports-color@7.2.0)
+        version: 4.8.1
       socket.io-client:
         specifier: 4.8.1
-        version: 4.8.1(supports-color@8.1.1)
+        version: 4.8.1
       ws:
         specifier: 8.21.0
         version: 8.21.0
@@ -977,13 +977,13 @@ importers:
         version: link:../mock
       mongoose:
         specifier: 8.24.1
-        version: 8.24.1(socks@2.8.7)(supports-color@8.1.1)
+        version: 8.24.1(socks@2.8.7)
 
   packages/mqtt:
     dependencies:
       mqtt:
         specifier: 5.15.2
-        version: 5.15.2(supports-color@7.2.0)
+        version: 5.15.2
     devDependencies:
       '@midwayjs/core':
         specifier: workspace:^
@@ -1012,13 +1012,13 @@ importers:
         version: 18.3.27
       babel-loader:
         specifier: ^9.2.1
-        version: 9.2.1(@babel/core@7.28.5(supports-color@8.1.1))(webpack@5.104.1(esbuild@0.27.3)(uglify-js@3.19.3))
+        version: 9.2.1(@babel/core@7.28.5)(webpack@5.104.1)
       next:
         specifier: ~16.2.0
-        version: 16.2.12(@babel/core@7.28.5(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 16.2.12(@babel/core@7.28.5)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       null-loader:
         specifier: ^4.0.1
-        version: 4.0.1(webpack@5.104.1(esbuild@0.27.3)(uglify-js@3.19.3))
+        version: 4.0.1(webpack@5.104.1)
       react:
         specifier: ^18
         version: 18.3.1
@@ -1043,7 +1043,7 @@ importers:
         version: 6.23.3
       ali-oss:
         specifier: 6.23.0
-        version: 6.23.0(supports-color@7.2.0)
+        version: 6.23.0
     devDependencies:
       '@midwayjs/core':
         specifier: workspace:^
@@ -1083,7 +1083,7 @@ importers:
         version: 0.8.2
       express-session:
         specifier: 1.18.1
-        version: 1.18.1(supports-color@8.1.1)
+        version: 1.18.1
       passport-http-bearer:
         specifier: 1.0.1
         version: 1.0.1
@@ -1176,7 +1176,7 @@ importers:
         version: link:../web
       egg:
         specifier: ^2.28.0
-        version: 2.37.0(supports-color@8.1.1)
+        version: 2.37.0
 
   packages/rabbitmq:
     dependencies:
@@ -1220,13 +1220,13 @@ importers:
         version: 18.3.1(react@18.3.1)
       tsup:
         specifier: 8.5.1
-        version: 8.5.1(postcss@8.5.6)(supports-color@8.1.1)(tsx@4.21.0)(typescript@5.6.3)(yaml@2.9.0)
+        version: 8.5.1(postcss@8.5.6)(tsx@4.21.0)(typescript@5.6.3)(yaml@2.9.0)
 
   packages/redis:
     dependencies:
       ioredis:
         specifier: 5.4.2
-        version: 5.4.2(supports-color@8.1.1)
+        version: 5.4.2
     devDependencies:
       '@midwayjs/core':
         specifier: workspace:^
@@ -1285,13 +1285,13 @@ importers:
         version: link:../mock
       sequelize:
         specifier: 6.37.8
-        version: 6.37.8(mysql2@3.23.1(@types/node@22.12.0))(sqlite3@5.1.7(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 6.37.8(mysql2@3.23.1(@types/node@22.12.0))(sqlite3@5.1.7)
       sequelize-typescript:
         specifier: 2.1.6
-        version: 2.1.6(@types/node@22.12.0)(@types/validator@13.15.10)(reflect-metadata@0.2.2)(sequelize@6.37.8(mysql2@3.23.1(@types/node@22.12.0))(sqlite3@5.1.7(supports-color@8.1.1))(supports-color@8.1.1))
+        version: 2.1.6(@types/node@22.12.0)(@types/validator@13.15.10)(reflect-metadata@0.2.2)(sequelize@6.37.8(sqlite3@5.1.7))
       sqlite3:
         specifier: 5.1.7
-        version: 5.1.7(supports-color@8.1.1)
+        version: 5.1.7
 
   packages/session:
     dependencies:
@@ -1326,7 +1326,7 @@ importers:
     dependencies:
       socket.io:
         specifier: 4.8.1
-        version: 4.8.1(supports-color@8.1.1)
+        version: 4.8.1
     devDependencies:
       '@midwayjs/core':
         specifier: workspace:^
@@ -1336,7 +1336,7 @@ importers:
         version: 11.3.4
       socket.io-client:
         specifier: 4.8.1
-        version: 4.8.1(supports-color@8.1.1)
+        version: 4.8.1
 
   packages/static-file:
     dependencies:
@@ -1345,7 +1345,7 @@ importers:
         version: 0.3.0
       koa-static-cache:
         specifier: 5.1.4
-        version: 5.1.4(supports-color@8.1.1)
+        version: 5.1.4
       ylru:
         specifier: 1.4.0
         version: 1.4.0
@@ -1447,10 +1447,10 @@ importers:
         version: link:../mock
       '@typegoose/typegoose':
         specifier: 12.10.1
-        version: 12.10.1(mongoose@8.24.1(socks@2.8.7)(supports-color@8.1.1))
+        version: 12.10.1(mongoose@8.24.1(socks@2.8.7))
       mongoose:
         specifier: 8.24.1
-        version: 8.24.1(socks@2.8.7)(supports-color@8.1.1)
+        version: 8.24.1(socks@2.8.7)
 
   packages/typeorm:
     devDependencies:
@@ -1465,13 +1465,13 @@ importers:
         version: 12.9.0
       typeorm:
         specifier: 1.1.0
-        version: 1.1.0(better-sqlite3@12.9.0)(ioredis@5.9.3(supports-color@8.1.1))(mysql2@3.23.1(@types/node@22.12.0))(supports-color@8.1.1)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3))
+        version: 1.1.0(better-sqlite3@12.9.0)(ioredis@5.9.3)(mysql2@3.23.1(@types/node@22.12.0))(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3))
 
   packages/upload:
     dependencies:
       file-type:
         specifier: 21.3.2
-        version: 21.3.2(supports-color@8.1.1)
+        version: 21.3.2
       raw-body:
         specifier: 2.5.2
         version: 2.5.2
@@ -1565,7 +1565,7 @@ importers:
         version: 0.14.3
       tsup:
         specifier: 8.5.1
-        version: 8.5.1(postcss@8.5.6)(supports-color@8.1.1)(tsx@4.21.0)(typescript@5.6.3)(yaml@2.9.0)
+        version: 8.5.1(postcss@8.5.6)(tsx@4.21.0)(typescript@5.6.3)(yaml@2.9.0)
 
   packages/validation-joi:
     dependencies:
@@ -1590,7 +1590,7 @@ importers:
         version: 17.13.4
       tsup:
         specifier: 8.5.1
-        version: 8.5.1(postcss@8.5.6)(supports-color@8.1.1)(tsx@4.21.0)(typescript@5.6.3)(yaml@2.9.0)
+        version: 8.5.1(postcss@8.5.6)(tsx@4.21.0)(typescript@5.6.3)(yaml@2.9.0)
 
   packages/validation-zod:
     dependencies:
@@ -1615,7 +1615,7 @@ importers:
         version: link:../core
       tsup:
         specifier: 8.5.1
-        version: 8.5.1(postcss@8.5.6)(supports-color@8.1.1)(tsx@4.21.0)(typescript@5.6.3)(yaml@2.9.0)
+        version: 8.5.1(postcss@8.5.6)(tsx@4.21.0)(typescript@5.6.3)(yaml@2.9.0)
       zod:
         specifier: 3.25.76
         version: 3.25.76
@@ -1643,7 +1643,7 @@ importers:
         version: link:../core
       tsup:
         specifier: 8.5.1
-        version: 8.5.1(postcss@8.5.6)(supports-color@8.1.1)(tsx@4.21.0)(typescript@5.6.3)(yaml@2.9.0)
+        version: 8.5.1(postcss@8.5.6)(tsx@4.21.0)(typescript@5.6.3)(yaml@2.9.0)
       zod:
         specifier: 4.2.1
         version: 4.2.1
@@ -1708,7 +1708,7 @@ importers:
     devDependencies:
       tsup:
         specifier: 8.5.1
-        version: 8.5.1(postcss@8.5.6)(supports-color@8.1.1)(tsx@4.21.0)(typescript@5.6.3)(yaml@2.9.0)
+        version: 8.5.1(postcss@8.5.6)(tsx@4.21.0)(typescript@5.6.3)(yaml@2.9.0)
       vue:
         specifier: ^3.5.22
         version: 3.5.28(typescript@5.6.3)
@@ -1723,10 +1723,10 @@ importers:
         version: link:../core
       egg:
         specifier: ^2.28.0
-        version: 2.37.0(supports-color@8.1.1)
+        version: 2.37.0
       egg-cluster:
         specifier: ^1.27.1
-        version: 1.27.1(supports-color@8.1.1)
+        version: 1.27.1
       egg-path-matching:
         specifier: ^2.1.0
         version: 2.1.0
@@ -1757,19 +1757,19 @@ importers:
         version: 3.6.1
       egg-mock:
         specifier: 4.2.1
-        version: 4.2.1(supports-color@8.1.1)
+        version: 4.2.1
       egg-scripts:
         specifier: 3.1.0
-        version: 3.1.0(supports-color@7.2.0)
+        version: 3.1.0
       egg-socket.io:
         specifier: 4.1.6
-        version: 4.1.6(supports-color@8.1.1)
+        version: 4.1.6
       egg-view-nunjucks:
         specifier: 2.3.0
         version: 2.3.0(chokidar@3.6.0)
       fake-egg:
         specifier: 1.0.0
-        version: 1.0.0(supports-color@8.1.1)
+        version: 1.0.0
       fs-extra:
         specifier: 11.3.4
         version: 11.3.4
@@ -1793,7 +1793,7 @@ importers:
         version: 17.0.2(react@17.0.2)
       supertest:
         specifier: 6.3.4
-        version: 6.3.4(supports-color@8.1.1)
+        version: 6.3.4
 
   packages/web-bridge:
     dependencies:
@@ -1803,7 +1803,7 @@ importers:
     devDependencies:
       tsup:
         specifier: 8.5.1
-        version: 8.5.1(postcss@8.5.6)(supports-color@8.1.1)(tsx@4.21.0)(typescript@5.6.3)(yaml@2.9.0)
+        version: 8.5.1(postcss@8.5.6)(tsx@4.21.0)(typescript@5.6.3)(yaml@2.9.0)
 
   packages/web-express:
     dependencies:
@@ -1812,13 +1812,13 @@ importers:
         version: link:../express-session
       body-parser:
         specifier: 2.3.0
-        version: 2.3.0(supports-color@8.1.1)
+        version: 2.3.0
       cookie-parser:
         specifier: ^1.4.6
         version: 1.4.7
       express:
         specifier: 4.22.2
-        version: 4.22.2(supports-color@8.1.1)
+        version: 4.22.2
     devDependencies:
       '@midwayjs/core':
         specifier: workspace:^
@@ -1840,7 +1840,7 @@ importers:
     dependencies:
       '@koa/router':
         specifier: ^12.0.0
-        version: 12.0.2(supports-color@7.2.0)
+        version: 12.0.2
       '@midwayjs/cookies':
         specifier: ^1.3.0
         version: 1.3.0
@@ -1874,7 +1874,7 @@ importers:
         version: 7.4.9
       axios:
         specifier: 1.18.0
-        version: 1.18.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 1.18.0
       fs-extra:
         specifier: 11.3.4
         version: 11.3.4
@@ -2001,7 +2001,7 @@ importers:
         version: 10.8.2
       mwts:
         specifier: ^1.3.0
-        version: 1.3.0(supports-color@8.1.1)(typescript@5.6.3)
+        version: 1.3.0(typescript@5.6.3)
       mwtsc:
         specifier: ^1.4.0
         version: 1.16.0
@@ -2044,7 +2044,7 @@ importers:
         version: 18.3.7(@types/react@18.3.27)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(supports-color@8.1.1)(vite@6.4.3(@types/node@22.12.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.7.0(vite@6.4.3(@types/node@22.12.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -2077,7 +2077,7 @@ importers:
         version: link:../../packages/web-bridge
       axios:
         specifier: ^1.13.2
-        version: 1.19.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 1.19.0
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -2096,7 +2096,7 @@ importers:
         version: 18.3.7(@types/react@18.3.27)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(supports-color@8.1.1)(vite@6.4.3(@types/node@22.12.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.7.0(vite@6.4.3(@types/node@22.12.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -2139,7 +2139,7 @@ importers:
         version: link:../../packages/mock
       '@rspack/cli':
         specifier: ^1.5.6
-        version: 1.7.11(@rspack/core@1.7.11(@swc/helpers@0.5.15))(@types/express@4.17.25)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(tslib@2.8.1)(webpack@5.104.1(esbuild@0.27.3)(uglify-js@3.19.3))
+        version: 1.7.11(@rspack/core@1.7.11(@swc/helpers@0.5.15))(@types/express@4.17.25)(tslib@2.8.1)(webpack@5.104.1)
       '@rspack/core':
         specifier: ^1.5.6
         version: 1.7.11(@swc/helpers@0.5.15)
@@ -2197,7 +2197,7 @@ importers:
         version: 18.3.7(@types/react@18.3.27)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(supports-color@8.1.1)(vite@6.4.3(@types/node@22.12.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.7.0(vite@6.4.3(@types/node@22.12.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -13413,7 +13413,7 @@ snapshots:
       '@apollo/utils.logger': 3.0.0
       graphql: 16.14.2
 
-  '@apollo/server@5.5.1(graphql@16.14.2)(supports-color@7.2.0)':
+  '@apollo/server@5.5.1(graphql@16.14.2)':
     dependencies:
       '@apollo/cache-control-types': 1.0.3(graphql@16.14.2)
       '@apollo/server-gateway-interface': 2.0.0(graphql@16.14.2)
@@ -13427,10 +13427,10 @@ snapshots:
       '@apollo/utils.withrequired': 3.0.0
       '@graphql-tools/schema': 10.0.38(graphql@16.14.2)
       async-retry: 1.3.3
-      body-parser: 2.2.2(supports-color@7.2.0)
+      body-parser: 2.2.2
       content-type: 1.0.5
       cors: 2.8.5
-      finalhandler: 2.1.1(supports-color@7.2.0)
+      finalhandler: 2.1.1
       graphql: 16.14.2
       loglevel: 1.9.2
       lru-cache: 11.3.6
@@ -13506,40 +13506,20 @@ snapshots:
 
   '@babel/compat-data@7.28.5': {}
 
-  '@babel/core@7.28.5(supports-color@7.2.0)':
+  '@babel/core@7.28.5':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/generator': 7.28.5
       '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
       '@babel/helpers': 7.28.4
       '@babel/parser': 7.29.0
       '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.5(supports-color@7.2.0)
+      '@babel/traverse': 7.28.5
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
       debug: 4.4.3(supports-color@7.2.0)
-      gensync: 1.0.0-beta.2
-      json5: 2.2.3
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/core@7.28.5(supports-color@8.1.1)':
-    dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.28.5
-      '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)
-      '@babel/helpers': 7.28.4
-      '@babel/parser': 7.29.0
-      '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.5(supports-color@8.1.1)
-      '@babel/types': 7.29.0
-      '@jridgewell/remapping': 2.3.5
-      convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -13566,57 +13546,41 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-create-class-features-plugin@7.28.5(@babel/core@7.28.5(supports-color@7.2.0))(supports-color@7.2.0)':
+  '@babel/helper-create-class-features-plugin@7.28.5(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-member-expression-to-functions': 7.28.5(supports-color@7.2.0)
+      '@babel/helper-member-expression-to-functions': 7.28.5
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.5(supports-color@7.2.0))(supports-color@7.2.0)
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1(supports-color@7.2.0)
-      '@babel/traverse': 7.28.5(supports-color@7.2.0)
+      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.5)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/traverse': 7.28.5
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-globals@7.28.0': {}
 
-  '@babel/helper-member-expression-to-functions@7.28.5(supports-color@7.2.0)':
+  '@babel/helper-member-expression-to-functions@7.28.5':
     dependencies:
-      '@babel/traverse': 7.28.5(supports-color@7.2.0)
+      '@babel/traverse': 7.28.5
       '@babel/types': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-imports@7.27.1(supports-color@7.2.0)':
+  '@babel/helper-module-imports@7.27.1':
     dependencies:
-      '@babel/traverse': 7.28.5(supports-color@7.2.0)
+      '@babel/traverse': 7.28.5
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-imports@7.27.1(supports-color@8.1.1)':
+  '@babel/helper-module-transforms@7.28.3(@babel/core@7.28.5)':
     dependencies:
-      '@babel/traverse': 7.28.5(supports-color@8.1.1)
-      '@babel/types': 7.29.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-module-transforms@7.28.3(@babel/core@7.28.5(supports-color@7.2.0))(supports-color@7.2.0)':
-    dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
-      '@babel/helper-module-imports': 7.27.1(supports-color@7.2.0)
+      '@babel/core': 7.28.5
+      '@babel/helper-module-imports': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.28.5(supports-color@7.2.0)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-module-transforms@7.28.3(@babel/core@7.28.5(supports-color@8.1.1))(supports-color@8.1.1)':
-    dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
-      '@babel/helper-module-imports': 7.27.1(supports-color@8.1.1)
-      '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.28.5(supports-color@8.1.1)
+      '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
@@ -13626,18 +13590,18 @@ snapshots:
 
   '@babel/helper-plugin-utils@7.27.1': {}
 
-  '@babel/helper-replace-supers@7.27.1(@babel/core@7.28.5(supports-color@7.2.0))(supports-color@7.2.0)':
+  '@babel/helper-replace-supers@7.27.1(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
-      '@babel/helper-member-expression-to-functions': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
+      '@babel/helper-member-expression-to-functions': 7.28.5
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/traverse': 7.28.5(supports-color@7.2.0)
+      '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-skip-transparent-expression-wrappers@7.27.1(supports-color@7.2.0)':
+  '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
     dependencies:
-      '@babel/traverse': 7.28.5(supports-color@7.2.0)
+      '@babel/traverse': 7.28.5
       '@babel/types': 7.28.5
     transitivePeerDependencies:
       - supports-color
@@ -13668,113 +13632,113 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
-  '@babel/plugin-proposal-decorators@7.25.9(@babel/core@7.28.5(supports-color@7.2.0))(supports-color@7.2.0)':
+  '@babel/plugin-proposal-decorators@7.25.9(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
-      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/core': 7.28.5
+      '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5)
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-syntax-decorators': 7.27.1(@babel/core@7.28.5(supports-color@7.2.0))
+      '@babel/plugin-syntax-decorators': 7.27.1(@babel/core@7.28.5)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.28.5(supports-color@7.2.0))':
+  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.28.5(supports-color@7.2.0))':
+  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.28.5(supports-color@7.2.0))':
+  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.28.5(supports-color@7.2.0))':
+  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-decorators@7.27.1(@babel/core@7.28.5(supports-color@7.2.0))':
+  '@babel/plugin-syntax-decorators@7.27.1(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-import-attributes@7.27.1(@babel/core@7.28.5(supports-color@7.2.0))':
+  '@babel/plugin-syntax-import-attributes@7.27.1(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.28.5(supports-color@7.2.0))':
+  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.28.5(supports-color@7.2.0))':
+  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.28.5(supports-color@7.2.0))':
+  '@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.28.5(supports-color@7.2.0))':
+  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.28.5(supports-color@7.2.0))':
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.28.5(supports-color@7.2.0))':
+  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.28.5(supports-color@7.2.0))':
+  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.28.5(supports-color@7.2.0))':
+  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.28.5(supports-color@7.2.0))':
+  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.28.5(supports-color@7.2.0))':
+  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.28.5(supports-color@7.2.0))':
+  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-typescript@7.27.1(@babel/core@7.28.5(supports-color@7.2.0))':
+  '@babel/plugin-syntax-typescript@7.27.1(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))':
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.28.5(supports-color@8.1.1))':
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/runtime@7.28.4': {}
@@ -13785,7 +13749,7 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/types': 7.29.0
 
-  '@babel/traverse@7.28.5(supports-color@7.2.0)':
+  '@babel/traverse@7.28.5':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/generator': 7.28.5
@@ -13794,18 +13758,6 @@ snapshots:
       '@babel/template': 7.27.2
       '@babel/types': 7.29.0
       debug: 4.4.3(supports-color@7.2.0)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/traverse@7.28.5(supports-color@8.1.1)':
-    dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.28.5
-      '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.29.0
-      '@babel/template': 7.27.2
-      '@babel/types': 7.29.0
-      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -14044,19 +13996,19 @@ snapshots:
   '@esbuild/win32-x64@0.27.3':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@10.0.0(supports-color@7.2.0))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.0.0)':
     dependencies:
-      eslint: 10.0.0(supports-color@7.2.0)
+      eslint: 10.0.0
       eslint-visitor-keys: 3.4.3
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@7.32.0(supports-color@7.2.0))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@7.32.0)':
     dependencies:
-      eslint: 7.32.0(supports-color@7.2.0)
+      eslint: 7.32.0
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/config-array@0.23.1(supports-color@7.2.0)':
+  '@eslint/config-array@0.23.1':
     dependencies:
       '@eslint/object-schema': 3.0.1
       debug: 4.4.3(supports-color@7.2.0)
@@ -14072,7 +14024,7 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/eslintrc@0.4.3(supports-color@7.2.0)':
+  '@eslint/eslintrc@0.4.3':
     dependencies:
       ajv: 6.12.6
       debug: 4.4.3(supports-color@7.2.0)
@@ -14086,9 +14038,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/js@10.0.1(eslint@10.0.0(supports-color@7.2.0))':
+  '@eslint/js@10.0.1(eslint@10.0.0)':
     optionalDependencies:
-      eslint: 10.0.0(supports-color@7.2.0)
+      eslint: 10.0.0
 
   '@eslint/object-schema@3.0.1': {}
 
@@ -14164,7 +14116,7 @@ snapshots:
       '@humanfs/core': 0.19.1
       '@humanwhocodes/retry': 0.4.3
 
-  '@humanwhocodes/config-array@0.5.0(supports-color@7.2.0)':
+  '@humanwhocodes/config-array@0.5.0':
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
       debug: 4.4.3(supports-color@7.2.0)
@@ -14431,12 +14383,12 @@ snapshots:
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(supports-color@7.2.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3))':
+  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3))':
     dependencies:
       '@jest/console': 29.7.0
-      '@jest/reporters': 29.7.0(supports-color@7.2.0)
+      '@jest/reporters': 29.7.0
       '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0(supports-color@7.2.0)
+      '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@types/node': 20.19.39
       ansi-escapes: 4.3.2
@@ -14445,15 +14397,15 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.19.39)(supports-color@7.2.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3))
+      jest-config: 29.7.0(@types/node@20.19.39)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
       jest-resolve: 29.7.0
-      jest-resolve-dependencies: 29.7.0(supports-color@7.2.0)
-      jest-runner: 29.7.0(supports-color@7.2.0)
-      jest-runtime: 29.7.0(supports-color@7.2.0)
-      jest-snapshot: 29.7.0(supports-color@7.2.0)
+      jest-resolve-dependencies: 29.7.0
+      jest-runner: 29.7.0
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
       jest-util: 29.7.0
       jest-validate: 29.7.0
       jest-watcher: 29.7.0
@@ -14481,10 +14433,10 @@ snapshots:
     dependencies:
       jest-get-type: 29.6.3
 
-  '@jest/expect@29.7.0(supports-color@7.2.0)':
+  '@jest/expect@29.7.0':
     dependencies:
       expect: 29.7.0
-      jest-snapshot: 29.7.0(supports-color@7.2.0)
+      jest-snapshot: 29.7.0
     transitivePeerDependencies:
       - supports-color
 
@@ -14499,21 +14451,21 @@ snapshots:
 
   '@jest/get-type@30.1.0': {}
 
-  '@jest/globals@29.7.0(supports-color@7.2.0)':
+  '@jest/globals@29.7.0':
     dependencies:
       '@jest/environment': 29.7.0
-      '@jest/expect': 29.7.0(supports-color@7.2.0)
+      '@jest/expect': 29.7.0
       '@jest/types': 29.6.3
       jest-mock: 29.7.0
     transitivePeerDependencies:
       - supports-color
 
-  '@jest/reporters@29.7.0(supports-color@7.2.0)':
+  '@jest/reporters@29.7.0':
     dependencies:
       '@bcoe/v8-coverage': 0.2.3
       '@jest/console': 29.7.0
       '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0(supports-color@7.2.0)
+      '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.31
       '@types/node': 22.12.0
@@ -14523,9 +14475,9 @@ snapshots:
       glob: 7.2.3
       graceful-fs: 4.2.11
       istanbul-lib-coverage: 3.2.2
-      istanbul-lib-instrument: 6.0.3(supports-color@7.2.0)
+      istanbul-lib-instrument: 6.0.3
       istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 4.0.1(supports-color@7.2.0)
+      istanbul-lib-source-maps: 4.0.1
       istanbul-reports: 3.2.0
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -14565,12 +14517,12 @@ snapshots:
       jest-haste-map: 29.7.0
       slash: 3.0.0
 
-  '@jest/transform@29.7.0(supports-color@7.2.0)':
+  '@jest/transform@29.7.0':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.31
-      babel-plugin-istanbul: 6.1.1(supports-color@7.2.0)
+      babel-plugin-istanbul: 6.1.1
       chalk: 4.1.2
       convert-source-map: 2.0.0
       fast-json-stable-stringify: 2.1.0
@@ -14754,7 +14706,7 @@ snapshots:
 
   '@keyv/serialize@1.1.1': {}
 
-  '@koa/router@12.0.2(supports-color@7.2.0)':
+  '@koa/router@12.0.2':
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
       http-errors: 2.0.1
@@ -14818,10 +14770,10 @@ snapshots:
     optionalDependencies:
       reflect-metadata: 0.2.2
 
-  '@mikro-orm/entity-generator@6.6.10(@mikro-orm/core@6.6.10)(better-sqlite3@12.9.0)(mysql2@3.23.1(@types/node@22.12.0))(sqlite3@5.1.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@mikro-orm/entity-generator@6.6.10(@mikro-orm/core@6.6.10)(better-sqlite3@12.9.0)':
     dependencies:
       '@mikro-orm/core': 6.6.10
-      '@mikro-orm/knex': 6.6.10(@mikro-orm/core@6.6.10)(better-sqlite3@12.9.0)(mysql2@3.23.1(@types/node@22.12.0))(sqlite3@5.1.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@mikro-orm/knex': 6.6.10(@mikro-orm/core@6.6.10)(better-sqlite3@12.9.0)(sqlite3@5.1.7)
       fs-extra: 11.3.3
     transitivePeerDependencies:
       - better-sqlite3
@@ -14840,11 +14792,11 @@ snapshots:
       '@mikro-orm/core': 7.0.13(dataloader@2.2.3)
       '@mikro-orm/sql': 7.0.13(@mikro-orm/core@7.0.13(dataloader@2.2.3))
 
-  '@mikro-orm/knex@6.6.10(@mikro-orm/core@6.6.10)(better-sqlite3@12.9.0)(mysql2@3.23.1(@types/node@22.12.0))(sqlite3@5.1.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@mikro-orm/knex@6.6.10(@mikro-orm/core@6.6.10)(better-sqlite3@12.9.0)(sqlite3@5.1.7)':
     dependencies:
       '@mikro-orm/core': 6.6.10
       fs-extra: 11.3.3
-      knex: 3.1.0(better-sqlite3@12.9.0)(mysql2@3.23.1(@types/node@22.12.0))(sqlite3@5.1.7(supports-color@8.1.1))(supports-color@8.1.1)
+      knex: 3.1.0(better-sqlite3@12.9.0)(sqlite3@5.1.7)
       sqlstring: 2.3.3
     optionalDependencies:
       better-sqlite3: 12.9.0
@@ -14862,12 +14814,12 @@ snapshots:
       '@mikro-orm/core': 7.0.13(dataloader@2.2.3)
       kysely: 0.28.16
 
-  '@mikro-orm/sqlite@6.6.10(@mikro-orm/core@6.6.10)(better-sqlite3@12.9.0)(mysql2@3.23.1(@types/node@22.12.0))(supports-color@8.1.1)':
+  '@mikro-orm/sqlite@6.6.10(@mikro-orm/core@6.6.10)(better-sqlite3@12.9.0)':
     dependencies:
       '@mikro-orm/core': 6.6.10
-      '@mikro-orm/knex': 6.6.10(@mikro-orm/core@6.6.10)(better-sqlite3@12.9.0)(mysql2@3.23.1(@types/node@22.12.0))(sqlite3@5.1.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@mikro-orm/knex': 6.6.10(@mikro-orm/core@6.6.10)(better-sqlite3@12.9.0)(sqlite3@5.1.7)
       fs-extra: 11.3.3
-      sqlite3: 5.1.7(supports-color@8.1.1)
+      sqlite3: 5.1.7
       sqlstring-sqlite: 0.1.1
     transitivePeerDependencies:
       - better-sqlite3
@@ -14888,7 +14840,7 @@ snapshots:
       better-sqlite3: 12.9.0
       kysely: 0.28.16
 
-  '@modelcontextprotocol/sdk@1.26.0(supports-color@8.1.1)(zod@3.25.76)':
+  '@modelcontextprotocol/sdk@1.26.0(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 1.19.11(hono@4.12.8)
       ajv: 8.17.1
@@ -14898,8 +14850,8 @@ snapshots:
       cross-spawn: 7.0.6
       eventsource: 3.0.7
       eventsource-parser: 3.0.6
-      express: 5.2.1(supports-color@8.1.1)
-      express-rate-limit: 8.3.1(express@5.2.1(supports-color@8.1.1))
+      express: 5.2.1
+      express-rate-limit: 8.3.1(express@5.2.1)
       hono: 4.12.8
       jose: 6.1.3
       json-schema-typed: 8.0.2
@@ -15089,23 +15041,23 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@npmcli/agent@4.0.2(supports-color@7.2.0)':
+  '@npmcli/agent@4.0.2':
     dependencies:
       agent-base: 7.1.4
-      http-proxy-agent: 7.0.2(supports-color@7.2.0)
-      https-proxy-agent: 7.0.6(supports-color@7.2.0)
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
       lru-cache: 11.3.6
-      socks-proxy-agent: 8.0.5(supports-color@7.2.0)
+      socks-proxy-agent: 8.0.5
     transitivePeerDependencies:
       - supports-color
 
-  '@npmcli/arborist@9.1.6(supports-color@7.2.0)':
+  '@npmcli/arborist@9.1.6':
     dependencies:
       '@isaacs/string-locale-compare': 1.1.0
       '@npmcli/fs': 4.0.0
       '@npmcli/installed-package-contents': 3.0.0
       '@npmcli/map-workspaces': 5.0.3
-      '@npmcli/metavuln-calculator': 9.0.3(supports-color@7.2.0)
+      '@npmcli/metavuln-calculator': 9.0.3
       '@npmcli/name-from-folder': 3.0.0
       '@npmcli/node-gyp': 4.0.0
       '@npmcli/package-json': 7.0.2
@@ -15123,8 +15075,8 @@ snapshots:
       npm-install-checks: 7.1.2
       npm-package-arg: 13.0.1
       npm-pick-manifest: 11.0.3
-      npm-registry-fetch: 19.1.0(supports-color@7.2.0)
-      pacote: 21.5.1(supports-color@7.2.0)
+      npm-registry-fetch: 19.1.0
+      pacote: 21.5.1
       parse-conflict-json: 4.0.0
       proc-log: 5.0.0
       proggy: 3.0.0
@@ -15189,11 +15141,11 @@ snapshots:
       glob: 13.0.6
       minimatch: 10.2.4
 
-  '@npmcli/metavuln-calculator@9.0.3(supports-color@7.2.0)':
+  '@npmcli/metavuln-calculator@9.0.3':
     dependencies:
       cacache: 20.0.4
       json-parse-even-better-errors: 5.0.0
-      pacote: 21.5.1(supports-color@7.2.0)
+      pacote: 21.5.1
       proc-log: 6.1.0
       semver: 7.7.4
     transitivePeerDependencies:
@@ -15247,9 +15199,9 @@ snapshots:
       proc-log: 6.1.0
       which: 6.0.1
 
-  '@nrwl/tao@16.10.0(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)':
+  '@nrwl/tao@16.10.0':
     dependencies:
-      nx: 16.10.0(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)
+      nx: 16.10.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@swc-node/register'
@@ -15556,11 +15508,11 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 1.7.11
       '@rspack/binding-win32-x64-msvc': 1.7.11
 
-  '@rspack/cli@1.7.11(@rspack/core@1.7.11(@swc/helpers@0.5.15))(@types/express@4.17.25)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(tslib@2.8.1)(webpack@5.104.1(esbuild@0.27.3)(uglify-js@3.19.3))':
+  '@rspack/cli@1.7.11(@rspack/core@1.7.11(@swc/helpers@0.5.15))(@types/express@4.17.25)(tslib@2.8.1)(webpack@5.104.1)':
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
       '@rspack/core': 1.7.11(@swc/helpers@0.5.15)
-      '@rspack/dev-server': 1.1.5(@rspack/core@1.7.11(@swc/helpers@0.5.15))(@types/express@4.17.25)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(tslib@2.8.1)(webpack@5.104.1(esbuild@0.27.3)(uglify-js@3.19.3))
+      '@rspack/dev-server': 1.1.5(@rspack/core@1.7.11(@swc/helpers@0.5.15))(@types/express@4.17.25)(tslib@2.8.1)(webpack@5.104.1)
       exit-hook: 4.0.0
       webpack-bundle-analyzer: 4.10.2
     transitivePeerDependencies:
@@ -15581,13 +15533,13 @@ snapshots:
     optionalDependencies:
       '@swc/helpers': 0.5.15
 
-  '@rspack/dev-server@1.1.5(@rspack/core@1.7.11(@swc/helpers@0.5.15))(@types/express@4.17.25)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(tslib@2.8.1)(webpack@5.104.1(esbuild@0.27.3)(uglify-js@3.19.3))':
+  '@rspack/dev-server@1.1.5(@rspack/core@1.7.11(@swc/helpers@0.5.15))(@types/express@4.17.25)(tslib@2.8.1)(webpack@5.104.1)':
     dependencies:
       '@rspack/core': 1.7.11(@swc/helpers@0.5.15)
       chokidar: 3.6.0
-      http-proxy-middleware: 2.0.9(@types/express@4.17.25)(debug@4.4.3(supports-color@8.1.1))
+      http-proxy-middleware: 2.0.9(@types/express@4.17.25)
       p-retry: 6.2.1
-      webpack-dev-server: 5.2.2(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(tslib@2.8.1)(webpack@5.104.1(esbuild@0.27.3)(uglify-js@3.19.3))
+      webpack-dev-server: 5.2.2(tslib@2.8.1)(webpack@5.104.1)
       ws: 8.21.0
     transitivePeerDependencies:
       - '@types/express'
@@ -15661,21 +15613,21 @@ snapshots:
 
   '@sigstore/protobuf-specs@0.5.2': {}
 
-  '@sigstore/sign@4.1.1(supports-color@7.2.0)':
+  '@sigstore/sign@4.1.1':
     dependencies:
       '@gar/promise-retry': 1.0.3
       '@sigstore/bundle': 4.0.0
       '@sigstore/core': 3.2.1
       '@sigstore/protobuf-specs': 0.5.2
-      make-fetch-happen: 15.0.6(supports-color@7.2.0)
+      make-fetch-happen: 15.0.6
       proc-log: 6.1.0
     transitivePeerDependencies:
       - supports-color
 
-  '@sigstore/tuf@4.0.2(supports-color@7.2.0)':
+  '@sigstore/tuf@4.0.2':
     dependencies:
       '@sigstore/protobuf-specs': 0.5.2
-      tuf-js: 4.1.0(supports-color@7.2.0)
+      tuf-js: 4.1.0
     transitivePeerDependencies:
       - supports-color
 
@@ -15730,9 +15682,9 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
-  '@tokenizer/inflate@0.4.1(supports-color@8.1.1)':
+  '@tokenizer/inflate@0.4.1':
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@7.2.0)
       token-types: 6.1.2
     transitivePeerDependencies:
       - supports-color
@@ -15765,11 +15717,11 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@typegoose/typegoose@12.10.1(mongoose@8.24.1(socks@2.8.7)(supports-color@8.1.1))':
+  '@typegoose/typegoose@12.10.1(mongoose@8.24.1(socks@2.8.7))':
     dependencies:
       lodash: 4.17.21
       loglevel: 1.9.2
-      mongoose: 8.24.1(socks@2.8.7)(supports-color@8.1.1)
+      mongoose: 8.24.1(socks@2.8.7)
       reflect-metadata: 0.2.2
       semver: 7.7.3
       tslib: 2.8.1
@@ -16141,15 +16093,15 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0(supports-color@7.2.0))(supports-color@8.1.1)(typescript@5.6.3))(eslint@7.32.0(supports-color@7.2.0))(supports-color@8.1.1)(typescript@5.6.3)':
+  '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.6.3))(eslint@7.32.0)(typescript@5.6.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 5.62.0(eslint@7.32.0(supports-color@7.2.0))(supports-color@8.1.1)(typescript@5.6.3)
+      '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@5.6.3)
       '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/type-utils': 5.62.0(eslint@7.32.0(supports-color@7.2.0))(supports-color@8.1.1)(typescript@5.6.3)
-      '@typescript-eslint/utils': 5.62.0(eslint@7.32.0(supports-color@7.2.0))(supports-color@8.1.1)(typescript@5.6.3)
+      '@typescript-eslint/type-utils': 5.62.0(eslint@7.32.0)(typescript@5.6.3)
+      '@typescript-eslint/utils': 5.62.0(eslint@7.32.0)(typescript@5.6.3)
       debug: 4.4.3(supports-color@7.2.0)
-      eslint: 7.32.0(supports-color@7.2.0)
+      eslint: 7.32.0
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare-lite: 1.4.0
@@ -16160,15 +16112,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.56.0(@typescript-eslint/parser@8.56.0(eslint@10.0.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.6.3))(eslint@10.0.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.6.3)':
+  '@typescript-eslint/eslint-plugin@8.56.0(@typescript-eslint/parser@8.56.0(eslint@10.0.0)(typescript@5.6.3))(eslint@10.0.0)(typescript@5.6.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.56.0(eslint@10.0.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.6.3)
+      '@typescript-eslint/parser': 8.56.0(eslint@10.0.0)(typescript@5.6.3)
       '@typescript-eslint/scope-manager': 8.56.0
-      '@typescript-eslint/type-utils': 8.56.0(eslint@10.0.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.6.3)
-      '@typescript-eslint/utils': 8.56.0(eslint@10.0.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.6.3)
+      '@typescript-eslint/type-utils': 8.56.0(eslint@10.0.0)(typescript@5.6.3)
+      '@typescript-eslint/utils': 8.56.0(eslint@10.0.0)(typescript@5.6.3)
       '@typescript-eslint/visitor-keys': 8.56.0
-      eslint: 10.0.0(supports-color@7.2.0)
+      eslint: 10.0.0
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.4.0(typescript@5.6.3)
@@ -16176,31 +16128,31 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@5.62.0(eslint@7.32.0(supports-color@7.2.0))(supports-color@8.1.1)(typescript@5.6.3)':
+  '@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.6.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(supports-color@8.1.1)(typescript@5.6.3)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.6.3)
       debug: 4.4.3(supports-color@7.2.0)
-      eslint: 7.32.0(supports-color@7.2.0)
+      eslint: 7.32.0
     optionalDependencies:
       typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.56.0(eslint@10.0.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.6.3)':
+  '@typescript-eslint/parser@8.56.0(eslint@10.0.0)(typescript@5.6.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.56.0
       '@typescript-eslint/types': 8.56.0
-      '@typescript-eslint/typescript-estree': 8.56.0(supports-color@7.2.0)(typescript@5.6.3)
+      '@typescript-eslint/typescript-estree': 8.56.0(typescript@5.6.3)
       '@typescript-eslint/visitor-keys': 8.56.0
       debug: 4.4.3(supports-color@7.2.0)
-      eslint: 10.0.0(supports-color@7.2.0)
+      eslint: 10.0.0
       typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.56.0(supports-color@7.2.0)(typescript@5.6.3)':
+  '@typescript-eslint/project-service@8.56.0(typescript@5.6.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.56.0(typescript@5.6.3)
       '@typescript-eslint/types': 8.56.0
@@ -16223,25 +16175,25 @@ snapshots:
     dependencies:
       typescript: 5.6.3
 
-  '@typescript-eslint/type-utils@5.62.0(eslint@7.32.0(supports-color@7.2.0))(supports-color@8.1.1)(typescript@5.6.3)':
+  '@typescript-eslint/type-utils@5.62.0(eslint@7.32.0)(typescript@5.6.3)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.62.0(supports-color@8.1.1)(typescript@5.6.3)
-      '@typescript-eslint/utils': 5.62.0(eslint@7.32.0(supports-color@7.2.0))(supports-color@8.1.1)(typescript@5.6.3)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.6.3)
+      '@typescript-eslint/utils': 5.62.0(eslint@7.32.0)(typescript@5.6.3)
       debug: 4.4.3(supports-color@7.2.0)
-      eslint: 7.32.0(supports-color@7.2.0)
+      eslint: 7.32.0
       tsutils: 3.21.0(typescript@5.6.3)
     optionalDependencies:
       typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@8.56.0(eslint@10.0.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.6.3)':
+  '@typescript-eslint/type-utils@8.56.0(eslint@10.0.0)(typescript@5.6.3)':
     dependencies:
       '@typescript-eslint/types': 8.56.0
-      '@typescript-eslint/typescript-estree': 8.56.0(supports-color@7.2.0)(typescript@5.6.3)
-      '@typescript-eslint/utils': 8.56.0(eslint@10.0.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.6.3)
+      '@typescript-eslint/typescript-estree': 8.56.0(typescript@5.6.3)
+      '@typescript-eslint/utils': 8.56.0(eslint@10.0.0)(typescript@5.6.3)
       debug: 4.4.3(supports-color@7.2.0)
-      eslint: 10.0.0(supports-color@7.2.0)
+      eslint: 10.0.0
       ts-api-utils: 2.4.0(typescript@5.6.3)
       typescript: 5.6.3
     transitivePeerDependencies:
@@ -16253,7 +16205,7 @@ snapshots:
 
   '@typescript-eslint/types@8.56.0': {}
 
-  '@typescript-eslint/typescript-estree@4.33.0(supports-color@7.2.0)(typescript@3.9.10)':
+  '@typescript-eslint/typescript-estree@4.33.0(typescript@3.9.10)':
     dependencies:
       '@typescript-eslint/types': 4.33.0
       '@typescript-eslint/visitor-keys': 4.33.0
@@ -16267,7 +16219,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@5.62.0(supports-color@7.2.0)(typescript@4.9.5)':
+  '@typescript-eslint/typescript-estree@5.62.0(typescript@4.9.5)':
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
@@ -16281,11 +16233,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@5.62.0(supports-color@8.1.1)(typescript@5.6.3)':
+  '@typescript-eslint/typescript-estree@5.62.0(typescript@5.6.3)':
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@7.2.0)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.7.4
@@ -16295,9 +16247,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.56.0(supports-color@7.2.0)(typescript@5.6.3)':
+  '@typescript-eslint/typescript-estree@8.56.0(typescript@5.6.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.56.0(supports-color@7.2.0)(typescript@5.6.3)
+      '@typescript-eslint/project-service': 8.56.0(typescript@5.6.3)
       '@typescript-eslint/tsconfig-utils': 8.56.0(typescript@5.6.3)
       '@typescript-eslint/types': 8.56.0
       '@typescript-eslint/visitor-keys': 8.56.0
@@ -16310,28 +16262,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@5.62.0(eslint@7.32.0(supports-color@7.2.0))(supports-color@8.1.1)(typescript@5.6.3)':
+  '@typescript-eslint/utils@5.62.0(eslint@7.32.0)(typescript@5.6.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@7.32.0(supports-color@7.2.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@7.32.0)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.7.1
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(supports-color@8.1.1)(typescript@5.6.3)
-      eslint: 7.32.0(supports-color@7.2.0)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.6.3)
+      eslint: 7.32.0
       eslint-scope: 5.1.1
       semver: 7.7.4
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@8.56.0(eslint@10.0.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.6.3)':
+  '@typescript-eslint/utils@8.56.0(eslint@10.0.0)(typescript@5.6.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.0.0(supports-color@7.2.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.0.0)
       '@typescript-eslint/scope-manager': 8.56.0
       '@typescript-eslint/types': 8.56.0
-      '@typescript-eslint/typescript-estree': 8.56.0(supports-color@7.2.0)(typescript@5.6.3)
-      eslint: 10.0.0(supports-color@7.2.0)
+      '@typescript-eslint/typescript-estree': 8.56.0(typescript@5.6.3)
+      eslint: 10.0.0
       typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
@@ -16355,11 +16307,11 @@ snapshots:
 
   '@vercel/ncc@0.38.4': {}
 
-  '@vitejs/plugin-react@4.7.0(supports-color@8.1.1)(vite@6.4.3(@types/node@22.12.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))':
+  '@vitejs/plugin-react@4.7.0(vite@6.4.3(@types/node@22.12.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.5(supports-color@8.1.1))
+      '@babel/core': 7.28.5
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.5)
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
@@ -16595,12 +16547,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  agent-base@6.0.2(supports-color@8.1.1):
-    dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - supports-color
-
   agent-base@7.1.4: {}
 
   agentkeepalive@3.5.3:
@@ -16662,7 +16608,7 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
-  ali-oss@6.23.0(supports-color@7.2.0):
+  ali-oss@6.23.0:
     dependencies:
       address: 1.2.2
       agentkeepalive: 3.5.3
@@ -16882,21 +16828,11 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  axios@1.18.0(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0):
+  axios@1.18.0:
     dependencies:
       follow-redirects: 1.16.0(debug@4.4.3(supports-color@7.2.0))
       form-data: 4.0.6
       https-proxy-agent: 5.0.1(supports-color@7.2.0)
-      proxy-from-env: 2.1.0
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-
-  axios@1.18.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1):
-    dependencies:
-      follow-redirects: 1.16.0(debug@4.4.3(supports-color@8.1.1))
-      form-data: 4.0.6
-      https-proxy-agent: 5.0.1(supports-color@8.1.1)
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
@@ -16912,42 +16848,42 @@ snapshots:
       - debug
       - supports-color
 
-  axios@1.19.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1):
+  axios@1.19.0:
     dependencies:
-      follow-redirects: 1.16.0(debug@4.4.3(supports-color@8.1.1))
+      follow-redirects: 1.16.0(debug@4.4.3(supports-color@7.2.0))
       form-data: 4.0.6
-      https-proxy-agent: 5.0.1(supports-color@8.1.1)
+      https-proxy-agent: 5.0.1(supports-color@7.2.0)
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  babel-jest@29.7.0(@babel/core@7.28.5(supports-color@7.2.0))(supports-color@7.2.0):
+  babel-jest@29.7.0(@babel/core@7.28.5):
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
-      '@jest/transform': 29.7.0(supports-color@7.2.0)
+      '@babel/core': 7.28.5
+      '@jest/transform': 29.7.0
       '@types/babel__core': 7.20.5
-      babel-plugin-istanbul: 6.1.1(supports-color@7.2.0)
-      babel-preset-jest: 29.6.3(@babel/core@7.28.5(supports-color@7.2.0))
+      babel-plugin-istanbul: 6.1.1
+      babel-preset-jest: 29.6.3(@babel/core@7.28.5)
       chalk: 4.1.2
       graceful-fs: 4.2.11
       slash: 3.0.0
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@9.2.1(@babel/core@7.28.5(supports-color@8.1.1))(webpack@5.104.1(esbuild@0.27.3)(uglify-js@3.19.3)):
+  babel-loader@9.2.1(@babel/core@7.28.5)(webpack@5.104.1):
     dependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
       find-cache-dir: 4.0.0
       schema-utils: 4.3.3
-      webpack: 5.104.1(esbuild@0.27.3)(uglify-js@3.19.3)
+      webpack: 5.104.1
 
-  babel-plugin-istanbul@6.1.1(supports-color@7.2.0):
+  babel-plugin-istanbul@6.1.1:
     dependencies:
       '@babel/helper-plugin-utils': 7.27.1
       '@istanbuljs/load-nyc-config': 1.1.0
       '@istanbuljs/schema': 0.1.3
-      istanbul-lib-instrument: 5.2.1(supports-color@7.2.0)
+      istanbul-lib-instrument: 5.2.1
       test-exclude: 6.0.0
     transitivePeerDependencies:
       - supports-color
@@ -16959,30 +16895,30 @@ snapshots:
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.28.0
 
-  babel-preset-current-node-syntax@1.2.0(@babel/core@7.28.5(supports-color@7.2.0)):
+  babel-preset-current-node-syntax@1.2.0(@babel/core@7.28.5):
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.28.5(supports-color@7.2.0))
-      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.28.5(supports-color@7.2.0))
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.28.5(supports-color@7.2.0))
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.28.5(supports-color@7.2.0))
-      '@babel/plugin-syntax-import-attributes': 7.27.1(@babel/core@7.28.5(supports-color@7.2.0))
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.28.5(supports-color@7.2.0))
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.28.5(supports-color@7.2.0))
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.28.5(supports-color@7.2.0))
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.28.5(supports-color@7.2.0))
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.28.5(supports-color@7.2.0))
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.28.5(supports-color@7.2.0))
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.28.5(supports-color@7.2.0))
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.28.5(supports-color@7.2.0))
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.28.5(supports-color@7.2.0))
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.28.5(supports-color@7.2.0))
+      '@babel/core': 7.28.5
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.28.5)
+      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.28.5)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.28.5)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.28.5)
+      '@babel/plugin-syntax-import-attributes': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.28.5)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.28.5)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.28.5)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.28.5)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.28.5)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.28.5)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.28.5)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.28.5)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.28.5)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.28.5)
 
-  babel-preset-jest@29.6.3(@babel/core@7.28.5(supports-color@7.2.0)):
+  babel-preset-jest@29.6.3(@babel/core@7.28.5):
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
       babel-plugin-jest-hoist: 29.6.3
-      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.28.5(supports-color@7.2.0))
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.28.5)
 
   backo2@1.0.2: {}
 
@@ -17058,11 +16994,11 @@ snapshots:
 
   blob@0.0.5: {}
 
-  body-parser@1.20.6(supports-color@8.1.1):
+  body-parser@1.20.6:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       depd: 2.0.0
       destroy: 1.2.0
       http-errors: 2.0.1
@@ -17075,7 +17011,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  body-parser@2.2.2(supports-color@7.2.0):
+  body-parser@2.2.2:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
@@ -17089,11 +17025,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  body-parser@2.3.0(supports-color@8.1.1):
+  body-parser@2.3.0:
     dependencies:
       bytes: 3.1.2
       content-type: 2.1.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@7.2.0)
       http-errors: 2.0.1
       iconv-lite: 0.7.3
       on-finished: 2.4.1
@@ -17153,7 +17089,7 @@ snapshots:
     dependencies:
       balanced-match: 4.0.3
 
-  braces@2.3.2(supports-color@8.1.1):
+  braces@2.3.2:
     dependencies:
       arr-flatten: 1.1.0
       array-unique: 0.3.2
@@ -17161,7 +17097,7 @@ snapshots:
       fill-range: 4.0.0
       isobject: 3.0.1
       repeat-element: 1.1.4
-      snapdragon: 0.8.2(supports-color@8.1.1)
+      snapdragon: 0.8.2
       snapdragon-node: 2.1.1
       split-string: 3.1.0
       to-regex: 3.0.2
@@ -17223,11 +17159,11 @@ snapshots:
 
   builtin-status-codes@3.0.0: {}
 
-  bull@4.16.5(supports-color@7.2.0):
+  bull@4.16.5:
     dependencies:
       cron-parser: 4.9.0
       get-port: 5.1.1
-      ioredis: 5.4.2(supports-color@7.2.0)
+      ioredis: 5.4.2
       lodash: 4.17.21
       msgpackr: 1.11.8
       semver: 7.7.3
@@ -17235,10 +17171,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  bullmq@5.71.0(supports-color@8.1.1):
+  bullmq@5.71.0:
     dependencies:
       cron-parser: 4.9.0
-      ioredis: 5.9.3(supports-color@8.1.1)
+      ioredis: 5.9.3
       msgpackr: 1.11.5
       node-abort-controller: 3.1.1
       semver: 7.7.4
@@ -17267,9 +17203,9 @@ snapshots:
 
   byte-size@8.1.1: {}
 
-  byte@2.0.0(supports-color@8.1.1):
+  byte@2.0.0:
     dependencies:
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7
       long: 4.0.0
       utility: 1.18.0
     transitivePeerDependencies:
@@ -17334,10 +17270,10 @@ snapshots:
       mime-types: 2.1.35
       ylru: 1.4.0
 
-  cache-manager-ioredis-yet@2.1.2(supports-color@7.2.0):
+  cache-manager-ioredis-yet@2.1.2:
     dependencies:
       cache-manager: 6.0.0
-      ioredis: 5.4.2(supports-color@7.2.0)
+      ioredis: 5.4.2
       telejson: 7.2.0
     transitivePeerDependencies:
       - supports-color
@@ -17599,16 +17535,16 @@ snapshots:
 
   clone@1.0.4: {}
 
-  cluster-client@3.7.0(supports-color@8.1.1):
+  cluster-client@3.7.0:
     dependencies:
-      byte: 2.0.0(supports-color@8.1.1)
+      byte: 2.0.0
       co: 4.6.0
       egg-logger: 3.6.1
       is-type-of: 1.4.0
       json-stringify-safe: 5.0.1
       long: 4.0.0
       sdk-base: 4.2.1
-      serialize-json: 1.0.3(supports-color@8.1.1)
+      serialize-json: 1.0.3
       tcp-base: 3.2.0
       utility: 2.5.0
     transitivePeerDependencies:
@@ -17641,7 +17577,7 @@ snapshots:
 
   cockatiel@3.2.1: {}
 
-  coffee@5.5.1(supports-color@7.2.0):
+  coffee@5.5.1:
     dependencies:
       cross-spawn: 6.0.6
       debug: 4.4.3(supports-color@7.2.0)
@@ -17703,7 +17639,7 @@ snapshots:
 
   common-ancestor-path@1.0.1: {}
 
-  common-bin@3.0.1(supports-color@7.2.0):
+  common-bin@3.0.1:
     dependencies:
       chalk: 4.1.2
       change-case: 4.1.2
@@ -17739,11 +17675,11 @@ snapshots:
     dependencies:
       mime-db: 1.54.0
 
-  compression@1.8.1(supports-color@8.1.1):
+  compression@1.8.1:
     dependencies:
       bytes: 3.1.2
       compressible: 2.0.18
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       negotiator: 0.6.4
       on-headers: 1.1.0
       safe-buffer: 5.2.1
@@ -17884,10 +17820,10 @@ snapshots:
       cookie: 0.7.2
       cookie-signature: 1.0.6
 
-  cookie-session@2.1.1(supports-color@8.1.1):
+  cookie-session@2.1.1:
     dependencies:
       cookies: 0.9.1
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7
       on-headers: 1.1.0
       safe-buffer: 5.2.1
     transitivePeerDependencies:
@@ -17945,13 +17881,13 @@ snapshots:
     dependencies:
       buffer: 5.7.1
 
-  create-jest@29.7.0(@types/node@22.12.0)(supports-color@7.2.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3)):
+  create-jest@29.7.0(@types/node@22.12.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@22.12.0)(supports-color@7.2.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3))
+      jest-config: 29.7.0(@types/node@22.12.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -18062,41 +17998,29 @@ snapshots:
 
   debounce@1.2.1: {}
 
-  debug@2.6.9(supports-color@8.1.1):
+  debug@2.6.9:
     dependencies:
       ms: 2.0.0
-    optionalDependencies:
-      supports-color: 8.1.1
 
-  debug@3.1.0(supports-color@8.1.1):
+  debug@3.1.0:
     dependencies:
       ms: 2.0.0
-    optionalDependencies:
-      supports-color: 8.1.1
 
-  debug@3.2.7(supports-color@8.1.1):
+  debug@3.2.7:
     dependencies:
       ms: 2.1.3
-    optionalDependencies:
-      supports-color: 8.1.1
 
-  debug@4.1.1(supports-color@8.1.1):
+  debug@4.1.1:
     dependencies:
       ms: 2.1.3
-    optionalDependencies:
-      supports-color: 8.1.1
 
-  debug@4.3.4(supports-color@8.1.1):
+  debug@4.3.4:
     dependencies:
       ms: 2.1.2
-    optionalDependencies:
-      supports-color: 8.1.1
 
-  debug@4.3.7(supports-color@8.1.1):
+  debug@4.3.7:
     dependencies:
       ms: 2.1.3
-    optionalDependencies:
-      supports-color: 8.1.1
 
   debug@4.4.3(supports-color@7.2.0):
     dependencies:
@@ -18222,12 +18146,12 @@ snapshots:
 
   depd@2.0.0: {}
 
-  dependency-tree@9.0.0(supports-color@7.2.0):
+  dependency-tree@9.0.0:
     dependencies:
       commander: 2.20.3
       debug: 4.4.3(supports-color@7.2.0)
-      filing-cabinet: 3.3.1(supports-color@7.2.0)
-      precinct: 9.2.1(supports-color@7.2.0)
+      filing-cabinet: 3.3.1
+      precinct: 9.2.1
       typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
@@ -18244,10 +18168,10 @@ snapshots:
 
   detect-node@2.1.0: {}
 
-  detect-port@1.6.1(supports-color@8.1.1):
+  detect-port@1.6.1:
     dependencies:
       address: 1.2.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -18283,7 +18207,7 @@ snapshots:
     dependencies:
       node-source-walk: 5.0.2
 
-  detective-less@1.0.2(supports-color@7.2.0):
+  detective-less@1.0.2:
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
       gonzales-pe: 4.3.0
@@ -18291,7 +18215,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  detective-postcss@4.0.0(supports-color@7.2.0):
+  detective-postcss@4.0.0:
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
       is-url: 1.2.4
@@ -18332,18 +18256,18 @@ snapshots:
 
   detective-stylus@3.0.0: {}
 
-  detective-typescript@7.0.2(supports-color@7.2.0):
+  detective-typescript@7.0.2:
     dependencies:
-      '@typescript-eslint/typescript-estree': 4.33.0(supports-color@7.2.0)(typescript@3.9.10)
+      '@typescript-eslint/typescript-estree': 4.33.0(typescript@3.9.10)
       ast-module-types: 2.7.1
       node-source-walk: 4.3.0
       typescript: 3.9.10
     transitivePeerDependencies:
       - supports-color
 
-  detective-typescript@9.1.1(supports-color@7.2.0):
+  detective-typescript@9.1.1:
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.62.0(supports-color@7.2.0)(typescript@4.9.5)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.9.5)
       ast-module-types: 4.0.0
       node-source-walk: 5.0.2
       typescript: 4.9.5
@@ -18447,16 +18371,16 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  egg-cluster@1.27.1(supports-color@8.1.1):
+  egg-cluster@1.27.1:
     dependencies:
       await-event: 2.1.0
       cfork: 1.11.0
       cluster-reload: 1.1.0
       co: 4.6.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@7.2.0)
       depd: 2.0.0
-      detect-port: 1.6.1(supports-color@8.1.1)
-      egg-logger: 2.9.1(supports-color@8.1.1)
+      detect-port: 1.6.1
+      egg-logger: 2.9.1
       egg-utils: 2.5.0
       get-ready: 2.0.1
       graceful-process: 1.3.0
@@ -18475,7 +18399,7 @@ snapshots:
       should-send-same-site-none: 2.0.5
       utility: 1.18.0
 
-  egg-core@4.31.0(supports-color@8.1.1):
+  egg-core@4.31.0:
     dependencies:
       '@eggjs/router': 2.2.0
       '@types/depd': 1.1.37
@@ -18483,17 +18407,17 @@ snapshots:
       co: 4.6.0
       debug: 4.4.3(supports-color@7.2.0)
       depd: 2.0.0
-      egg-logger: 2.9.1(supports-color@8.1.1)
+      egg-logger: 2.9.1
       egg-path-matching: 1.2.0
       extend2: 1.0.1
       gals: 1.0.2
       get-ready: 2.0.1
       globby: 10.0.2
       is-type-of: 1.4.0
-      koa: 2.16.3(supports-color@7.2.0)
+      koa: 2.16.3
       koa-convert: 1.2.0
       node-homedir: 1.1.1
-      ready-callback: 2.1.0(supports-color@8.1.1)
+      ready-callback: 2.1.0
       tsconfig-paths: 4.2.0
       utility: 1.18.0
     transitivePeerDependencies:
@@ -18509,10 +18433,10 @@ snapshots:
 
   egg-errors@2.3.2: {}
 
-  egg-i18n@2.1.1(supports-color@8.1.1):
+  egg-i18n@2.1.1:
     dependencies:
-      debug: 3.2.7(supports-color@8.1.1)
-      koa-locales: 1.12.0(supports-color@8.1.1)
+      debug: 3.2.7
+      koa-locales: 1.12.0
     transitivePeerDependencies:
       - supports-color
 
@@ -18521,11 +18445,11 @@ snapshots:
       is-type-of: 1.4.0
       jsonp-body: 1.1.0
 
-  egg-logger@2.9.1(supports-color@8.1.1):
+  egg-logger@2.9.1:
     dependencies:
       chalk: 2.4.2
       circular-json-for-egg: 1.0.0
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       depd: 2.0.0
       egg-errors: 2.3.2
       iconv-lite: 0.4.24
@@ -18548,20 +18472,20 @@ snapshots:
       moment: 2.30.1
       mz: 2.7.0
 
-  egg-mock@4.2.1(supports-color@8.1.1):
+  egg-mock@4.2.1:
     dependencies:
       '@types/power-assert': 1.5.12
       '@types/supertest': 2.0.16
       await-event: 2.1.0
       co: 4.6.0
-      coffee: 5.5.1(supports-color@7.2.0)
+      coffee: 5.5.1
       debug: 4.4.3(supports-color@7.2.0)
-      detect-port: 1.6.1(supports-color@8.1.1)
-      egg-logger: 2.9.1(supports-color@8.1.1)
+      detect-port: 1.6.1
+      egg-logger: 2.9.1
       egg-utils: 2.5.0
       extend2: 1.0.1
       get-ready: 2.0.1
-      globby: 9.2.0(supports-color@8.1.1)
+      globby: 9.2.0
       is-type-of: 1.4.0
       ko-sleep: 1.1.4
       merge-descriptors: 1.0.3
@@ -18569,7 +18493,7 @@ snapshots:
       mm: 3.4.0
       mz-modules: 2.1.0
       power-assert: 1.6.1
-      supertest: 4.0.2(supports-color@8.1.1)
+      supertest: 4.0.2
       urllib: 2.44.0
     transitivePeerDependencies:
       - proxy-agent
@@ -18609,10 +18533,10 @@ snapshots:
       safe-timers: 1.1.0
       utility: 1.18.0
 
-  egg-scripts@3.1.0(supports-color@7.2.0):
+  egg-scripts@3.1.0:
     dependencies:
       await-event: 2.1.0
-      common-bin: 3.0.1(supports-color@7.2.0)
+      common-bin: 3.0.1
       egg-utils: 2.5.0
       mz: 2.7.0
       mz-modules: 2.1.0
@@ -18624,7 +18548,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  egg-security@2.11.0(supports-color@7.2.0):
+  egg-security@2.11.0:
     dependencies:
       csrf: 3.1.0
       debug: 4.4.3(supports-color@7.2.0)
@@ -18644,31 +18568,31 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  egg-session@3.3.0(supports-color@7.2.0):
+  egg-session@3.3.0:
     dependencies:
-      koa-session: 6.4.0(supports-color@7.2.0)
+      koa-session: 6.4.0
     transitivePeerDependencies:
       - supports-color
 
-  egg-socket.io@4.1.6(supports-color@8.1.1):
+  egg-socket.io@4.1.6:
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
       delegates: 1.0.0
       is-type-of: 1.4.0
       koa-compose: 4.1.0
-      socket.io: 2.5.1(supports-color@8.1.1)
-      socket.io-redis: 5.4.0(supports-color@8.1.1)
+      socket.io: 2.5.1
+      socket.io-redis: 5.4.0
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  egg-static@2.3.1(supports-color@8.1.1):
+  egg-static@2.3.1:
     dependencies:
       is-type-of: 1.4.0
       koa-compose: 4.1.0
       koa-range: 0.3.0
-      koa-static-cache: 5.1.4(supports-color@8.1.1)
+      koa-static-cache: 5.1.4
       ylru: 1.4.0
     transitivePeerDependencies:
       - supports-color
@@ -18688,15 +18612,15 @@ snapshots:
     dependencies:
       mz: 2.7.0
 
-  egg-watcher@3.1.1(supports-color@8.1.1):
+  egg-watcher@3.1.1:
     dependencies:
       camelcase: 5.3.1
       sdk-base: 3.6.0
-      wt: 1.2.0(supports-color@8.1.1)
+      wt: 1.2.0
     transitivePeerDependencies:
       - supports-color
 
-  egg@2.37.0(supports-color@8.1.1):
+  egg@2.37.0:
     dependencies:
       '@types/accepts': 1.3.7
       '@types/koa': 2.15.2
@@ -18705,26 +18629,26 @@ snapshots:
       agentkeepalive: 4.6.0
       cache-content-type: 1.0.1
       circular-json-for-egg: 1.0.0
-      cluster-client: 3.7.0(supports-color@8.1.1)
+      cluster-client: 3.7.0
       debug: 4.4.3(supports-color@7.2.0)
       delegates: 1.0.0
-      egg-cluster: 1.27.1(supports-color@8.1.1)
+      egg-cluster: 1.27.1
       egg-cookies: 2.10.1
-      egg-core: 4.31.0(supports-color@8.1.1)
+      egg-core: 4.31.0
       egg-development: 2.7.0
       egg-errors: 2.3.2
-      egg-i18n: 2.1.1(supports-color@8.1.1)
+      egg-i18n: 2.1.1
       egg-jsonp: 2.0.0
-      egg-logger: 2.9.1(supports-color@8.1.1)
+      egg-logger: 2.9.1
       egg-logrotator: 3.2.0
       egg-multipart: 2.13.1
       egg-onerror: 2.4.0
       egg-schedule: 3.7.0
-      egg-security: 2.11.0(supports-color@7.2.0)
-      egg-session: 3.3.0(supports-color@7.2.0)
-      egg-static: 2.3.1(supports-color@8.1.1)
+      egg-security: 2.11.0
+      egg-session: 3.3.0
+      egg-static: 2.3.1
       egg-view: 2.1.4
-      egg-watcher: 3.1.1(supports-color@8.1.1)
+      egg-watcher: 3.1.1
       extend2: 1.0.1
       graceful: 1.1.0
       humanize-ms: 1.2.1
@@ -18791,11 +18715,11 @@ snapshots:
 
   end-or-error@1.0.1: {}
 
-  engine.io-client@3.5.6(supports-color@8.1.1):
+  engine.io-client@3.5.6:
     dependencies:
       component-emitter: 1.3.1
       component-inherit: 0.0.3
-      debug: 3.1.0(supports-color@8.1.1)
+      debug: 3.1.0
       engine.io-parser: 2.2.1
       has-cors: 1.1.0
       indexof: 0.0.1
@@ -18809,22 +18733,10 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  engine.io-client@6.6.4(supports-color@7.2.0):
+  engine.io-client@6.6.4:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
       debug: 4.4.3(supports-color@7.2.0)
-      engine.io-parser: 5.2.3
-      ws: 8.18.3
-      xmlhttprequest-ssl: 2.1.2
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  engine.io-client@6.6.4(supports-color@8.1.1):
-    dependencies:
-      '@socket.io/component-emitter': 3.1.2
-      debug: 4.4.3(supports-color@8.1.1)
       engine.io-parser: 5.2.3
       ws: 8.18.3
       xmlhttprequest-ssl: 2.1.2
@@ -18843,12 +18755,12 @@ snapshots:
 
   engine.io-parser@5.2.3: {}
 
-  engine.io@3.6.2(supports-color@8.1.1):
+  engine.io@3.6.2:
     dependencies:
       accepts: 1.3.8
       base64id: 2.0.0
       cookie: 0.4.2
-      debug: 4.1.1(supports-color@8.1.1)
+      debug: 4.1.1
       engine.io-parser: 2.2.1
       ws: 7.5.10
     transitivePeerDependencies:
@@ -18856,7 +18768,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  engine.io@6.6.5(supports-color@7.2.0):
+  engine.io@6.6.5:
     dependencies:
       '@types/cors': 2.8.19
       '@types/node': 20.19.39
@@ -18865,22 +18777,6 @@ snapshots:
       cookie: 0.7.2
       cors: 2.8.5
       debug: 4.4.3(supports-color@7.2.0)
-      engine.io-parser: 5.2.3
-      ws: 8.18.3
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  engine.io@6.6.5(supports-color@8.1.1):
-    dependencies:
-      '@types/cors': 2.8.19
-      '@types/node': 20.19.39
-      accepts: 1.3.8
-      base64id: 2.0.0
-      cookie: 0.7.2
-      cors: 2.8.5
-      debug: 4.4.3(supports-color@8.1.1)
       engine.io-parser: 5.2.3
       ws: 8.18.3
     transitivePeerDependencies:
@@ -19098,38 +18994,38 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-compat-utils@0.5.1(eslint@10.0.0(supports-color@7.2.0)):
+  eslint-compat-utils@0.5.1(eslint@10.0.0):
     dependencies:
-      eslint: 10.0.0(supports-color@7.2.0)
+      eslint: 10.0.0
       semver: 7.7.4
 
-  eslint-config-prettier@10.1.8(eslint@10.0.0(supports-color@7.2.0)):
+  eslint-config-prettier@10.1.8(eslint@10.0.0):
     dependencies:
-      eslint: 10.0.0(supports-color@7.2.0)
+      eslint: 10.0.0
 
-  eslint-config-prettier@8.10.2(eslint@7.32.0(supports-color@7.2.0)):
+  eslint-config-prettier@8.10.2(eslint@7.32.0):
     dependencies:
-      eslint: 7.32.0(supports-color@7.2.0)
+      eslint: 7.32.0
 
-  eslint-plugin-es-x@7.8.0(eslint@10.0.0(supports-color@7.2.0)):
+  eslint-plugin-es-x@7.8.0(eslint@10.0.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.0.0(supports-color@7.2.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.0.0)
       '@eslint-community/regexpp': 4.12.2
-      eslint: 10.0.0(supports-color@7.2.0)
-      eslint-compat-utils: 0.5.1(eslint@10.0.0(supports-color@7.2.0))
+      eslint: 10.0.0
+      eslint-compat-utils: 0.5.1(eslint@10.0.0)
 
-  eslint-plugin-es@3.0.1(eslint@7.32.0(supports-color@7.2.0)):
+  eslint-plugin-es@3.0.1(eslint@7.32.0):
     dependencies:
-      eslint: 7.32.0(supports-color@7.2.0)
+      eslint: 7.32.0
       eslint-utils: 2.1.0
       regexpp: 3.2.0
 
-  eslint-plugin-n@17.24.0(eslint@10.0.0(supports-color@7.2.0))(typescript@5.6.3):
+  eslint-plugin-n@17.24.0(eslint@10.0.0)(typescript@5.6.3):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.0.0(supports-color@7.2.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.0.0)
       enhanced-resolve: 5.19.0
-      eslint: 10.0.0(supports-color@7.2.0)
-      eslint-plugin-es-x: 7.8.0(eslint@10.0.0(supports-color@7.2.0))
+      eslint: 10.0.0
+      eslint-plugin-es-x: 7.8.0(eslint@10.0.0)
       get-tsconfig: 4.13.6
       globals: 15.15.0
       globrex: 0.1.2
@@ -19139,33 +19035,33 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  eslint-plugin-node@11.1.0(eslint@7.32.0(supports-color@7.2.0)):
+  eslint-plugin-node@11.1.0(eslint@7.32.0):
     dependencies:
-      eslint: 7.32.0(supports-color@7.2.0)
-      eslint-plugin-es: 3.0.1(eslint@7.32.0(supports-color@7.2.0))
+      eslint: 7.32.0
+      eslint-plugin-es: 3.0.1(eslint@7.32.0)
       eslint-utils: 2.1.0
       ignore: 5.3.2
       minimatch: 3.1.5
       resolve: 1.22.11
       semver: 6.3.1
 
-  eslint-plugin-prettier@3.4.1(eslint-config-prettier@8.10.2(eslint@7.32.0(supports-color@7.2.0)))(eslint@7.32.0(supports-color@7.2.0))(prettier@2.8.8):
+  eslint-plugin-prettier@3.4.1(eslint-config-prettier@8.10.2(eslint@7.32.0))(eslint@7.32.0)(prettier@2.8.8):
     dependencies:
-      eslint: 7.32.0(supports-color@7.2.0)
+      eslint: 7.32.0
       prettier: 2.8.8
       prettier-linter-helpers: 1.0.1
     optionalDependencies:
-      eslint-config-prettier: 8.10.2(eslint@7.32.0(supports-color@7.2.0))
+      eslint-config-prettier: 8.10.2(eslint@7.32.0)
 
-  eslint-plugin-prettier@5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@10.0.0(supports-color@7.2.0)))(eslint@10.0.0(supports-color@7.2.0))(prettier@3.8.1):
+  eslint-plugin-prettier@5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@10.0.0))(eslint@10.0.0)(prettier@3.8.1):
     dependencies:
-      eslint: 10.0.0(supports-color@7.2.0)
+      eslint: 10.0.0
       prettier: 3.8.1
       prettier-linter-helpers: 1.0.1
       synckit: 0.11.12
     optionalDependencies:
       '@types/eslint': 9.6.1
-      eslint-config-prettier: 10.1.8(eslint@10.0.0(supports-color@7.2.0))
+      eslint-config-prettier: 10.1.8(eslint@10.0.0)
 
   eslint-scope@5.1.1:
     dependencies:
@@ -19191,11 +19087,11 @@ snapshots:
 
   eslint-visitor-keys@5.0.0: {}
 
-  eslint@10.0.0(supports-color@7.2.0):
+  eslint@10.0.0:
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.0.0(supports-color@7.2.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.0.0)
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.23.1(supports-color@7.2.0)
+      '@eslint/config-array': 0.23.1
       '@eslint/config-helpers': 0.5.2
       '@eslint/core': 1.1.0
       '@eslint/plugin-kit': 0.6.0
@@ -19226,11 +19122,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint@7.32.0(supports-color@7.2.0):
+  eslint@7.32.0:
     dependencies:
       '@babel/code-frame': 7.12.11
-      '@eslint/eslintrc': 0.4.3(supports-color@7.2.0)
-      '@humanwhocodes/config-array': 0.5.0(supports-color@7.2.0)
+      '@eslint/eslintrc': 0.4.3
+      '@humanwhocodes/config-array': 0.5.0
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
@@ -19385,14 +19281,14 @@ snapshots:
 
   exit@0.1.2: {}
 
-  expand-brackets@2.1.4(supports-color@8.1.1):
+  expand-brackets@2.1.4:
     dependencies:
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       define-property: 0.2.5
       extend-shallow: 2.0.1
       posix-character-classes: 0.1.1
       regex-not: 1.0.2
-      snapdragon: 0.8.2(supports-color@8.1.1)
+      snapdragon: 0.8.2
       to-regex: 3.0.2
     transitivePeerDependencies:
       - supports-color
@@ -19409,16 +19305,16 @@ snapshots:
 
   exponential-backoff@3.1.3: {}
 
-  express-rate-limit@8.3.1(express@5.2.1(supports-color@8.1.1)):
+  express-rate-limit@8.3.1(express@5.2.1):
     dependencies:
-      express: 5.2.1(supports-color@8.1.1)
+      express: 5.2.1
       ip-address: 10.1.0
 
-  express-session@1.18.1(supports-color@8.1.1):
+  express-session@1.18.1:
     dependencies:
       cookie: 0.7.2
       cookie-signature: 1.0.7
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       depd: 2.0.0
       on-headers: 1.0.2
       parseurl: 1.3.3
@@ -19427,21 +19323,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  express@4.22.2(supports-color@8.1.1):
+  express@4.22.2:
     dependencies:
       accepts: 1.3.8
       array-flatten: 1.1.1
-      body-parser: 1.20.6(supports-color@8.1.1)
+      body-parser: 1.20.6
       content-disposition: 0.5.4
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.0.7
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 1.3.1(supports-color@8.1.1)
+      finalhandler: 1.3.1
       fresh: 0.5.2
       http-errors: 2.0.1
       merge-descriptors: 1.0.3
@@ -19453,8 +19349,8 @@ snapshots:
       qs: 6.15.2
       range-parser: 1.2.1
       safe-buffer: 5.2.1
-      send: 0.19.0(supports-color@8.1.1)
-      serve-static: 1.16.2(supports-color@8.1.1)
+      send: 0.19.0
+      serve-static: 1.16.2
       setprototypeof: 1.2.0
       statuses: 2.0.2
       type-is: 1.6.18
@@ -19463,10 +19359,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  express@5.2.1(supports-color@8.1.1):
+  express@5.2.1:
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.3.0(supports-color@8.1.1)
+      body-parser: 2.3.0
       content-disposition: 1.0.1
       content-type: 1.0.5
       cookie: 0.7.2
@@ -19476,7 +19372,7 @@ snapshots:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 2.1.1(supports-color@8.1.1)
+      finalhandler: 2.1.1
       fresh: 2.0.0
       http-errors: 2.0.1
       merge-descriptors: 2.0.0
@@ -19487,9 +19383,9 @@ snapshots:
       proxy-addr: 2.0.7
       qs: 6.16.0
       range-parser: 1.2.1
-      router: 2.2.0(supports-color@7.2.0)
-      send: 1.2.1(supports-color@7.2.0)
-      serve-static: 2.2.1(supports-color@8.1.1)
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
       statuses: 2.0.2
       type-is: 2.1.0
       vary: 1.1.2
@@ -19515,24 +19411,24 @@ snapshots:
       iconv-lite: 0.4.24
       tmp: 0.0.33
 
-  extglob@2.0.4(supports-color@8.1.1):
+  extglob@2.0.4:
     dependencies:
       array-unique: 0.3.2
       define-property: 1.0.0
-      expand-brackets: 2.1.4(supports-color@8.1.1)
+      expand-brackets: 2.1.4
       extend-shallow: 2.0.1
       fragment-cache: 0.2.1
       regex-not: 1.0.2
-      snapdragon: 0.8.2(supports-color@8.1.1)
+      snapdragon: 0.8.2
       to-regex: 3.0.2
     transitivePeerDependencies:
       - supports-color
 
   extsprintf@1.3.0: {}
 
-  fake-egg@1.0.0(supports-color@8.1.1):
+  fake-egg@1.0.0:
     dependencies:
-      egg: 2.37.0(supports-color@8.1.1)
+      egg: 2.37.0
     transitivePeerDependencies:
       - proxy-agent
       - supports-color
@@ -19541,14 +19437,14 @@ snapshots:
 
   fast-diff@1.3.0: {}
 
-  fast-glob@2.2.7(supports-color@8.1.1):
+  fast-glob@2.2.7:
     dependencies:
       '@mrmlnc/readdir-enhanced': 2.2.1
       '@nodelib/fs.stat': 1.1.3
       glob-parent: 3.1.0
       is-glob: 4.0.3
       merge2: 1.4.1
-      micromatch: 3.1.10(supports-color@8.1.1)
+      micromatch: 3.1.10
     transitivePeerDependencies:
       - supports-color
 
@@ -19613,9 +19509,9 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
-  file-type@21.3.2(supports-color@8.1.1):
+  file-type@21.3.2:
     dependencies:
-      '@tokenizer/inflate': 0.4.1(supports-color@8.1.1)
+      '@tokenizer/inflate': 0.4.1
       strtok3: 10.3.5
       token-types: 6.1.2
       uint8array-extras: 1.5.0
@@ -19628,7 +19524,7 @@ snapshots:
     dependencies:
       minimatch: 5.1.9
 
-  filing-cabinet@3.3.1(supports-color@7.2.0):
+  filing-cabinet@3.3.1:
     dependencies:
       app-module-path: 2.2.0
       commander: 2.20.3
@@ -19636,11 +19532,11 @@ snapshots:
       enhanced-resolve: 5.18.4
       is-relative-path: 1.0.2
       module-definition: 3.4.0
-      module-lookup-amd: 7.0.1(supports-color@7.2.0)
+      module-lookup-amd: 7.0.1
       resolve: 1.22.11
       resolve-dependency-path: 2.0.0
       sass-lookup: 3.0.0
-      stylus-lookup: 3.0.2(supports-color@7.2.0)
+      stylus-lookup: 3.0.2
       tsconfig-paths: 3.15.0
       typescript: 3.9.10
     transitivePeerDependencies:
@@ -19657,9 +19553,9 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  finalhandler@1.3.1(supports-color@8.1.1):
+  finalhandler@1.3.1:
     dependencies:
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -19669,20 +19565,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  finalhandler@2.1.1(supports-color@7.2.0):
+  finalhandler@2.1.1:
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      on-finished: 2.4.1
-      parseurl: 1.3.3
-      statuses: 2.0.2
-    transitivePeerDependencies:
-      - supports-color
-
-  finalhandler@2.1.1(supports-color@8.1.1):
-    dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -19747,10 +19632,6 @@ snapshots:
   follow-redirects@1.16.0(debug@4.4.3(supports-color@7.2.0)):
     optionalDependencies:
       debug: 4.4.3(supports-color@7.2.0)
-
-  follow-redirects@1.16.0(debug@4.4.3(supports-color@8.1.1)):
-    optionalDependencies:
-      debug: 4.4.3(supports-color@8.1.1)
 
   for-each@0.3.5:
     dependencies:
@@ -20117,12 +19998,12 @@ snapshots:
       merge2: 1.4.1
       slash: 3.0.0
 
-  globby@9.2.0(supports-color@8.1.1):
+  globby@9.2.0:
     dependencies:
       '@types/glob': 7.2.0
       array-union: 1.0.2
       dir-glob: 2.2.2
-      fast-glob: 2.2.7(supports-color@8.1.1)
+      fast-glob: 2.2.7
       glob: 7.2.3
       ignore: 4.0.6
       pify: 4.0.1
@@ -20378,7 +20259,7 @@ snapshots:
 
   http-parser-js@0.5.10: {}
 
-  http-proxy-agent@4.0.1(supports-color@7.2.0):
+  http-proxy-agent@4.0.1:
     dependencies:
       '@tootallnate/once': 1.1.2
       agent-base: 6.0.2(supports-color@7.2.0)
@@ -20386,26 +20267,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  http-proxy-agent@4.0.1(supports-color@8.1.1):
-    dependencies:
-      '@tootallnate/once': 1.1.2
-      agent-base: 6.0.2(supports-color@8.1.1)
-      debug: 4.4.3(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
-  http-proxy-agent@7.0.2(supports-color@7.2.0):
+  http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  http-proxy-middleware@2.0.9(@types/express@4.17.25)(debug@4.4.3(supports-color@8.1.1)):
+  http-proxy-middleware@2.0.9(@types/express@4.17.25):
     dependencies:
       '@types/http-proxy': 1.17.17
-      http-proxy: 1.18.1(debug@4.4.3(supports-color@8.1.1))
+      http-proxy: 1.18.1
       is-glob: 4.0.3
       is-plain-obj: 3.0.0
       micromatch: 4.0.8
@@ -20414,10 +20286,10 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  http-proxy@1.18.1(debug@4.4.3(supports-color@8.1.1)):
+  http-proxy@1.18.1:
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.16.0(debug@4.4.3(supports-color@8.1.1))
+      follow-redirects: 1.16.0(debug@4.4.3(supports-color@7.2.0))
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -20440,14 +20312,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@5.0.1(supports-color@8.1.1):
-    dependencies:
-      agent-base: 6.0.2(supports-color@8.1.1)
-      debug: 4.4.3(supports-color@7.2.0)
-    transitivePeerDependencies:
-      - supports-color
-
-  https-proxy-agent@7.0.6(supports-color@7.2.0):
+  https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@7.2.0)
@@ -20606,7 +20471,7 @@ snapshots:
 
   interpret@2.2.0: {}
 
-  ioredis@5.4.2(supports-color@7.2.0):
+  ioredis@5.4.2:
     dependencies:
       '@ioredis/commands': 1.5.0
       cluster-key-slot: 1.1.2
@@ -20620,25 +20485,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ioredis@5.4.2(supports-color@8.1.1):
+  ioredis@5.9.3:
     dependencies:
       '@ioredis/commands': 1.5.0
       cluster-key-slot: 1.1.2
-      debug: 4.4.3(supports-color@8.1.1)
-      denque: 2.1.0
-      lodash.defaults: 4.2.0
-      lodash.isarguments: 3.1.0
-      redis-errors: 1.2.0
-      redis-parser: 3.0.0
-      standard-as-callback: 2.1.0
-    transitivePeerDependencies:
-      - supports-color
-
-  ioredis@5.9.3(supports-color@8.1.1):
-    dependencies:
-      '@ioredis/commands': 1.5.0
-      cluster-key-slot: 1.1.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@7.2.0)
       denque: 2.1.0
       lodash.defaults: 4.2.0
       lodash.isarguments: 3.1.0
@@ -20947,9 +20798,9 @@ snapshots:
 
   istanbul-lib-coverage@3.2.2: {}
 
-  istanbul-lib-instrument@5.2.1(supports-color@7.2.0):
+  istanbul-lib-instrument@5.2.1:
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
       '@babel/parser': 7.29.0
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
@@ -20957,9 +20808,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  istanbul-lib-instrument@6.0.3(supports-color@7.2.0):
+  istanbul-lib-instrument@6.0.3:
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
       '@babel/parser': 7.28.5
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
@@ -20973,7 +20824,7 @@ snapshots:
       make-dir: 4.0.0
       supports-color: 7.2.0
 
-  istanbul-lib-source-maps@4.0.1(supports-color@7.2.0):
+  istanbul-lib-source-maps@4.0.1:
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
       istanbul-lib-coverage: 3.2.2
@@ -21002,10 +20853,10 @@ snapshots:
       jest-util: 29.7.0
       p-limit: 3.1.0
 
-  jest-circus@29.7.0(supports-color@7.2.0):
+  jest-circus@29.7.0:
     dependencies:
       '@jest/environment': 29.7.0
-      '@jest/expect': 29.7.0(supports-color@7.2.0)
+      '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       '@types/node': 22.12.0
@@ -21016,8 +20867,8 @@ snapshots:
       jest-each: 29.7.0
       jest-matcher-utils: 29.7.0
       jest-message-util: 29.7.0
-      jest-runtime: 29.7.0(supports-color@7.2.0)
-      jest-snapshot: 29.7.0(supports-color@7.2.0)
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
       jest-util: 29.7.0
       p-limit: 3.1.0
       pretty-format: 29.7.0
@@ -21028,16 +20879,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@22.12.0)(supports-color@7.2.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3)):
+  jest-cli@29.7.0(@types/node@22.12.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3)):
     dependencies:
-      '@jest/core': 29.7.0(supports-color@7.2.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@22.12.0)(supports-color@7.2.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3))
+      create-jest: 29.7.0(@types/node@22.12.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@22.12.0)(supports-color@7.2.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3))
+      jest-config: 29.7.0(@types/node@22.12.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -21047,23 +20898,23 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@20.19.39)(supports-color@7.2.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3)):
+  jest-config@29.7.0(@types/node@20.19.39)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3)):
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
       '@jest/test-sequencer': 29.7.0
       '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.28.5(supports-color@7.2.0))(supports-color@7.2.0)
+      babel-jest: 29.7.0(@babel/core@7.28.5)
       chalk: 4.1.2
       ci-info: 3.9.0
       deepmerge: 4.3.1
       glob: 7.2.3
       graceful-fs: 4.2.11
-      jest-circus: 29.7.0(supports-color@7.2.0)
+      jest-circus: 29.7.0
       jest-environment-node: 29.7.0
       jest-get-type: 29.6.3
       jest-regex-util: 29.6.3
       jest-resolve: 29.7.0
-      jest-runner: 29.7.0(supports-color@7.2.0)
+      jest-runner: 29.7.0
       jest-util: 29.7.0
       jest-validate: 29.7.0
       micromatch: 4.0.8
@@ -21078,23 +20929,23 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@22.12.0)(supports-color@7.2.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3)):
+  jest-config@29.7.0(@types/node@22.12.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3)):
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
       '@jest/test-sequencer': 29.7.0
       '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.28.5(supports-color@7.2.0))(supports-color@7.2.0)
+      babel-jest: 29.7.0(@babel/core@7.28.5)
       chalk: 4.1.2
       ci-info: 3.9.0
       deepmerge: 4.3.1
       glob: 7.2.3
       graceful-fs: 4.2.11
-      jest-circus: 29.7.0(supports-color@7.2.0)
+      jest-circus: 29.7.0
       jest-environment-node: 29.7.0
       jest-get-type: 29.6.3
       jest-regex-util: 29.6.3
       jest-resolve: 29.7.0
-      jest-runner: 29.7.0(supports-color@7.2.0)
+      jest-runner: 29.7.0
       jest-util: 29.7.0
       jest-validate: 29.7.0
       micromatch: 4.0.8
@@ -21198,10 +21049,10 @@ snapshots:
 
   jest-regex-util@29.6.3: {}
 
-  jest-resolve-dependencies@29.7.0(supports-color@7.2.0):
+  jest-resolve-dependencies@29.7.0:
     dependencies:
       jest-regex-util: 29.6.3
-      jest-snapshot: 29.7.0(supports-color@7.2.0)
+      jest-snapshot: 29.7.0
     transitivePeerDependencies:
       - supports-color
 
@@ -21217,12 +21068,12 @@ snapshots:
       resolve.exports: 2.0.3
       slash: 3.0.0
 
-  jest-runner@29.7.0(supports-color@7.2.0):
+  jest-runner@29.7.0:
     dependencies:
       '@jest/console': 29.7.0
       '@jest/environment': 29.7.0
       '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0(supports-color@7.2.0)
+      '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@types/node': 22.12.0
       chalk: 4.1.2
@@ -21234,7 +21085,7 @@ snapshots:
       jest-leak-detector: 29.7.0
       jest-message-util: 29.7.0
       jest-resolve: 29.7.0
-      jest-runtime: 29.7.0(supports-color@7.2.0)
+      jest-runtime: 29.7.0
       jest-util: 29.7.0
       jest-watcher: 29.7.0
       jest-worker: 29.7.0
@@ -21243,14 +21094,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  jest-runtime@29.7.0(supports-color@7.2.0):
+  jest-runtime@29.7.0:
     dependencies:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
-      '@jest/globals': 29.7.0(supports-color@7.2.0)
+      '@jest/globals': 29.7.0
       '@jest/source-map': 29.6.3
       '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0(supports-color@7.2.0)
+      '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@types/node': 22.12.0
       chalk: 4.1.2
@@ -21263,24 +21114,24 @@ snapshots:
       jest-mock: 29.7.0
       jest-regex-util: 29.6.3
       jest-resolve: 29.7.0
-      jest-snapshot: 29.7.0(supports-color@7.2.0)
+      jest-snapshot: 29.7.0
       jest-util: 29.7.0
       slash: 3.0.0
       strip-bom: 4.0.0
     transitivePeerDependencies:
       - supports-color
 
-  jest-snapshot@29.7.0(supports-color@7.2.0):
+  jest-snapshot@29.7.0:
     dependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
+      '@babel/core': 7.28.5
       '@babel/generator': 7.28.5
-      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.5(supports-color@7.2.0))
-      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.5(supports-color@7.2.0))
+      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.5)
       '@babel/types': 7.28.5
       '@jest/expect-utils': 29.7.0
-      '@jest/transform': 29.7.0(supports-color@7.2.0)
+      '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.28.5(supports-color@7.2.0))
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.28.5)
       chalk: 4.1.2
       expect: 29.7.0
       graceful-fs: 4.2.11
@@ -21326,7 +21177,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 22.12.0
+      '@types/node': 20.19.39
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -21337,12 +21188,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@22.12.0)(supports-color@7.2.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3)):
+  jest@29.7.0(@types/node@22.12.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3)):
     dependencies:
-      '@jest/core': 29.7.0(supports-color@7.2.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@22.12.0)(supports-color@7.2.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3))
+      jest-cli: 29.7.0(@types/node@22.12.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -21512,11 +21363,11 @@ snapshots:
 
   kleur@3.0.3: {}
 
-  knex@3.1.0(better-sqlite3@12.9.0)(mysql2@3.23.1(@types/node@22.12.0))(sqlite3@5.1.7(supports-color@8.1.1))(supports-color@8.1.1):
+  knex@3.1.0(better-sqlite3@12.9.0)(sqlite3@5.1.7):
     dependencies:
       colorette: 2.0.19
       commander: 10.0.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       escalade: 3.2.0
       esm: 3.2.25
       get-package-type: 0.1.0
@@ -21530,8 +21381,7 @@ snapshots:
       tildify: 2.0.0
     optionalDependencies:
       better-sqlite3: 12.9.0
-      mysql2: 3.23.1(@types/node@22.12.0)
-      sqlite3: 5.1.7(supports-color@8.1.1)
+      sqlite3: 5.1.7
     transitivePeerDependencies:
       - supports-color
 
@@ -21563,9 +21413,9 @@ snapshots:
 
   koa-is-json@1.0.0: {}
 
-  koa-locales@1.12.0(supports-color@8.1.1):
+  koa-locales@1.12.0:
     dependencies:
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       humanize-ms: 1.2.1
       ini: 1.3.8
       object-assign: 4.1.1
@@ -21585,7 +21435,7 @@ snapshots:
     dependencies:
       stream-slice: 0.1.2
 
-  koa-session@6.4.0(supports-color@7.2.0):
+  koa-session@6.4.0:
     dependencies:
       crc: 3.8.0
       debug: 4.4.3(supports-color@7.2.0)
@@ -21594,17 +21444,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  koa-static-cache@5.1.4(supports-color@8.1.1):
+  koa-static-cache@5.1.4:
     dependencies:
       compressible: 2.0.18
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7
       fs-readdir-recursive: 1.1.0
       mime-types: 2.1.35
       mz: 2.7.0
     transitivePeerDependencies:
       - supports-color
 
-  koa@2.16.3(supports-color@7.2.0):
+  koa@2.16.3:
     dependencies:
       accepts: 1.3.8
       cache-content-type: 1.0.1
@@ -21668,10 +21518,10 @@ snapshots:
       picocolors: 1.1.1
       shell-quote: 1.8.3
 
-  leoric@2.14.0(mysql2@3.23.1(@types/node@22.12.0))(sqlite3@5.1.7(supports-color@8.1.1))(supports-color@8.1.1):
+  leoric@2.14.0(mysql2@3.23.1(@types/node@22.12.0))(sqlite3@5.1.7):
     dependencies:
       dayjs: 1.11.19
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7
       deep-equal: 2.2.3
       heredoc: 1.3.1
       pluralize: 7.0.0
@@ -21681,17 +21531,17 @@ snapshots:
       validator: 13.15.26
     optionalDependencies:
       mysql2: 3.23.1(@types/node@22.12.0)
-      sqlite3: 5.1.7(supports-color@8.1.1)
+      sqlite3: 5.1.7
     transitivePeerDependencies:
       - supports-color
 
-  lerna-changelog@2.2.0(supports-color@7.2.0):
+  lerna-changelog@2.2.0:
     dependencies:
       chalk: 4.1.2
       cli-highlight: 2.1.11
       execa: 5.1.1
       hosted-git-info: 4.1.0
-      make-fetch-happen: 9.1.0(supports-color@7.2.0)
+      make-fetch-happen: 9.1.0
       p-map: 3.0.0
       progress: 2.0.3
       yargs: 17.7.2
@@ -21699,9 +21549,9 @@ snapshots:
       - bluebird
       - supports-color
 
-  lerna@9.0.7(@types/node@22.12.0)(supports-color@7.2.0):
+  lerna@9.0.7(@types/node@22.12.0):
     dependencies:
-      '@npmcli/arborist': 9.1.6(supports-color@7.2.0)
+      '@npmcli/arborist': 9.1.6
       '@npmcli/package-json': 7.0.2
       '@npmcli/run-script': 10.0.3
       '@nx/devkit': 22.7.8(nx@22.7.8)
@@ -21734,14 +21584,14 @@ snapshots:
       is-ci: 3.0.1
       jest-diff: 30.4.1
       js-yaml: 4.1.1
-      libnpmaccess: 10.0.3(supports-color@7.2.0)
-      libnpmpublish: 11.1.2(supports-color@7.2.0)
+      libnpmaccess: 10.0.3
+      libnpmpublish: 11.1.2
       load-json-file: 6.2.0
-      make-fetch-happen: 15.0.2(supports-color@7.2.0)
+      make-fetch-happen: 15.0.2
       minimatch: 3.1.4
       npm-package-arg: 13.0.1
       npm-packlist: 10.0.3
-      npm-registry-fetch: 19.1.0(supports-color@7.2.0)
+      npm-registry-fetch: 19.1.0
       nx: 22.7.8
       p-map: 4.0.0
       p-map-series: 2.1.0
@@ -21749,7 +21599,7 @@ snapshots:
       p-queue: 6.6.2
       p-reduce: 2.1.0
       p-waterfall: 2.1.1
-      pacote: 21.0.1(supports-color@7.2.0)
+      pacote: 21.0.1
       read-cmd-shim: 4.0.0
       semver: 7.7.2
       signal-exit: 3.0.7
@@ -21781,22 +21631,22 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
-  libnpmaccess@10.0.3(supports-color@7.2.0):
+  libnpmaccess@10.0.3:
     dependencies:
       npm-package-arg: 13.0.1
-      npm-registry-fetch: 19.1.0(supports-color@7.2.0)
+      npm-registry-fetch: 19.1.0
     transitivePeerDependencies:
       - supports-color
 
-  libnpmpublish@11.1.2(supports-color@7.2.0):
+  libnpmpublish@11.1.2:
     dependencies:
       '@npmcli/package-json': 7.0.2
       ci-info: 4.3.1
       npm-package-arg: 13.0.1
-      npm-registry-fetch: 19.1.0(supports-color@7.2.0)
+      npm-registry-fetch: 19.1.0
       proc-log: 5.0.0
       semver: 7.7.4
-      sigstore: 4.1.1(supports-color@7.2.0)
+      sigstore: 4.1.1
       ssri: 12.0.0
     transitivePeerDependencies:
       - supports-color
@@ -21953,25 +21803,25 @@ snapshots:
 
   luxon@3.7.2: {}
 
-  madge@6.1.0(supports-color@7.2.0)(typescript@5.6.3):
+  madge@6.1.0(typescript@5.6.3):
     dependencies:
       chalk: 4.1.2
       commander: 7.2.0
       commondir: 1.0.1
       debug: 4.4.3(supports-color@7.2.0)
-      dependency-tree: 9.0.0(supports-color@7.2.0)
+      dependency-tree: 9.0.0
       detective-amd: 4.2.0
       detective-cjs: 4.1.0
       detective-es6: 3.0.1
-      detective-less: 1.0.2(supports-color@7.2.0)
+      detective-less: 1.0.2
       detective-postcss: 6.1.3
       detective-sass: 4.1.3
       detective-scss: 3.1.1
       detective-stylus: 2.0.1
-      detective-typescript: 9.1.1(supports-color@7.2.0)
+      detective-typescript: 9.1.1
       ora: 5.4.1
       pluralize: 8.0.0
-      precinct: 8.3.1(supports-color@7.2.0)
+      precinct: 8.3.1
       pretty-ms: 7.0.1
       rc: 1.2.8
       stream-to-array: 2.3.0
@@ -21996,9 +21846,9 @@ snapshots:
 
   make-error@1.3.6: {}
 
-  make-fetch-happen@15.0.2(supports-color@7.2.0):
+  make-fetch-happen@15.0.2:
     dependencies:
-      '@npmcli/agent': 4.0.2(supports-color@7.2.0)
+      '@npmcli/agent': 4.0.2
       cacache: 20.0.4
       http-cache-semantics: 4.2.0
       minipass: 7.1.3
@@ -22012,10 +21862,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  make-fetch-happen@15.0.6(supports-color@7.2.0):
+  make-fetch-happen@15.0.6:
     dependencies:
       '@gar/promise-retry': 1.0.3
-      '@npmcli/agent': 4.0.2(supports-color@7.2.0)
+      '@npmcli/agent': 4.0.2
       '@npmcli/redact': 4.0.0
       cacache: 20.0.4
       http-cache-semantics: 4.2.0
@@ -22029,12 +21879,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  make-fetch-happen@9.1.0(supports-color@7.2.0):
+  make-fetch-happen@9.1.0:
     dependencies:
       agentkeepalive: 4.6.0
       cacache: 15.3.0
       http-cache-semantics: 4.2.0
-      http-proxy-agent: 4.0.1(supports-color@7.2.0)
+      http-proxy-agent: 4.0.1
       https-proxy-agent: 5.0.1(supports-color@7.2.0)
       is-lambda: 1.0.1
       lru-cache: 6.0.0
@@ -22045,34 +21895,11 @@ snapshots:
       minipass-pipeline: 1.2.4
       negotiator: 0.6.4
       promise-retry: 2.0.1
-      socks-proxy-agent: 6.2.1(supports-color@7.2.0)
+      socks-proxy-agent: 6.2.1
       ssri: 8.0.1
     transitivePeerDependencies:
       - bluebird
       - supports-color
-
-  make-fetch-happen@9.1.0(supports-color@8.1.1):
-    dependencies:
-      agentkeepalive: 4.6.0
-      cacache: 15.3.0
-      http-cache-semantics: 4.2.0
-      http-proxy-agent: 4.0.1(supports-color@8.1.1)
-      https-proxy-agent: 5.0.1(supports-color@8.1.1)
-      is-lambda: 1.0.1
-      lru-cache: 6.0.0
-      minipass: 3.3.6
-      minipass-collect: 1.0.2
-      minipass-fetch: 1.4.1
-      minipass-flush: 1.0.5
-      minipass-pipeline: 1.2.4
-      negotiator: 0.6.4
-      promise-retry: 2.0.1
-      socks-proxy-agent: 6.2.1(supports-color@8.1.1)
-      ssri: 8.0.1
-    transitivePeerDependencies:
-      - bluebird
-      - supports-color
-    optional: true
 
   makeerror@1.0.12:
     dependencies:
@@ -22150,7 +21977,7 @@ snapshots:
 
   memory-pager@1.5.0: {}
 
-  memorystore@1.6.7(supports-color@7.2.0):
+  memorystore@1.6.7:
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
       lru-cache: 4.1.5
@@ -22213,20 +22040,20 @@ snapshots:
 
   micromark-util-types@2.0.2: {}
 
-  micromatch@3.1.10(supports-color@8.1.1):
+  micromatch@3.1.10:
     dependencies:
       arr-diff: 4.0.0
       array-unique: 0.3.2
-      braces: 2.3.2(supports-color@8.1.1)
+      braces: 2.3.2
       define-property: 2.0.2
       extend-shallow: 3.0.2
-      extglob: 2.0.4(supports-color@8.1.1)
+      extglob: 2.0.4
       fragment-cache: 0.2.1
       kind-of: 6.0.3
-      nanomatch: 1.2.13(supports-color@8.1.1)
+      nanomatch: 1.2.13
       object.pick: 1.3.0
       regex-not: 1.0.2
-      snapdragon: 0.8.2(supports-color@8.1.1)
+      snapdragon: 0.8.2
       to-regex: 3.0.2
     transitivePeerDependencies:
       - supports-color
@@ -22450,7 +22277,7 @@ snapshots:
       ast-module-types: 4.0.0
       node-source-walk: 5.0.2
 
-  module-lookup-amd@7.0.1(supports-color@7.2.0):
+  module-lookup-amd@7.0.1:
     dependencies:
       commander: 2.20.3
       debug: 4.4.3(supports-color@7.2.0)
@@ -22479,32 +22306,13 @@ snapshots:
     optionalDependencies:
       socks: 2.8.7
 
-  mongoose@8.24.1(socks@2.8.7)(supports-color@7.2.0):
+  mongoose@8.24.1(socks@2.8.7):
     dependencies:
       bson: 6.10.4
       kareem: 2.6.3
       mongodb: 6.20.0(socks@2.8.7)
       mpath: 0.9.0
-      mquery: 5.0.0(supports-color@7.2.0)
-      ms: 2.1.3
-      sift: 17.1.3
-    transitivePeerDependencies:
-      - '@aws-sdk/credential-providers'
-      - '@mongodb-js/zstd'
-      - gcp-metadata
-      - kerberos
-      - mongodb-client-encryption
-      - snappy
-      - socks
-      - supports-color
-
-  mongoose@8.24.1(socks@2.8.7)(supports-color@8.1.1):
-    dependencies:
-      bson: 6.10.4
-      kareem: 2.6.3
-      mongodb: 6.20.0(socks@2.8.7)
-      mpath: 0.9.0
-      mquery: 5.0.0(supports-color@8.1.1)
+      mquery: 5.0.0
       ms: 2.1.3
       sift: 17.1.3
     transitivePeerDependencies:
@@ -22519,7 +22327,7 @@ snapshots:
 
   mpath@0.9.0: {}
 
-  mqtt-packet@9.0.2(supports-color@7.2.0):
+  mqtt-packet@9.0.2:
     dependencies:
       bl: 6.1.6
       debug: 4.4.3(supports-color@7.2.0)
@@ -22527,7 +22335,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  mqtt@5.15.2(supports-color@7.2.0):
+  mqtt@5.15.2:
     dependencies:
       '@types/readable-stream': 4.0.23
       '@types/ws': 8.18.1
@@ -22537,8 +22345,8 @@ snapshots:
       help-me: 5.0.0
       lru-cache: 10.4.3
       minimist: 1.2.8
-      mqtt-packet: 9.0.2(supports-color@7.2.0)
-      number-allocator: 1.0.14(supports-color@7.2.0)
+      mqtt-packet: 9.0.2
+      number-allocator: 1.0.14
       readable-stream: 4.7.0
       rfdc: 1.4.1
       socks: 2.8.7
@@ -22550,15 +22358,9 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  mquery@5.0.0(supports-color@7.2.0):
+  mquery@5.0.0:
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
-    transitivePeerDependencies:
-      - supports-color
-
-  mquery@5.0.0(supports-color@8.1.1):
-    dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -22610,15 +22412,15 @@ snapshots:
 
   mute-stream@2.0.0: {}
 
-  mwts@1.3.0(supports-color@8.1.1)(typescript@5.6.3):
+  mwts@1.3.0(typescript@5.6.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0(supports-color@7.2.0))(supports-color@8.1.1)(typescript@5.6.3))(eslint@7.32.0(supports-color@7.2.0))(supports-color@8.1.1)(typescript@5.6.3)
-      '@typescript-eslint/parser': 5.62.0(eslint@7.32.0(supports-color@7.2.0))(supports-color@8.1.1)(typescript@5.6.3)
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@7.32.0)(typescript@5.6.3))(eslint@7.32.0)(typescript@5.6.3)
+      '@typescript-eslint/parser': 5.62.0(eslint@7.32.0)(typescript@5.6.3)
       chalk: 4.1.2
-      eslint: 7.32.0(supports-color@7.2.0)
-      eslint-config-prettier: 8.10.2(eslint@7.32.0(supports-color@7.2.0))
-      eslint-plugin-node: 11.1.0(eslint@7.32.0(supports-color@7.2.0))
-      eslint-plugin-prettier: 3.4.1(eslint-config-prettier@8.10.2(eslint@7.32.0(supports-color@7.2.0)))(eslint@7.32.0(supports-color@7.2.0))(prettier@2.8.8)
+      eslint: 7.32.0
+      eslint-config-prettier: 8.10.2(eslint@7.32.0)
+      eslint-plugin-node: 11.1.0(eslint@7.32.0)
+      eslint-plugin-prettier: 3.4.1(eslint-config-prettier@8.10.2(eslint@7.32.0))(eslint@7.32.0)(prettier@2.8.8)
       execa: 5.1.1
       inquirer: 7.3.3
       json5: 2.2.3
@@ -22632,16 +22434,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  mwts@2.0.4(@types/eslint@9.6.1)(supports-color@7.2.0)(typescript@5.6.3):
+  mwts@2.0.4(@types/eslint@9.6.1)(typescript@5.6.3):
     dependencies:
-      '@eslint/js': 10.0.1(eslint@10.0.0(supports-color@7.2.0))
-      '@typescript-eslint/eslint-plugin': 8.56.0(@typescript-eslint/parser@8.56.0(eslint@10.0.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.6.3))(eslint@10.0.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.6.3)
-      '@typescript-eslint/parser': 8.56.0(eslint@10.0.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.6.3)
+      '@eslint/js': 10.0.1(eslint@10.0.0)
+      '@typescript-eslint/eslint-plugin': 8.56.0(@typescript-eslint/parser@8.56.0(eslint@10.0.0)(typescript@5.6.3))(eslint@10.0.0)(typescript@5.6.3)
+      '@typescript-eslint/parser': 8.56.0(eslint@10.0.0)(typescript@5.6.3)
       chalk: 4.1.2
-      eslint: 10.0.0(supports-color@7.2.0)
-      eslint-config-prettier: 10.1.8(eslint@10.0.0(supports-color@7.2.0))
-      eslint-plugin-n: 17.24.0(eslint@10.0.0(supports-color@7.2.0))(typescript@5.6.3)
-      eslint-plugin-prettier: 5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@10.0.0(supports-color@7.2.0)))(eslint@10.0.0(supports-color@7.2.0))(prettier@3.8.1)
+      eslint: 10.0.0
+      eslint-config-prettier: 10.1.8(eslint@10.0.0)
+      eslint-plugin-n: 17.24.0(eslint@10.0.0)(typescript@5.6.3)
+      eslint-plugin-prettier: 5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@10.0.0))(eslint@10.0.0)(prettier@3.8.1)
       execa: 5.1.1
       globals: 16.5.0
       inquirer: 7.3.3
@@ -22651,7 +22453,7 @@ snapshots:
       prettier: 3.8.1
       rimraf: 3.0.2
       typescript: 5.6.3
-      typescript-eslint: 8.56.0(eslint@10.0.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.6.3)
+      typescript-eslint: 8.56.0(eslint@10.0.0)(typescript@5.6.3)
       update-notifier: 6.0.2
       write-file-atomic: 6.0.0
     transitivePeerDependencies:
@@ -22703,7 +22505,7 @@ snapshots:
 
   nanoid@3.3.18: {}
 
-  nanomatch@1.2.13(supports-color@8.1.1):
+  nanomatch@1.2.13:
     dependencies:
       arr-diff: 4.0.0
       array-unique: 0.3.2
@@ -22714,7 +22516,7 @@ snapshots:
       kind-of: 6.0.3
       object.pick: 1.3.0
       regex-not: 1.0.2
-      snapdragon: 0.8.2(supports-color@8.1.1)
+      snapdragon: 0.8.2
       to-regex: 3.0.2
     transitivePeerDependencies:
       - supports-color
@@ -22737,7 +22539,7 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next@16.2.12(@babel/core@7.28.5(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@16.2.12(@babel/core@7.28.5)(@opentelemetry/api@1.9.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 16.2.12
       '@swc/helpers': 0.5.15
@@ -22746,7 +22548,7 @@ snapshots:
       postcss: 8.4.31
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      styled-jsx: 5.1.6(@babel/core@7.28.5(supports-color@8.1.1))(react@18.3.1)
+      styled-jsx: 5.1.6(@babel/core@7.28.5)(react@18.3.1)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.12
       '@next/swc-darwin-x64': 16.2.12
@@ -22777,17 +22579,9 @@ snapshots:
       lower-case: 2.0.2
       tslib: 2.8.1
 
-  nock@13.5.6(supports-color@7.2.0):
+  nock@13.5.6:
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
-      json-stringify-safe: 5.0.1
-      propagate: 2.0.1
-    transitivePeerDependencies:
-      - supports-color
-
-  nock@13.5.6(supports-color@8.1.1):
-    dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
       json-stringify-safe: 5.0.1
       propagate: 2.0.1
     transitivePeerDependencies:
@@ -22825,12 +22619,12 @@ snapshots:
       undici: 6.28.0
       which: 6.0.1
 
-  node-gyp@8.4.1(supports-color@8.1.1):
+  node-gyp@8.4.1:
     dependencies:
       env-paths: 2.2.1
       glob: 7.2.3
       graceful-fs: 4.2.11
-      make-fetch-happen: 9.1.0(supports-color@8.1.1)
+      make-fetch-happen: 9.1.0
       nopt: 5.0.0
       npmlog: 6.0.2
       rimraf: 3.0.2
@@ -22948,11 +22742,11 @@ snapshots:
       npm-package-arg: 13.0.1
       semver: 7.7.4
 
-  npm-registry-fetch@19.1.0(supports-color@7.2.0):
+  npm-registry-fetch@19.1.0:
     dependencies:
       '@npmcli/redact': 3.2.2
       jsonparse: 1.3.1
-      make-fetch-happen: 15.0.2(supports-color@7.2.0)
+      make-fetch-happen: 15.0.2
       minipass: 7.1.3
       minipass-fetch: 4.0.1
       minizlib: 3.1.0
@@ -22978,13 +22772,13 @@ snapshots:
       set-blocking: 2.0.0
     optional: true
 
-  null-loader@4.0.1(webpack@5.104.1(esbuild@0.27.3)(uglify-js@3.19.3)):
+  null-loader@4.0.1(webpack@5.104.1):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.104.1(esbuild@0.27.3)(uglify-js@3.19.3)
+      webpack: 5.104.1
 
-  number-allocator@1.0.14(supports-color@7.2.0):
+  number-allocator@1.0.14:
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
       js-sdsl: 4.3.0
@@ -22999,14 +22793,14 @@ snapshots:
     optionalDependencies:
       chokidar: 3.6.0
 
-  nx@16.10.0(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0):
+  nx@16.10.0:
     dependencies:
-      '@nrwl/tao': 16.10.0(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)
+      '@nrwl/tao': 16.10.0
       '@parcel/watcher': 2.0.4
       '@yarnpkg/lockfile': 1.1.0
       '@yarnpkg/parsers': 3.0.0-rc.46
       '@zkochan/js-yaml': 0.0.6
-      axios: 1.18.0(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)
+      axios: 1.18.0
       chalk: 4.1.2
       cli-cursor: 3.1.0
       cli-spinners: 2.6.1
@@ -23420,7 +23214,7 @@ snapshots:
       registry-url: 6.0.1
       semver: 7.7.4
 
-  pacote@21.0.1(supports-color@7.2.0):
+  pacote@21.0.1:
     dependencies:
       '@npmcli/git': 6.0.3
       '@npmcli/installed-package-contents': 3.0.0
@@ -23433,16 +23227,16 @@ snapshots:
       npm-package-arg: 13.0.1
       npm-packlist: 10.0.3
       npm-pick-manifest: 10.0.0
-      npm-registry-fetch: 19.1.0(supports-color@7.2.0)
+      npm-registry-fetch: 19.1.0
       proc-log: 5.0.0
       promise-retry: 2.0.1
-      sigstore: 4.1.1(supports-color@7.2.0)
+      sigstore: 4.1.1
       ssri: 12.0.0
       tar: 7.5.11
     transitivePeerDependencies:
       - supports-color
 
-  pacote@21.5.1(supports-color@7.2.0):
+  pacote@21.5.1:
     dependencies:
       '@gar/promise-retry': 1.0.3
       '@npmcli/git': 7.0.2
@@ -23456,9 +23250,9 @@ snapshots:
       npm-package-arg: 13.0.1
       npm-packlist: 10.0.3
       npm-pick-manifest: 11.0.3
-      npm-registry-fetch: 19.1.0(supports-color@7.2.0)
+      npm-registry-fetch: 19.1.0
       proc-log: 6.1.0
-      sigstore: 4.1.1(supports-color@7.2.0)
+      sigstore: 4.1.1
       ssri: 13.0.1
       tar: 7.5.11
     transitivePeerDependencies:
@@ -23779,25 +23573,25 @@ snapshots:
       tar-fs: 2.1.4
       tunnel-agent: 0.6.0
 
-  precinct@8.3.1(supports-color@7.2.0):
+  precinct@8.3.1:
     dependencies:
       commander: 2.20.3
       debug: 4.4.3(supports-color@7.2.0)
       detective-amd: 3.1.2
       detective-cjs: 3.1.3
       detective-es6: 2.2.2
-      detective-less: 1.0.2(supports-color@7.2.0)
-      detective-postcss: 4.0.0(supports-color@7.2.0)
+      detective-less: 1.0.2
+      detective-postcss: 4.0.0
       detective-sass: 3.0.2
       detective-scss: 2.0.2
       detective-stylus: 1.0.3
-      detective-typescript: 7.0.2(supports-color@7.2.0)
+      detective-typescript: 7.0.2
       module-definition: 3.4.0
       node-source-walk: 4.3.0
     transitivePeerDependencies:
       - supports-color
 
-  precinct@9.2.1(supports-color@7.2.0):
+  precinct@9.2.1:
     dependencies:
       '@dependents/detective-less': 3.0.2
       commander: 9.5.0
@@ -23808,7 +23602,7 @@ snapshots:
       detective-sass: 4.1.3
       detective-scss: 3.1.1
       detective-stylus: 3.0.0
-      detective-typescript: 9.1.1(supports-color@7.2.0)
+      detective-typescript: 9.1.1
       module-definition: 4.1.0
       node-source-walk: 5.0.2
     transitivePeerDependencies:
@@ -24129,9 +23923,9 @@ snapshots:
 
   readdirp@4.1.2: {}
 
-  ready-callback@2.1.0(supports-color@8.1.1):
+  ready-callback@2.1.0:
     dependencies:
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       get-ready: 2.0.1
       once: 1.4.0
       uuid: 3.4.0
@@ -24357,7 +24151,7 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.54.0
       fsevents: 2.3.3
 
-  router@2.2.0(supports-color@7.2.0):
+  router@2.2.0:
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
       depd: 2.0.0
@@ -24499,9 +24293,9 @@ snapshots:
 
   semver@7.7.4: {}
 
-  send@0.19.0(supports-color@8.1.1):
+  send@0.19.0:
     dependencies:
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       depd: 2.0.0
       destroy: 1.2.0
       encodeurl: 1.0.2
@@ -24517,25 +24311,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  send@1.2.1(supports-color@7.2.0):
+  send@1.2.1:
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      etag: 1.8.1
-      fresh: 2.0.0
-      http-errors: 2.0.1
-      mime-types: 3.0.2
-      ms: 2.1.3
-      on-finished: 2.4.1
-      range-parser: 1.2.1
-      statuses: 2.0.2
-    transitivePeerDependencies:
-      - supports-color
-
-  send@1.2.1(supports-color@8.1.1):
-    dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -24559,23 +24337,15 @@ snapshots:
 
   sequelize-pool@7.1.0: {}
 
-  sequelize-typescript@2.1.6(@types/node@22.12.0)(@types/validator@13.15.10)(reflect-metadata@0.2.2)(sequelize@6.37.8(mysql2@3.23.1(@types/node@22.12.0))(sqlite3@5.1.7(supports-color@8.1.1))(supports-color@7.2.0)):
+  sequelize-typescript@2.1.6(@types/node@22.12.0)(@types/validator@13.15.10)(reflect-metadata@0.2.2)(sequelize@6.37.8(sqlite3@5.1.7)):
     dependencies:
       '@types/node': 22.12.0
       '@types/validator': 13.15.10
       glob: 7.2.0
       reflect-metadata: 0.2.2
-      sequelize: 6.37.8(mysql2@3.23.1(@types/node@22.12.0))(sqlite3@5.1.7(supports-color@8.1.1))(supports-color@7.2.0)
+      sequelize: 6.37.8(mysql2@3.23.1(@types/node@22.12.0))(sqlite3@5.1.7)
 
-  sequelize-typescript@2.1.6(@types/node@22.12.0)(@types/validator@13.15.10)(reflect-metadata@0.2.2)(sequelize@6.37.8(mysql2@3.23.1(@types/node@22.12.0))(sqlite3@5.1.7(supports-color@8.1.1))(supports-color@8.1.1)):
-    dependencies:
-      '@types/node': 22.12.0
-      '@types/validator': 13.15.10
-      glob: 7.2.0
-      reflect-metadata: 0.2.2
-      sequelize: 6.37.8(mysql2@3.23.1(@types/node@22.12.0))(sqlite3@5.1.7(supports-color@8.1.1))(supports-color@8.1.1)
-
-  sequelize@6.37.8(mysql2@3.23.1(@types/node@22.12.0))(sqlite3@5.1.7(supports-color@8.1.1))(supports-color@7.2.0):
+  sequelize@6.37.8(mysql2@3.23.1(@types/node@22.12.0))(sqlite3@5.1.7):
     dependencies:
       '@types/debug': 4.1.12
       '@types/validator': 13.15.10
@@ -24595,31 +24365,7 @@ snapshots:
       wkx: 0.5.0
     optionalDependencies:
       mysql2: 3.23.1(@types/node@22.12.0)
-      sqlite3: 5.1.7(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - supports-color
-
-  sequelize@6.37.8(mysql2@3.23.1(@types/node@22.12.0))(sqlite3@5.1.7(supports-color@8.1.1))(supports-color@8.1.1):
-    dependencies:
-      '@types/debug': 4.1.12
-      '@types/validator': 13.15.10
-      debug: 4.4.3(supports-color@8.1.1)
-      dottie: 2.0.6
-      inflection: 1.13.4
-      lodash: 4.17.23
-      moment: 2.30.1
-      moment-timezone: 0.5.48
-      pg-connection-string: 2.9.1
-      retry-as-promised: 7.1.1
-      semver: 7.7.4
-      sequelize-pool: 7.1.0
-      toposort-class: 1.0.1
-      uuid: 8.3.2
-      validator: 13.15.26
-      wkx: 0.5.0
-    optionalDependencies:
-      mysql2: 3.23.1(@types/node@22.12.0)
-      sqlite3: 5.1.7(supports-color@8.1.1)
+      sqlite3: 5.1.7
     transitivePeerDependencies:
       - supports-color
 
@@ -24627,19 +24373,19 @@ snapshots:
     dependencies:
       randombytes: 2.1.0
 
-  serialize-json@1.0.3(supports-color@8.1.1):
+  serialize-json@1.0.3:
     dependencies:
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7
       is-type-of: 1.4.0
       utility: 1.18.0
     transitivePeerDependencies:
       - supports-color
 
-  serve-index@1.9.2(supports-color@8.1.1):
+  serve-index@1.9.2:
     dependencies:
       accepts: 1.3.8
       batch: 0.6.1
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       escape-html: 1.0.3
       http-errors: 1.8.1
       mime-types: 2.1.35
@@ -24647,21 +24393,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  serve-static@1.16.2(supports-color@8.1.1):
+  serve-static@1.16.2:
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 0.19.0(supports-color@8.1.1)
+      send: 0.19.0
     transitivePeerDependencies:
       - supports-color
 
-  serve-static@2.2.1(supports-color@8.1.1):
+  serve-static@2.2.1:
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 1.2.1(supports-color@8.1.1)
+      send: 1.2.1
     transitivePeerDependencies:
       - supports-color
 
@@ -24807,13 +24553,13 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  sigstore@4.1.1(supports-color@7.2.0):
+  sigstore@4.1.1:
     dependencies:
       '@sigstore/bundle': 4.0.0
       '@sigstore/core': 3.2.1
       '@sigstore/protobuf-specs': 0.5.2
-      '@sigstore/sign': 4.1.1(supports-color@7.2.0)
-      '@sigstore/tuf': 4.0.2(supports-color@7.2.0)
+      '@sigstore/sign': 4.1.1
+      '@sigstore/tuf': 4.0.2
       '@sigstore/verify': 3.1.1
     transitivePeerDependencies:
       - supports-color
@@ -24872,10 +24618,10 @@ snapshots:
     dependencies:
       kind-of: 3.2.2
 
-  snapdragon@0.8.2(supports-color@8.1.1):
+  snapdragon@0.8.2:
     dependencies:
       base: 0.11.2
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       define-property: 0.2.5
       extend-shallow: 2.0.1
       map-cache: 0.2.2
@@ -24887,7 +24633,7 @@ snapshots:
 
   socket.io-adapter@1.1.2: {}
 
-  socket.io-adapter@2.5.6(supports-color@7.2.0):
+  socket.io-adapter@2.5.6:
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
       ws: 8.18.3
@@ -24896,88 +24642,61 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  socket.io-adapter@2.5.6(supports-color@8.1.1):
-    dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
-      ws: 8.18.3
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  socket.io-client@2.5.0(supports-color@8.1.1):
+  socket.io-client@2.5.0:
     dependencies:
       backo2: 1.0.2
       component-bind: 1.0.0
       component-emitter: 1.3.1
-      debug: 3.1.0(supports-color@8.1.1)
-      engine.io-client: 3.5.6(supports-color@8.1.1)
+      debug: 3.1.0
+      engine.io-client: 3.5.6
       has-binary2: 1.0.3
       indexof: 0.0.1
       parseqs: 0.0.6
       parseuri: 0.0.6
-      socket.io-parser: 3.3.4(supports-color@8.1.1)
+      socket.io-parser: 3.3.4
       to-array: 0.1.4
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  socket.io-client@4.8.1(supports-color@7.2.0):
+  socket.io-client@4.8.1:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
-      debug: 4.3.7(supports-color@8.1.1)
-      engine.io-client: 6.6.4(supports-color@7.2.0)
-      socket.io-parser: 4.2.5(supports-color@7.2.0)
+      debug: 4.3.7
+      engine.io-client: 6.6.4
+      socket.io-parser: 4.2.5
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  socket.io-client@4.8.1(supports-color@8.1.1):
-    dependencies:
-      '@socket.io/component-emitter': 3.1.2
-      debug: 4.3.7(supports-color@8.1.1)
-      engine.io-client: 6.6.4(supports-color@8.1.1)
-      socket.io-parser: 4.2.5(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  socket.io-parser@3.3.4(supports-color@8.1.1):
+  socket.io-parser@3.3.4:
     dependencies:
       component-emitter: 1.3.1
-      debug: 3.1.0(supports-color@8.1.1)
+      debug: 3.1.0
       isarray: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
-  socket.io-parser@3.4.3(supports-color@8.1.1):
+  socket.io-parser@3.4.3:
     dependencies:
       component-emitter: 1.2.1
-      debug: 4.1.1(supports-color@8.1.1)
+      debug: 4.1.1
       isarray: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
-  socket.io-parser@4.2.5(supports-color@7.2.0):
+  socket.io-parser@4.2.5:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
       debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  socket.io-parser@4.2.5(supports-color@8.1.1):
+  socket.io-redis@5.4.0:
     dependencies:
-      '@socket.io/component-emitter': 3.1.2
-      debug: 4.4.3(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - supports-color
-
-  socket.io-redis@5.4.0(supports-color@8.1.1):
-    dependencies:
-      debug: 4.1.1(supports-color@8.1.1)
+      debug: 4.1.1
       notepack.io: 2.2.0
       redis: 3.1.2
       socket.io-adapter: 1.1.2
@@ -24985,42 +24704,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  socket.io@2.5.1(supports-color@8.1.1):
+  socket.io@2.5.1:
     dependencies:
-      debug: 4.1.1(supports-color@8.1.1)
-      engine.io: 3.6.2(supports-color@8.1.1)
+      debug: 4.1.1
+      engine.io: 3.6.2
       has-binary2: 1.0.3
       socket.io-adapter: 1.1.2
-      socket.io-client: 2.5.0(supports-color@8.1.1)
-      socket.io-parser: 3.4.3(supports-color@8.1.1)
+      socket.io-client: 2.5.0
+      socket.io-parser: 3.4.3
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  socket.io@4.8.1(supports-color@7.2.0):
+  socket.io@4.8.1:
     dependencies:
       accepts: 1.3.8
       base64id: 2.0.0
       cors: 2.8.5
-      debug: 4.3.7(supports-color@8.1.1)
-      engine.io: 6.6.5(supports-color@7.2.0)
-      socket.io-adapter: 2.5.6(supports-color@7.2.0)
-      socket.io-parser: 4.2.5(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  socket.io@4.8.1(supports-color@8.1.1):
-    dependencies:
-      accepts: 1.3.8
-      base64id: 2.0.0
-      cors: 2.8.5
-      debug: 4.3.7(supports-color@8.1.1)
-      engine.io: 6.6.5(supports-color@8.1.1)
-      socket.io-adapter: 2.5.6(supports-color@8.1.1)
-      socket.io-parser: 4.2.5(supports-color@8.1.1)
+      debug: 4.3.7
+      engine.io: 6.6.5
+      socket.io-adapter: 2.5.6
+      socket.io-parser: 4.2.5
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -25032,7 +24737,7 @@ snapshots:
       uuid: 8.3.2
       websocket-driver: 0.7.4
 
-  socks-proxy-agent@6.2.1(supports-color@7.2.0):
+  socks-proxy-agent@6.2.1:
     dependencies:
       agent-base: 6.0.2(supports-color@7.2.0)
       debug: 4.4.3(supports-color@7.2.0)
@@ -25040,16 +24745,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  socks-proxy-agent@6.2.1(supports-color@8.1.1):
-    dependencies:
-      agent-base: 6.0.2(supports-color@8.1.1)
-      debug: 4.4.3(supports-color@8.1.1)
-      socks: 2.8.7
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
-  socks-proxy-agent@8.0.5(supports-color@7.2.0):
+  socks-proxy-agent@8.0.5:
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@7.2.0)
@@ -25110,7 +24806,7 @@ snapshots:
 
   spdx-license-ids@3.0.22: {}
 
-  spdy-transport@3.0.0(supports-color@7.2.0):
+  spdy-transport@3.0.0:
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
       detect-node: 2.1.0
@@ -25121,13 +24817,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  spdy@4.0.2(supports-color@7.2.0):
+  spdy@4.0.2:
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
       handle-thing: 2.0.1
       http-deceiver: 1.2.7
       select-hose: 2.0.0
-      spdy-transport: 3.0.0(supports-color@7.2.0)
+      spdy-transport: 3.0.0
     transitivePeerDependencies:
       - supports-color
 
@@ -25159,14 +24855,14 @@ snapshots:
 
   sql-highlight@6.1.0: {}
 
-  sqlite3@5.1.7(supports-color@8.1.1):
+  sqlite3@5.1.7:
     dependencies:
       bindings: 1.5.0
       node-addon-api: 7.1.1
       prebuild-install: 7.1.3
       tar: 6.2.1
     optionalDependencies:
-      node-gyp: 8.4.1(supports-color@8.1.1)
+      node-gyp: 8.4.1
     transitivePeerDependencies:
       - bluebird
       - supports-color
@@ -25370,14 +25066,14 @@ snapshots:
     dependencies:
       '@tokenizer/token': 0.3.0
 
-  styled-jsx@5.1.6(@babel/core@7.28.5(supports-color@8.1.1))(react@18.3.1):
+  styled-jsx@5.1.6(@babel/core@7.28.5)(react@18.3.1):
     dependencies:
       client-only: 0.0.1
       react: 18.3.1
     optionalDependencies:
-      '@babel/core': 7.28.5(supports-color@8.1.1)
+      '@babel/core': 7.28.5
 
-  stylus-lookup@3.0.2(supports-color@7.2.0):
+  stylus-lookup@3.0.2:
     dependencies:
       commander: 2.20.3
       debug: 4.4.3(supports-color@7.2.0)
@@ -25398,11 +25094,11 @@ snapshots:
       tinyglobby: 0.2.15
       ts-interface-checker: 0.1.13
 
-  superagent@3.8.3(supports-color@8.1.1):
+  superagent@3.8.3:
     dependencies:
       component-emitter: 1.3.1
       cookiejar: 2.1.4
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7
       extend: 3.0.2
       form-data: 2.5.5
       formidable: 1.2.6
@@ -25413,7 +25109,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  superagent@8.1.2(supports-color@7.2.0):
+  superagent@8.1.2:
     dependencies:
       component-emitter: 1.3.1
       cookiejar: 2.1.4
@@ -25428,39 +25124,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  superagent@8.1.2(supports-color@8.1.1):
+  supertest@4.0.2:
     dependencies:
-      component-emitter: 1.3.1
-      cookiejar: 2.1.4
-      debug: 4.4.3(supports-color@8.1.1)
-      fast-safe-stringify: 2.1.1
-      form-data: 4.0.6
-      formidable: 2.1.5
       methods: 1.1.2
-      mime: 2.6.0
-      qs: 6.16.0
-      semver: 7.7.4
+      superagent: 3.8.3
     transitivePeerDependencies:
       - supports-color
 
-  supertest@4.0.2(supports-color@8.1.1):
+  supertest@6.3.4:
     dependencies:
       methods: 1.1.2
-      superagent: 3.8.3(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - supports-color
-
-  supertest@6.3.4(supports-color@7.2.0):
-    dependencies:
-      methods: 1.1.2
-      superagent: 8.1.2(supports-color@7.2.0)
-    transitivePeerDependencies:
-      - supports-color
-
-  supertest@6.3.4(supports-color@8.1.1):
-    dependencies:
-      methods: 1.1.2
-      superagent: 8.1.2(supports-color@8.1.1)
+      superagent: 8.1.2
     transitivePeerDependencies:
       - supports-color
 
@@ -25564,16 +25238,13 @@ snapshots:
     dependencies:
       memoizerific: 1.11.3
 
-  terser-webpack-plugin@5.4.0(esbuild@0.27.3)(uglify-js@3.19.3)(webpack@5.104.1(esbuild@0.27.3)(uglify-js@3.19.3)):
+  terser-webpack-plugin@5.4.0(webpack@5.104.1):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.46.1
-      webpack: 5.104.1(esbuild@0.27.3)(uglify-js@3.19.3)
-    optionalDependencies:
-      esbuild: 0.27.3
-      uglify-js: 3.19.3
+      webpack: 5.104.1
 
   terser@5.46.1:
     dependencies:
@@ -25732,12 +25403,12 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-jest@29.2.5(@babel/core@7.28.5(supports-color@7.2.0))(@jest/transform@29.7.0(supports-color@7.2.0))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5(supports-color@7.2.0))(supports-color@7.2.0))(esbuild@0.27.3)(jest@29.7.0(@types/node@22.12.0)(supports-color@7.2.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3)))(typescript@5.6.3):
+  ts-jest@29.2.5(@babel/core@7.28.5)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(jest@29.7.0(@types/node@22.12.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3)))(typescript@5.6.3):
     dependencies:
       bs-logger: 0.2.6
       ejs: 3.1.10
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@22.12.0)(supports-color@7.2.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3))
+      jest: 29.7.0(@types/node@22.12.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3))
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -25746,11 +25417,10 @@ snapshots:
       typescript: 5.6.3
       yargs-parser: 21.1.1
     optionalDependencies:
-      '@babel/core': 7.28.5(supports-color@7.2.0)
-      '@jest/transform': 29.7.0(supports-color@7.2.0)
+      '@babel/core': 7.28.5
+      '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.28.5(supports-color@7.2.0))(supports-color@7.2.0)
-      esbuild: 0.27.3
+      babel-jest: 29.7.0(@babel/core@7.28.5)
 
   ts-node@10.9.2(@types/node@20.19.39)(typescript@5.6.3):
     dependencies:
@@ -25817,41 +25487,13 @@ snapshots:
 
   tsscmp@1.0.6: {}
 
-  tsup@8.5.1(postcss@8.5.6)(supports-color@7.2.0)(tsx@4.21.0)(typescript@5.6.3)(yaml@2.9.0):
+  tsup@8.5.1(postcss@8.5.6)(tsx@4.21.0)(typescript@5.6.3)(yaml@2.9.0):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.3)
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
       debug: 4.4.3(supports-color@7.2.0)
-      esbuild: 0.27.3
-      fix-dts-default-cjs-exports: 1.0.1
-      joycon: 3.1.1
-      picocolors: 1.1.1
-      postcss-load-config: 6.0.1(postcss@8.5.6)(tsx@4.21.0)(yaml@2.9.0)
-      resolve-from: 5.0.0
-      rollup: 4.54.0
-      source-map: 0.7.6
-      sucrase: 3.35.1
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.15
-      tree-kill: 1.2.2
-    optionalDependencies:
-      postcss: 8.5.6
-      typescript: 5.6.3
-    transitivePeerDependencies:
-      - jiti
-      - supports-color
-      - tsx
-      - yaml
-
-  tsup@8.5.1(postcss@8.5.6)(supports-color@8.1.1)(tsx@4.21.0)(typescript@5.6.3)(yaml@2.9.0):
-    dependencies:
-      bundle-require: 5.1.0(esbuild@0.27.3)
-      cac: 6.7.14
-      chokidar: 4.0.3
-      consola: 3.4.2
-      debug: 4.4.3(supports-color@8.1.1)
       esbuild: 0.27.3
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
@@ -25895,11 +25537,11 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  tuf-js@4.1.0(supports-color@7.2.0):
+  tuf-js@4.1.0:
     dependencies:
       '@tufjs/models': 4.1.0
       debug: 4.4.3(supports-color@7.2.0)
-      make-fetch-happen: 15.0.2(supports-color@7.2.0)
+      make-fetch-happen: 15.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -26009,7 +25651,7 @@ snapshots:
       typescript: 5.6.3
       yaml: 2.8.2
 
-  typeorm@1.1.0(better-sqlite3@12.9.0)(ioredis@5.9.3(supports-color@8.1.1))(mysql2@3.23.1(@types/node@22.12.0))(supports-color@7.2.0)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3)):
+  typeorm@1.1.0(better-sqlite3@12.9.0)(ioredis@5.9.3)(mysql2@3.23.1(@types/node@22.12.0))(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3)):
     dependencies:
       '@sqltools/formatter': 1.2.5
       ansis: 4.3.1
@@ -26023,41 +25665,20 @@ snapshots:
       yargs: 18.0.0
     optionalDependencies:
       better-sqlite3: 12.9.0
-      ioredis: 5.9.3(supports-color@8.1.1)
+      ioredis: 5.9.3
       mysql2: 3.23.1(@types/node@22.12.0)
       ts-node: 10.9.2(@types/node@22.12.0)(typescript@5.6.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
 
-  typeorm@1.1.0(better-sqlite3@12.9.0)(ioredis@5.9.3(supports-color@8.1.1))(mysql2@3.23.1(@types/node@22.12.0))(supports-color@8.1.1)(ts-node@10.9.2(@types/node@22.12.0)(typescript@5.6.3)):
+  typescript-eslint@8.56.0(eslint@10.0.0)(typescript@5.6.3):
     dependencies:
-      '@sqltools/formatter': 1.2.5
-      ansis: 4.3.1
-      dayjs: 1.11.23
-      debug: 4.4.3(supports-color@8.1.1)
-      dedent: 1.7.2
-      reflect-metadata: 0.2.2
-      sql-highlight: 6.1.0
-      tinyglobby: 0.2.17
-      tslib: 2.8.1
-      yargs: 18.0.0
-    optionalDependencies:
-      better-sqlite3: 12.9.0
-      ioredis: 5.9.3(supports-color@8.1.1)
-      mysql2: 3.23.1(@types/node@22.12.0)
-      ts-node: 10.9.2(@types/node@22.12.0)(typescript@5.6.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  typescript-eslint@8.56.0(eslint@10.0.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.6.3):
-    dependencies:
-      '@typescript-eslint/eslint-plugin': 8.56.0(@typescript-eslint/parser@8.56.0(eslint@10.0.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.6.3))(eslint@10.0.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.6.3)
-      '@typescript-eslint/parser': 8.56.0(eslint@10.0.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.6.3)
-      '@typescript-eslint/typescript-estree': 8.56.0(supports-color@7.2.0)(typescript@5.6.3)
-      '@typescript-eslint/utils': 8.56.0(eslint@10.0.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.6.3)
-      eslint: 10.0.0(supports-color@7.2.0)
+      '@typescript-eslint/eslint-plugin': 8.56.0(@typescript-eslint/parser@8.56.0(eslint@10.0.0)(typescript@5.6.3))(eslint@10.0.0)(typescript@5.6.3)
+      '@typescript-eslint/parser': 8.56.0(eslint@10.0.0)(typescript@5.6.3)
+      '@typescript-eslint/typescript-estree': 8.56.0(typescript@5.6.3)
+      '@typescript-eslint/utils': 8.56.0(eslint@10.0.0)(typescript@5.6.3)
+      eslint: 10.0.0
       typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
@@ -26382,7 +26003,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.104.1(esbuild@0.27.3)(uglify-js@3.19.3)):
+  webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.104.1):
     dependencies:
       colorette: 2.0.20
       memfs: 4.57.1(tslib@2.8.1)
@@ -26391,11 +26012,11 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.104.1(esbuild@0.27.3)(uglify-js@3.19.3)
+      webpack: 5.104.1
     transitivePeerDependencies:
       - tslib
 
-  webpack-dev-server@5.2.2(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(tslib@2.8.1)(webpack@5.104.1(esbuild@0.27.3)(uglify-js@3.19.3)):
+  webpack-dev-server@5.2.2(tslib@2.8.1)(webpack@5.104.1):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -26409,24 +26030,24 @@ snapshots:
       bonjour-service: 1.3.0
       chokidar: 3.6.0
       colorette: 2.0.20
-      compression: 1.8.1(supports-color@8.1.1)
+      compression: 1.8.1
       connect-history-api-fallback: 2.0.0
-      express: 4.22.2(supports-color@8.1.1)
+      express: 4.22.2
       graceful-fs: 4.2.11
-      http-proxy-middleware: 2.0.9(@types/express@4.17.25)(debug@4.4.3(supports-color@8.1.1))
+      http-proxy-middleware: 2.0.9(@types/express@4.17.25)
       ipaddr.js: 2.3.0
       launch-editor: 2.13.2
       open: 10.2.0
       p-retry: 6.2.1
       schema-utils: 4.3.3
       selfsigned: 2.4.1
-      serve-index: 1.9.2(supports-color@8.1.1)
+      serve-index: 1.9.2
       sockjs: 0.3.24
-      spdy: 4.0.2(supports-color@7.2.0)
-      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.104.1(esbuild@0.27.3)(uglify-js@3.19.3))
+      spdy: 4.0.2
+      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.104.1)
       ws: 8.21.0
     optionalDependencies:
-      webpack: 5.104.1(esbuild@0.27.3)(uglify-js@3.19.3)
+      webpack: 5.104.1
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -26436,7 +26057,7 @@ snapshots:
 
   webpack-sources@3.3.4: {}
 
-  webpack@5.104.1(esbuild@0.27.3)(uglify-js@3.19.3):
+  webpack@5.104.1:
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -26460,7 +26081,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.2
-      terser-webpack-plugin: 5.4.0(esbuild@0.27.3)(uglify-js@3.19.3)(webpack@5.104.1(esbuild@0.27.3)(uglify-js@3.19.3))
+      terser-webpack-plugin: 5.4.0(webpack@5.104.1)
       watchpack: 2.5.1
       webpack-sources: 3.3.4
     transitivePeerDependencies:
@@ -26674,9 +26295,9 @@ snapshots:
     dependencies:
       is-wsl: 3.1.1
 
-  wt@1.2.0(supports-color@8.1.1):
+  wt@1.2.0:
     dependencies:
-      debug: 2.6.9(supports-color@8.1.1)
+      debug: 2.6.9
       ndir: 0.1.5
       sdk-base: 2.0.1
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,5 +4,6 @@ packages:
   - 'packages-resource/*'
   - 'samples/*'
 onlyBuiltDependencies: [
+  'better-sqlite3',
   'sqlite3'
 ]


### PR DESCRIPTION
## Summary

- pin the repository package manager to pnpm 10.33.0
- let pnpm/action-setup read the version from package.json
- regenerate pnpm-lock.yaml with pnpm 10

## Validation

- pnpm install --frozen-lockfile --ignore-scripts
- pnpm -C packages/core test -- dataSourceManager.test.ts
- git diff --check