### PR TITLE
fix(core): preserve CommonJS module load errors

### DIFF
--- a/packages/core/src/util/index.ts
+++ b/packages/core/src/util/index.ts
@@ -89,7 +89,7 @@ export const loadModule = async (
       if (options.loadMode === 'commonjs') {
         try {
           return require(p);
-        } catch {
+        } catch (err) {
           for (const extraPath of [
             process.cwd(),
             ...(options.extraModuleRoot || []),
@@ -100,6 +100,8 @@ export const loadModule = async (
               // do nothing
             }
           }
+          // Preserve the original error for the safeLoad handling below.
+          throw err;
         }
       } else {
         // if json file, import need add options

--- a/packages/core/test/util/loadModule.test.ts
+++ b/packages/core/test/util/loadModule.test.ts
@@ -1,0 +1,105 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { loadModule } from '../../src/util';
+
+describe('loadModule with CommonJS', () => {
+  let fixtureDir: string;
+  let throwingModule: string;
+  let missingModule: string;
+  let originalError: Error;
+  let originalStack: string;
+  let warnSpy: jest.SpyInstance;
+
+  beforeAll(() => {
+    fixtureDir = mkdtempSync(join(tmpdir(), 'midway-load-module-'));
+    throwingModule = join(fixtureDir, 'throwing.cjs');
+    missingModule = join(fixtureDir, 'missing.cjs');
+
+    // Reuse the same error across load attempts to check its identity and stack.
+    const errorModule = join(fixtureDir, 'error.cjs');
+    writeFileSync(
+      errorModule,
+      "module.exports = new Error('configuration initialization failed');"
+    );
+    writeFileSync(throwingModule, "throw require('./error.cjs');");
+    originalError = require(errorModule);
+    originalStack = originalError.stack;
+
+    const fallbackDir = join(
+      fixtureDir,
+      'node_modules',
+      'midway-load-module-fallback'
+    );
+    mkdirSync(fallbackDir, { recursive: true });
+    writeFileSync(
+      join(fallbackDir, 'index.js'),
+      "module.exports = { loadedFrom: 'extraModuleRoot' };"
+    );
+  });
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  afterAll(() => {
+    rmSync(fixtureDir, { recursive: true, force: true });
+  });
+
+  it('should reject with the original runtime error by default', async () => {
+    await expect(loadModule(throwingModule)).rejects.toBe(originalError);
+    expect(originalError.stack).toBe(originalStack);
+  });
+
+  it('should reject with the original runtime error when safeLoad is false', async () => {
+    await expect(
+      loadModule(throwingModule, { loadMode: 'commonjs', safeLoad: false })
+    ).rejects.toBe(originalError);
+    expect(originalError.stack).toBe(originalStack);
+  });
+
+  it('should warn with the original error and stack when safe loading fails', async () => {
+    await expect(
+      loadModule(throwingModule, { safeLoad: true, warnOnLoadError: true })
+    ).resolves.toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toBe(originalError);
+    expect(warnSpy.mock.calls[0][0].stack).toBe(originalStack);
+  });
+
+  it('should suppress runtime errors when safe loading without warnings', async () => {
+    await expect(
+      loadModule(throwingModule, { safeLoad: true })
+    ).resolves.toBeUndefined();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('should still load a module from an extra module root', async () => {
+    await expect(
+      loadModule('midway-load-module-fallback', {
+        extraModuleRoot: [fixtureDir],
+      })
+    ).resolves.toEqual({ loadedFrom: 'extraModuleRoot' });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('should reject with MODULE_NOT_FOUND when a module is missing', async () => {
+    await expect(loadModule(missingModule)).rejects.toMatchObject({
+      code: 'MODULE_NOT_FOUND',
+    });
+  });
+
+  it.each([false, true])(
+    'should silently skip missing modules with safeLoad and warnOnLoadError=%s',
+    async warnOnLoadError => {
+      await expect(
+        loadModule(missingModule, { safeLoad: true, warnOnLoadError })
+      ).resolves.toBeUndefined();
+      expect(warnSpy).not.toHaveBeenCalled();
+    }
+  );
+});


### PR DESCRIPTION
##### Checklist

- [x] Core package tests pass (`pnpm -C packages/core test`)
- [x] Regression tests are included
- [x] Commit message follows commit guidelines

##### Affected core subsystem(s)

`@midwayjs/core`: CommonJS module loading (`loadModule`).

##### Description of change

When a CommonJS module throws during initialization, `loadModule` currently swallows the initial `require` error and all fallback failures, returning `undefined` even with `safeLoad: false`. This hides errors in files such as `configuration.ts`.

Rethrow the original error after all fallback paths fail, allowing the existing outer handler to apply `safeLoad` and `warnOnLoadError`. Strict loads reject with the original error and stack; safe loads can report that error. Successful fallback loading and silent safe loading of missing modules are preserved.

Related discussion: https://github.com/midwayjs/midway/discussions/4583

This follows the maintainer's proposed error-handling behavior: https://github.com/midwayjs/midway/discussions/4583#discussioncomment-17094164

##### Validation

- Added eight tests using real temporary CommonJS modules: original error/stack preservation, strict and safe loading, warning behavior, missing modules, and successful `extraModuleRoot` fallback. Four tests fail before the fix; all eight pass afterward.
- Node.js 20.20.2: `pnpm -C packages/core test` — 98 suites passed, 1,358 tests passed, 2 skipped; 64 snapshots passed.
- `pnpm -C packages/core build` — passed.
- `pnpm exec mwts check packages/core/src/util/index.ts` — passed; the new test file also passes Prettier.
