### PR TITLE
docs(cache-manager): clarify multi-cache TTL configuration

### DIFF
--- a/site/docs/extensions/caching.md
+++ b/site/docs/extensions/caching.md
@@ -302,7 +302,7 @@ export default {
 
 [cache-manager](https://github.com/node-cache-manager/node-cache-manager) 支持将多个缓存 Store 聚合到一起，实现多级缓存。
 
-比如我可以创建一个多级缓存将多个缓存 Store 合并到一起。
+下面的示例将内存缓存和 Redis 缓存组合到一起，分别设置 60 秒和 600 秒的默认过期时间。
 
 ```typescript
 // src/config/config.default.ts
@@ -312,18 +312,18 @@ export default {
     clients: {
       memoryCaching: {
         store: 'memory',
+        options: {
+          ttl: 60_000, // 60 秒，单位为毫秒
+        },
       },
       redisCaching: {
         store: createRedisStore('default'),
         options: {
-          ttl: 10,
+          ttl: 600_000, // 600 秒，单位为毫秒
         },
       },
       multiCaching: {
         store: ['memoryCaching', 'redisCaching'],
-        options: {
-          ttl: 100,
-        },
       },
     },
   },
@@ -340,6 +340,8 @@ export default {
 ```
 
 这样 `multiCaching` 这个缓存实例就包含了两级缓存，缓存的优先级从上到下，在查找时，会先查找 `memoryCaching` ，如果内存缓存不存在 key，则继续查找 `redisCaching`。
+
+多级缓存自身的 `options.ttl` 不参与 `set`、`mset` 的写入，请在各个子缓存的 `options.ttl` 中配置默认过期时间。内置内存 Store 和 `createRedisStore` 使用的 TTL 单位都是毫秒。
 
 
 
@@ -395,6 +397,16 @@ export class UserService {
   }
 }
 
+```
+
+对于上面的内存和 Redis 缓存，调用 `set` 或 `mset` 时省略 TTL 参数，各层会使用自己的默认过期时间；显式传入 TTL 时，本次写入的所有缓存层都会使用该值。
+
+```typescript
+// 使用各层默认 TTL：内存 60 秒，Redis 600 秒
+await this.multiCache.set('key', 'value');
+
+// 覆盖各层默认 TTL：本次写入的两层缓存都使用 30 秒
+await this.multiCache.set('key', 'value', 30_000);
 ```
 
 ### 8、自动刷新

--- a/site/i18n/en/docusaurus-plugin-content-docs/current/extensions/caching.md
+++ b/site/i18n/en/docusaurus-plugin-content-docs/current/extensions/caching.md
@@ -298,7 +298,7 @@ export default {
 
 [cache-manager](https://github.com/node-cache-manager/node-cache-manager) supports aggregating multiple cache stores to achieve multi-level caching.
 
-For example, I can create a multi-level cache to merge multiple cache stores together.
+The following example combines memory and Redis caches with default expiration times of 60 seconds and 600 seconds, respectively.
 
 ```typescript
 // src/config/config.default.ts
@@ -308,18 +308,18 @@ export default {
     clients: {
       memoryCaching: {
         store: 'memory',
+        options: {
+          ttl: 60_000, // 60 seconds, expressed in milliseconds
+        },
       },
       redisCaching: {
         store: createRedisStore('default'),
         options: {
-          ttl: 10,
+          ttl: 600_000, // 600 seconds, expressed in milliseconds
         }
       },
       multiCaching: {
         store: ['memoryCaching', 'redisCaching'],
-        options: {
-          ttl: 100,
-        },
       },
     },
   },
@@ -335,6 +335,8 @@ export default {
 ```
 
 In this way, the cache instance `multiCaching` contains two levels of cache. The cache priority is from top to bottom. When searching, it will first search `memoryCaching`. If the key does not exist in the memory cache, it will continue to search `redisCaching`.
+
+The multi-level cache's own `options.ttl` is not used by `set` or `mset`. Configure the default expiration time in each child cache's `options.ttl` instead. Both the built-in memory store and `createRedisStore` use milliseconds for TTL values.
 
 
 
@@ -390,6 +392,16 @@ export class UserService {
    }
 }
 
+```
+
+For the memory and Redis caches above, omitting the TTL argument from `set` or `mset` uses each layer's default expiration time. Passing an explicit TTL applies that value to all layers for that write.
+
+```typescript
+// Use each layer's default TTL: 60 seconds in memory, 600 seconds in Redis
+await this.multiCache.set('key', 'value');
+
+// Override both defaults: use 30 seconds in both layers for this write
+await this.multiCache.set('key', 'value', 30_000);
 ```
 
 ### 8. Automatic refresh


### PR DESCRIPTION
##### Checklist

- [x] Documentation is changed or added
- [x] Commit message follows commit guidelines

##### Affected core subsystem(s)

`@midwayjs/cache-manager` documentation (Chinese and English).

##### Description of change

The multi-level cache example sets `multiCaching.options.ttl`, but that option is not used when writing to the child caches. This can lead readers to expect an expiration time that the configuration does not apply.

Remove the ineffective option and configure default TTLs on the memory and Redis caches instead. Clarify that TTLs are in milliseconds, omitting the TTL argument from `set`/`mset` uses each child cache's default, and passing an explicit TTL applies it to all layers for that write.

Both language versions include the same examples. This is a documentation-only correction reflecting existing behavior.

Related: [Discussion #4622](https://github.com/midwayjs/midway/discussions/4622), including the [maintainer's clarification](https://github.com/midwayjs/midway/discussions/4622#discussioncomment-18145098).

##### Validation

- Checked the documented behavior against the factory, multi-cache implementation, and built-in memory/Redis stores.
- Verified TypeScript syntax and equivalent configuration values in the Chinese and English examples.
- `git diff --check` passed.
- No build or runtime tests were run for this documentation-only change.
